### PR TITLE
validate_fields return consistency

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -132,9 +132,11 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		} else {
 			$method_name = 'validate_' . str_replace( '-', '_', strtolower( $this->get_payment_type() ) ) . '_fields';
 			if ( method_exists( $this, $method_name ) ) {
-				$this->$method_name( $is_valid );
+				return $this->$method_name( $is_valid );
 			}
 		}
+		
+		return true;
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -136,7 +136,9 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 			}
 		}
 		
-		return true;
+		// no more validation to perform. Return the parent method's outcome.
+		return $is_valid;
+
 	}
 
 


### PR DESCRIPTION
- `$this->$method_name( $is_valid );` looks like missing return?
- default return is missing, too. I guess, it's `true`?