### PR TITLE
Make API classes more REST friendly, and various other small fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,69 @@
 
 This is a SkyVerge library module: a full featured WooCommerce Plugin Framework
 
+## Sample API Implementation
+
+The following is a sample basic REST API implementation using the API classes/interfaces provided by the framework. Comments are largely omitted for brevity:
+
+```php
+class WC_Acme_API extends SV_WC_API_Base {
+
+	/** the base API endpoint */
+	const API_ENDPOINT = 'https://api.acme.com';
+
+	/** @var string Acme API key */
+	private $api_key;
+
+	public function __construct( $api_key ) {
+
+		// set auth creds
+		$this->api_key = $api_key;
+
+		// set up the request defaults
+		$this->request_uri = self::API_ENDPOINT;
+		$this->set_request_content_type_header( 'application/x-www-form-urlencoded' );
+		$this->set_request_accept_header( 'application/json' );
+		$this->set_request_header( 'Authorization', 'Token ' . $this->api_key );
+
+		$this->response_handler = 'SV_WC_API_JSON_Response';
+	}
+
+	// get some API resource by name
+	public function get_product( $name ) {
+		return $this->perform_request( $this->get_new_request( array( 'method' => 'GET', 'path' => '/products', 'params' => array( 'name' => $name ) ) ) );
+	}
+
+	// create some API resource
+	public function create_product( $name, $sku ) {
+		return $this->perform_request( $this->get_new_request( array( 'method' => 'POST', 'path' => '/products', 'params' => array( 'name' => $name, 'sku' => $sku ) ) ) );
+	}
+
+	// handle non-200 responses
+	protected function do_pre_parse_response_validation() {
+		if ( 200 != $this->get_response_code() ) {
+			// need the parsed response, which we don't have access to yet
+			$response = $this->get_parsed_response( $this->get_raw_response_body() );
+			throw new SV_WC_API_Exception( $response->error->message );
+		}
+	}
+
+	protected function get_new_request( $args = array() ) {
+		return new SV_WC_API_REST_Request( $args['method'], $args['path'], $args['params'] );
+	}
+
+	protected function get_plugin() {
+		return wc_acme();
+	}
+
+}
+
+// usage
+$api = new WC_Acme_API( $secret_key );
+$api->create_product( 'widget', '122' );
+$product = $api->get_product( 'widget' );
+echo $product->sku;
+```
+
 ## Known Issues
 
 ### Subscriptions Authorize-only Renewal

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -53,7 +53,7 @@ abstract class SV_WC_API_Base {
 	protected $request_http_version = '1.0';
 
 	/** @var string request duration */
-	private $request_duration;
+	protected $request_duration;
 
 	/** @var object request */
 	protected $request;
@@ -90,6 +90,9 @@ abstract class SV_WC_API_Base {
 	 * @return object class instance which implements \SV_WC_API_Response
 	 */
 	protected function perform_request( $request ) {
+
+		// ensure API is in its default state
+		$this->reset_response();
 
 		// save the request object
 		$this->request = $request;
@@ -146,7 +149,6 @@ abstract class SV_WC_API_Base {
 
 		// check for WP HTTP API specific errors (network timeout, etc)
 		if ( is_wp_error( $response ) ) {
-
 			throw new SV_WC_API_Exception( $response->get_error_message(), (int) $response->get_error_code() );
 		}
 
@@ -256,6 +258,22 @@ abstract class SV_WC_API_Base {
 	}
 
 
+	/**
+	 * Reset the API response members to their
+	 *
+	 * @since 1.0.0
+	 */
+	protected function reset_response() {
+
+		$this->response_code     = null;
+		$this->response_message  = null;
+		$this->response_headers  = null;
+		$this->raw_response_body = null;
+		$this->response          = null;
+		$this->request_duration  = null;
+	}
+
+
 	/** Request Getters *******************************************************/
 
 
@@ -266,7 +284,8 @@ abstract class SV_WC_API_Base {
 	 * @return string
 	 */
 	protected function get_request_uri() {
-		return $this->request_uri;
+		// API base request URI + any request-specific path
+		return $this->request_uri . ( $this->get_request() ? $this->get_request()->get_path() : '' );
 	}
 
 
@@ -283,7 +302,7 @@ abstract class SV_WC_API_Base {
 			'timeout'     => MINUTE_IN_SECONDS,
 			'redirection' => 0,
 			'httpversion' => $this->get_request_http_version(),
-			'sslverify'   => false,
+			'sslverify'   => true,
 			'blocking'    => true,
 			'user-agent'  => $this->get_request_user_agent(),
 			'headers'     => $this->get_request_headers(),
@@ -313,7 +332,8 @@ abstract class SV_WC_API_Base {
 	 * @return string
 	 */
 	protected function get_request_method() {
-		return $this->request_method;
+		// if the request object specifies the method to use, use that, otherwise use the API default
+		return $this->get_request() && $this->get_request()->get_method() ? $this->get_request()->get_method() : $this->request_method;
 	}
 
 
@@ -504,13 +524,14 @@ abstract class SV_WC_API_Base {
 	 *
 	 * Child classes must implement this to return an object that implements
 	 * \SV_WC_API_Request which should be used in the child class API methods
-	 * to build the request. This is then passed to self::perform_request()
+	 * to build the request. The returned SV_WC_API_Request should be passed
+	 * to self::perform_request() by your concrete API methods
 	 *
 	 * @since 2.2.0
-	 * @param string $type optional request type
+	 * @param array $args optional request arguments
 	 * @return \SV_WC_API_Request
 	 */
-	abstract protected function get_new_request( $type = null );
+	abstract protected function get_new_request( $args = array() );
 
 
 	/**
@@ -572,7 +593,7 @@ abstract class SV_WC_API_Base {
 	 * Set the Accept request header
 	 *
 	 * @since 2.2.0
-	 * @param $type
+	 * @param string $type the request accept type
 	 */
 	protected function set_request_accept_header( $type ) {
 		$this->request_headers['accept'] = $type;

--- a/woocommerce/api/class-sv-wc-api-json-response.php
+++ b/woocommerce/api/class-sv-wc-api-json-response.php
@@ -42,7 +42,7 @@ class SV_WC_API_JSON_Response implements SV_WC_API_Response {
 	protected $raw_response_json;
 
 	/** @var mixed decoded response data */
-	protected $response_data;
+	public $response_data;
 
 
 	/**
@@ -65,11 +65,6 @@ class SV_WC_API_JSON_Response implements SV_WC_API_Response {
 	 * @return mixed the attribute value
 	 */
 	public function __get( $name ) {
-
-		// accessing the response_data object directly (useful when it's an array)
-		if ( 'response_data' == $name ) {
-			return $this->response_data;
-		}
 
 		// accessing the response_data object indirectly via attribute (useful when it's a class)
 		return isset( $this->response_data->$name ) ? $this->response_data->$name : null;

--- a/woocommerce/api/class-sv-wc-api-json-response.php
+++ b/woocommerce/api/class-sv-wc-api-json-response.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/API/Response
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2015, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+if ( ! class_exists( 'SV_WC_API_JSON_Response' ) ) :
+
+
+/**
+ * API JSON Base Response Class
+ *
+ * Useful for API's that return application/json responses
+ *
+ * @since 3.1.2-1
+ * @see SV_WC_API_Response
+ */
+class SV_WC_API_JSON_Response implements SV_WC_API_Response {
+
+
+	/** @var string string representation of this response */
+	protected $raw_response_json;
+
+	/** @var mixed decoded response data */
+	protected $response_data;
+
+
+	/**
+	 * Build a response object from the raw response JSON
+	 *
+	 * @since 3.1.2-1
+	 * @param string $raw_response_json the raw response JSON
+	 */
+	public function __construct( $raw_response_json ) {
+		$this->raw_response_json = $raw_response_json;
+		$this->response_data     = json_decode( $raw_response_json );
+	}
+
+
+	/**
+	 * Magic accessor for response data attributes
+	 *
+	 * @since 3.1.2-1
+	 * @param string $name the attribute name to get
+	 * @return mixed the attribute value
+	 */
+	public function __get( $name ) {
+
+		// accessing the response_data object directly (useful when it's an array)
+		if ( 'response_data' == $name ) {
+			return $this->response_data;
+		}
+
+		// accessing the response_data object indirectly via attribute (useful when it's a class)
+		return isset( $this->response_data->$name ) ? $this->response_data->$name : null;
+	}
+
+
+	/**
+	 * Returns the string representation of this response
+	 *
+	 * @since 3.1.2-1
+	 * @see SV_WC_API_Response::to_string()
+	 * @return string the raw response
+	 */
+	public function to_string() {
+
+		return $this->raw_response_json;
+	}
+
+
+	/**
+	 * Returns the string representation of this response with any and all
+	 * sensitive elements masked or removed
+	 *
+	 * @since 3.1.2-1
+	 * @see SV_WC_API_Response::to_string_safe()
+	 * @return string response safe for logging/displaying
+	 */
+	public function to_string_safe() {
+
+		// no sensitive data to mask
+		return $this->to_string();
+	}
+
+
+}
+
+endif;

--- a/woocommerce/api/class-sv-wc-api-rest-request.php
+++ b/woocommerce/api/class-sv-wc-api-rest-request.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/API/Request
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2015, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+if ( ! class_exists( 'SV_WC_API_REST_Request' ) ) :
+
+
+/**
+ * Base REST API Request class
+ *
+ * @since 3.1.2-1
+ */
+class SV_WC_API_REST_Request implements SV_WC_API_Request {
+
+
+	/** @var string the request method, one of HEAD, GET, PUT, PATCH, POST, DELETE */
+	protected $method;
+
+	/** @var string the request path */
+	protected $path;
+
+	/** @var array the request parameters, if any */
+	protected $params;
+
+
+	/**
+	 * Construct REST request object
+	 *
+	 * @since 3.1.2-1
+	 * @param string $method the request method, one of HEAD, GET, PUT, PATCH, POST, DELETE
+	 * @param string $path optional request path
+	 * @param array $params optional associative array of request parameters
+	 */
+	public function __construct( $method, $path = '', $params = array() ) {
+		$this->method = $method;
+		$this->path   = $path;
+		$this->params = $params;
+	}
+
+
+	/** Getter Methods ******************************************************/
+
+
+	/**
+	 * Returns the method for this request: one of HEAD, GET, PUT, PATCH, POST, DELETE
+	 *
+	 * @since 3.1.2-1
+	 * @see SV_WC_API_Request::get_method()
+	 * @return string the request method
+	 */
+	public function get_method() {
+		return $this->method;
+	}
+
+
+	/**
+	 * Returns the request path
+	 *
+	 * @since 3.1.2-1
+	 * @see SV_WC_API_Request::get_path()
+	 * @return string the request path
+	 */
+	public function get_path() {
+		return $this->path;
+	}
+
+
+	/**
+	 * Returns the request params, if any
+	 *
+	 * @since 3.1.2-1
+	 * @return array the request params
+	 */
+	public function get_params() {
+		return $this->params;
+	}
+
+
+	/** API Helper Methods ******************************************************/
+
+
+	/**
+	 * Returns the string representation of this request
+	 *
+	 * @since 3.1.2-1
+	 * @see SV_WC_API_Request::to_string()
+	 * @return string request
+	 */
+	public function to_string() {
+		// URL encode params
+		return build_query( $this->get_params() );
+	}
+
+
+	/**
+	 * Returns the string representation of this request with any and all
+	 * sensitive elements masked or removed
+	 *
+	 * @since 3.1.2-1
+	 * @see SV_WC_API_Request::to_string_safe()
+	 * @return string the request, safe for logging/displaying
+	 */
+	public function to_string_safe() {
+
+		return $this->to_string();
+	}
+
+
+}
+
+endif;

--- a/woocommerce/api/interface-sv-wc-api-request.php
+++ b/woocommerce/api/interface-sv-wc-api-request.php
@@ -33,6 +33,24 @@ interface SV_WC_API_Request {
 
 
 	/**
+	 * Returns the method for this request: one of HEAD, GET, PUT, PATCH, POST, DELETE
+	 *
+	 * @since 3.1.2-1
+	 * @return string the request method, or null to use the API default
+	 */
+	public function get_method();
+
+
+	/**
+	 * Returns the request path
+	 *
+	 * @since 3.1.2-1
+	 * @return string the request path, or '' if none
+	 */
+	public function get_path();
+
+
+	/**
 	 * Returns the string representation of this request
 	 *
 	 * @since 2.2.0

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,10 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+XXXX.XX.XX - version 3.1.2-1
+ * Tweak - Improved support for REST API development
+
 2015.03.17 - version 3.1.2
-* Fix - JS variable `wc_select_params` undefined in WC 2.3.6+
+ * Fix - JS variable `wc_select_params` undefined in WC 2.3.6+
 
 2015.03.10 - version 3.1.1
  * Tweak - Add `get_cancel_order_url_raw()` compatibility method

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -45,8 +45,8 @@ if ( ! class_exists( 'SV_WC_Helper' ) ) :
 		 * Note: case-sensitive
 		 *
 		 * @since 2.2.0
-		 * @param $haystack
-		 * @param $needle
+		 * @param string $haystack
+		 * @param string $needle
 		 * @return bool
 		 */
 		public static function str_starts_with( $haystack, $needle) {
@@ -72,8 +72,8 @@ if ( ! class_exists( 'SV_WC_Helper' ) ) :
 		 * Note: case-sensitive
 		 *
 		 * @since 2.2.0
-		 * @param $haystack
-		 * @param $needle
+		 * @param string $haystack
+		 * @param string $needle
 		 * @return bool
 		 */
 		public static function str_ends_with( $haystack, $needle ) {
@@ -102,8 +102,8 @@ if ( ! class_exists( 'SV_WC_Helper' ) ) :
 		 * Note: case-sensitive
 		 *
 		 * @since 2.2.0
-		 * @param $haystack
-		 * @param $needle
+		 * @param string $haystack
+		 * @param string $needle
 		 * @return bool
 		 */
 		public static function str_exists( $haystack, $needle ) {
@@ -682,6 +682,18 @@ if ( ! class_exists( 'SV_WC_Helper' ) ) :
 
 				do_action( 'sv_wc_select2_ajax_rendered' );
 			}
+		}
+
+
+		/**
+		 * Gets the full URL to the log file for a given $handle
+		 *
+		 * @since 3.1.2-1
+		 * @param string $handle log handle
+		 * @return string URL to the WC log file identified by $handle
+		 */
+		public static function get_wc_log_file_url( $handle ) {
+			return admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&log_file=%s-%s-log', $handle, sanitize_file_name( wp_hash( $handle ) ) ) );
 		}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -89,7 +89,7 @@ if ( ! class_exists( 'SV_WC_Plugin' ) ) :
 abstract class SV_WC_Plugin {
 
 	/** Plugin Framework Version */
-	const VERSION = '3.1.2';
+	const VERSION = '3.1.2-1';
 
 	/** @var object single instance of plugin */
 	protected static $instance;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -742,7 +742,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * Perform a credit card capture for the given order
 	 *
 	 * @since 1.0.0
-	 * @param $order WC_Order the order
+	 * @param WC_Order $order the order
 	 * @return null|SV_WC_Payment_Gateway_API_Response the response of the capture attempt
 	 */
 	public function do_credit_card_capture( $order ) {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -644,11 +644,11 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 
 		// add any common bottom fields
 		$this->form_fields['debug_mode'] = array(
-			'title'       => __( 'Debug Mode', $this->text_domain ),
-			'type'        => 'select',
-			'description' => sprintf( __( 'Show Detailed Error Messages and API requests/responses on the checkout page and/or save them to the debug log: %s', $this->text_domain ), '<strong class="nobr">' . SV_WC_Plugin_Compatibility::wc_get_log_file_path( $this->get_id() ) . '</strong>' ),
-			'default'     => self::DEBUG_MODE_OFF,
-			'options'     => array(
+			'title'   => __( 'Debug Mode', $this->text_domain ),
+			'type'    => 'select',
+			'desc'    => sprintf( __( 'Show Detailed Error Messages and API requests/responses on the checkout page and/or save them to the <a href="%s">debug log</a>', $this->text_domain ), SV_WC_Helper::get_wc_log_file_url( $this->get_id() ) ),
+			'default' => self::DEBUG_MODE_OFF,
+			'options' => array(
 				self::DEBUG_MODE_OFF      => _x( 'Off', 'Debug mode off', $this->text_domain ),
 				self::DEBUG_MODE_CHECKOUT => __( 'Show on Checkout Page', $this->text_domain ),
 				self::DEBUG_MODE_LOG      => __( 'Save to Log', $this->text_domain ),
@@ -1870,7 +1870,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * Returns true if the authorization for $order is still valid for capture
 	 *
 	 * @since 2.0.0
-	 * @param $order WC_Order the order
+	 * @param WC_Order $order the order
 	 * @return boolean true if the authorization is valid for capture, false otherwise
 	 */
 	public function authorization_valid_for_capture( $order ) {
@@ -1898,7 +1898,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * Returns true if the authorization for $order has expired
 	 *
 	 * @since 2.0.0
-	 * @param $order WC_Order the order
+	 * @param WC_Order $order the order
 	 * @return boolean true if the authorization has expired, false otherwise
 	 */
 	public function has_authorization_expired( $order ) {


### PR DESCRIPTION
The goal of this PR is to make the minimal changes required to the framework API classes to make them REST friendly. These changes, while minor, do involve method signature changes, and Interface definition changes, so when released this will be a breaking change and require updates to existing code that relies on the previous signatures.

Also included is a simple sample REST API implementation in the readme, though this should probably be moved to the project wiki once the PR is ready to be merged

## Done:

* `get_new_request()` now takes an `$args` array, rather than the simple `$type` string, allowing for the construction of more complex request objects
* rather than assuming that there will be a single request method/uri/etc, these are defined by the Request interface, and returned by the Request object
* `SV_WC_API_JSON_Response` concrete base JSON response class
* `SV_WC_API_REST_Request` concrete base REST request class
* Simple, sample REST API implementation described in project readme
* default `ssl_verify` to true
* API `reset_response()` so that multiple API requests can be made in the same session without bleeding into each other
* Fixes payment gateway `debug_mode` setting description attribute
* Link to WP Admin WC Status Log page from payment gateway `debug_mode` setting, rather than  showing the log file path
* fix @param phpDoc's