### PR TITLE
get_default_description return consistency

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -680,6 +680,8 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 		} elseif ( $this->is_echeck_gateway() ) {
 			return _x( 'Pay securely using your checking account.', 'Supports cheque', $this->text_domain );
 		}
+		
+		return '';
 	}
 
 


### PR DESCRIPTION
Again, the method should not return `void`. Need to QA for (unlikely) side effects.