### PR TITLE
get_default_title return consistency

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -662,6 +662,8 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 		} elseif ( $this->is_echeck_gateway() ) {
 			return _x( 'eCheck', 'Supports cheque', $this->text_domain );
 		}
+		
+		return '';
 	}
 
 


### PR DESCRIPTION
Function is described as `string`, so it must not have a `void` return.