### PR TITLE
Add Subscriptions 2.0 support for gateways

### DIFF
--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -281,8 +281,22 @@ abstract class SV_WC_API_Base {
 	 * @return string
 	 */
 	protected function get_request_uri() {
+
 		// API base request URI + any request-specific path
-		return $this->request_uri . ( $this->get_request() ? $this->get_request()->get_path() : '' );
+		$uri = $this->request_uri . ( $this->get_request() ? $this->get_request()->get_path() : '' );
+
+		/**
+		 * Request URI Filter.
+		 *
+		 * Allow actors to filter the request URI. Note that child classes can override
+		 * this method, which means this filter may be invoked prior to the overridden
+		 * method.
+		 *
+		 * @since 4.0.1-2
+		 * @param string $uri current request URI
+		 * @param \SV_WC_API_Base class instance
+		 */
+		return apply_filters( 'wc_' . $this->get_api_id() . '_request_uri', $uri, $this );
 	}
 
 
@@ -314,9 +328,9 @@ abstract class SV_WC_API_Base {
 		 * child classes can override this method, which means this filter may
 		 * not be invoked, or may be invoked prior to the overridden method
 		 *
+		 * @since 2.2.0
 		 * @param array $args request arguments
 		 * @param \SV_WC_API_Base class instance
-		 * @since 2.2.0
 		 */
 		return apply_filters( 'wc_' . $this->get_api_id() . '_http_request_args', $args, $this );
 	}

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -292,7 +292,7 @@ abstract class SV_WC_API_Base {
 		 * this method, which means this filter may be invoked prior to the overridden
 		 * method.
 		 *
-		 * @since 4.0.1-2
+		 * @since 4.1.0
 		 * @param string $uri current request URI
 		 * @param \SV_WC_API_Base class instance
 		 */

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -296,7 +296,7 @@ abstract class SV_WC_API_Base {
 		 * @param string $uri current request URI
 		 * @param \SV_WC_API_Base class instance
 		 */
-		return apply_filters( 'wc_' . $this->get_api_id() . '_request_uri', $uri, $this );
+		return apply_filters( 'wc_' . $this->get_api_id() . '_api_request_uri', $uri, $this );
 	}
 
 

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,8 +1,9 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
-2015.nn.nn - version 4.0.1-2
- * Fix - Fix assert() warnings with certain gateway configurations on the My Account page
+2015.08.27 - version 4.1.0
+ * Feature - WooCommerce Subscriptions 2.0 Support
  * Tweak - Add specific width/height styling for payment method icons
+ * Fix - Fix assert() warnings with certain gateway configurations on the My Account page
 
 2015.07.29 - version 4.0.1
  * Fix - Fix typo in payment gateway frontend javascript

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,6 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
-2015.nn.nn - version 4.0.1-1
+2015.nn.nn - version 4.0.1-2
  * Fix - Fix assert() warnings with certain gateway configurations on the My Account page
  * Tweak - Add specific width/height styling for payment method icons
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -31,13 +31,15 @@ if ( ! class_exists( 'SV_WC_Plugin_Compatibility' ) ) :
  *
  * The unfortunate purpose of this class is to provide a single point of
  * compatibility functions for dealing with supporting multiple versions
- * of WooCommerce.
+ * of WooCommerce and various extensions.
  *
  * The expected procedure is to remove methods from this class, using the
  * latest ones directly in code, as support for older versions of WooCommerce
  * are dropped.
  *
- * Current Compatibility: 2.2.x - 2.4.x
+ * Current Compatibility
+ * + Core 2.2.x - 2.4.x
+ * + Subscriptions 1.5.x - 2.0.x
  *
  * @since 2.0.0
  */
@@ -173,6 +175,35 @@ class SV_WC_Plugin_Compatibility {
 	 */
 	public static function is_wc_version_gt( $version ) {
 		return self::get_wc_version() && version_compare( self::get_wc_version(), $version, '>' );
+	}
+
+
+	/** Subscriptions *********************************************************/
+
+
+	/**
+	 * Returns true if the installed version of WooCommerce Subscriptions is
+	 * 2.0.0 or greater
+	 *
+	 * @since 4.0.1-2
+	 * @return boolean
+	 */
+	public static function is_wc_subscriptions_version_gte_2_0() {
+
+		return self::get_wc_subscriptions_version() && version_compare( self::get_wc_subscriptions_version(), '2.0-beta-1', '>=' );
+	}
+
+
+	/**
+	 * Helper method to get the version of the currently installed WooCommerce
+	 * Subscriptions
+	 *
+	 * @since 4.0.1-2
+	 * @return string woocommerce version number or null
+	 */
+	protected static function get_wc_subscriptions_version() {
+
+		return class_exists( 'WC_Subscriptions' ) && ! empty( WC_Subscriptions::$version ) ? WC_Subscriptions::$version : null;
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -185,7 +185,7 @@ class SV_WC_Plugin_Compatibility {
 	 * Returns true if the installed version of WooCommerce Subscriptions is
 	 * 2.0.0 or greater
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return boolean
 	 */
 	public static function is_wc_subscriptions_version_gte_2_0() {
@@ -198,7 +198,7 @@ class SV_WC_Plugin_Compatibility {
 	 * Helper method to get the version of the currently installed WooCommerce
 	 * Subscriptions
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return string woocommerce version number or null
 	 */
 	protected static function get_wc_subscriptions_version() {

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -84,12 +84,12 @@ if ( ! class_exists( 'SV_WC_Plugin' ) ) :
  * Use the standard WordPress/WooCommerce `is_*` methods when adding the notice
  * to control which pages it does (or does not) display on.
  *
- * @version 4.0.1-2
+ * @version 4.1.0
  */
 abstract class SV_WC_Plugin {
 
 	/** Plugin Framework Version */
-	const VERSION = '4.0.1-2';
+	const VERSION = '4.1.0';
 
 	/** @var object single instance of plugin */
 	protected static $instance;

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -84,12 +84,12 @@ if ( ! class_exists( 'SV_WC_Plugin' ) ) :
  * Use the standard WordPress/WooCommerce `is_*` methods when adding the notice
  * to control which pages it does (or does not) display on.
  *
- * @version 4.0.1-1
+ * @version 4.0.1-2
  */
 abstract class SV_WC_Plugin {
 
 	/** Plugin Framework Version */
-	const VERSION = '4.0.1-1';
+	const VERSION = '4.0.1-2';
 
 	/** @var object single instance of plugin */
 	protected static $instance;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
@@ -180,7 +180,7 @@ interface SV_WC_Payment_Gateway_API {
 	 * Returns the most recent request object
 	 *
 	 * @since 1.0.0
-	 * @return SV_WC_Payment_Gateway_API_Request the most recent request object
+	 * @return \SV_WC_Payment_Gateway_API_Request the most recent request object
 	 */
 	public function get_request();
 
@@ -189,9 +189,19 @@ interface SV_WC_Payment_Gateway_API {
 	 * Returns the most recent response object
 	 *
 	 * @since 1.0.0
-	 * @return SV_WC_Payment_Gateway_API_Response the most recent response object
+	 * @return \SV_WC_Payment_Gateway_API_Response the most recent response object
 	 */
 	public function get_response();
+
+
+	/**
+	 * Returns the WC_Order object associated with the request, if any
+	 *
+	 * @since 4.0.1-2
+	 * @return \WC_Order
+	 */
+	public function get_order();
+
 
 }
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
@@ -197,7 +197,7 @@ interface SV_WC_Payment_Gateway_API {
 	/**
 	 * Returns the WC_Order object associated with the request, if any
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return \WC_Order
 	 */
 	public function get_order();

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -37,17 +37,17 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	/** Add new payment method feature */
 	const FEATURE_ADD_PAYMENT_METHOD = 'add_payment_method';
 
-	/** Subscriptions feature */
-	const FEATURE_SUBSCRIPTIONS = 'subscriptions';
+	/** Subscriptions integration ID */
+	const INTEGRATION_SUBSCRIPTIONS = 'subscriptions';
 
-	/** Subscription payment method change feature */
-	const FEATURE_SUBSCRIPTION_PAYMENT_METHOD_CHANGE = 'subscription_payment_method_change';
-
-	/** Pre-orders feature */
-	const FEATURE_PRE_ORDERS = 'pre-orders';
+	/** Pre-orders integration ID */
+	const INTEGRATION_PRE_ORDERS = 'pre_orders';
 
 	/** @var array array of cached user id to array of SV_WC_Payment_Gateway_Payment_Token token objects */
 	protected $tokens;
+
+	/** @var array of SV_WC_Payment_Gateway_Integration objects for Subscriptions, Pre-Orders, etc. */
+	protected $integrations;
 
 
 	/**
@@ -67,30 +67,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		// parent constructor
 		parent::__construct( $id, $plugin, $text_domain, $args );
 
-		// watch for subscriptions support
-		if ( $this->get_plugin()->is_subscriptions_active() ) {
-
-			$subscription_support_hook               = 'wc_payment_gateway_' . $this->get_id() . '_supports_' . self::FEATURE_SUBSCRIPTIONS;
-			$subscription_payment_method_change_hook = 'wc_payment_gateway_' . $this->get_id() . '_supports_' . self::FEATURE_SUBSCRIPTION_PAYMENT_METHOD_CHANGE;
-
-			if ( ! has_action( $subscription_support_hook ) ) {
-				add_action( $subscription_support_hook, array( $this, 'add_subscriptions_support' ) );
-			}
-
-			if ( ! has_action( $subscription_payment_method_change_hook ) ) {
-				add_action( $subscription_payment_method_change_hook, array( $this, 'add_subscription_payment_method_change_support' ) );
-			}
-		}
-
-		// watch for pre-orders support
-		if ( $this->get_plugin()->is_pre_orders_active() ) {
-
-			$pre_orders_support_hook = 'wc_payment_gateway_' . $this->get_id() . '_supports_' . str_replace( '-', '_', self::FEATURE_PRE_ORDERS );
-
-			if ( ! has_action( $pre_orders_support_hook ) ) {
-				add_action( $pre_orders_support_hook, array( $this, 'add_pre_orders_support' ) );
-			}
-		}
+		$this->init_integrations();
 	}
 
 
@@ -448,7 +425,12 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 					$order->payment_complete(); // mark order as having received payment
 				}
 
-				WC()->cart->empty_cart();
+				// process_payment() can sometimes be called in an admin-context
+				if ( isset( WC()->cart ) ) {
+					WC()->cart->empty_cart();
+				}
+
+				do_action( 'wc_payment_gateway_' . $this->get_id() . '_payment_processed', $order, $this );
 
 				return array(
 					'result'   => 'success',
@@ -494,7 +476,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * @param int|\WC_Order $order_id order ID being processed
 	 * @return WC_Order object with payment and transaction information attached
 	 */
-	protected function get_order( $order_id ) {
+	public function get_order( $order_id ) {
 
 		$order = parent::get_order( $order_id );
 
@@ -628,6 +610,8 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 				$message .= ' ' . sprintf( _x( '(Transaction ID %s)', 'Supports direct cheque', $this->text_domain ), $response->get_transaction_id() );
 			}
 
+			$message = apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_check_transaction_approved_order_note', $message, $order, $response, $this );
+
 			$order->add_order_note( $message );
 
 		}
@@ -686,6 +670,8 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 			if ( $response->get_transaction_id() ) {
 				$message .= ' ' . sprintf( _x( '(Transaction ID %s)', 'Supports direct credit card', $this->text_domain ), $response->get_transaction_id() );
 			}
+
+			$message = apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_credit_card_transaction_approved_order_note', $message, $order, $response, $this );
 
 			$order->add_order_note( $message );
 
@@ -854,7 +840,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * @param WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response|null $response optional transaction response
 	 */
-	protected function add_transaction_data( $order, $response = null ) {
+	public function add_transaction_data( $order, $response = null ) {
 
 		// add parent transaction data
 		parent::add_transaction_data( $order, $response );
@@ -946,661 +932,144 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	}
 
 
-	/** Subscriptions feature ******************************************************/
+	/** Integrations Feature **************************************************/
 
 
 	/**
-	 * Returns true if this gateway with its current configuration supports subscriptions
+	 * Initialize supported integrations
+	 *
+	 * @since 4.0.1-2
+	 */
+	public function init_integrations() {
+
+		if ( $this->supports_subscriptions() ) {
+			$this->integrations[ self::INTEGRATION_SUBSCRIPTIONS ] = $this->build_subscriptions_integration();
+		}
+
+		if ( $this->supports_pre_orders() ) {
+			$this->integrations[ self::INTEGRATION_PRE_ORDERS ] = $this->build_pre_orders_integration();
+		}
+
+		do_action( 'wc_payment_gateway_' . $this->get_id() . '_init_integrations', $this );
+	}
+
+
+	/**
+	 * Return an array of available integration objects
+	 *
+	 * @since 4.0.1-2
+	 * @return array
+	 */
+	public function get_integrations() {
+
+		return $this->integrations;
+	}
+
+
+	/**
+	 * Get the integration object for the given ID
+	 *
+	 * @since 4.0.1-2
+	 * @param string $id the integration ID, e.g. subscriptions
+	 * @return \SV_WC_Payment_Gateway_Integration|null
+	 */
+	public function get_integration( $id ) {
+
+		return isset( $this->integrations[ $id ] ) ? $this->integrations[ $id ] : null;
+	}
+
+
+	/**
+	 * A factory method to build and return the Subscriptions class instance.
+	 * Concrete classes can override this method to return a custom
+	 * implementation.
+	 *
+	 * @since 4.0.1-2
+	 * @return \SV_WC_Payment_Gateway_Integration_Subscriptions
+	 */
+	protected function build_subscriptions_integration() {
+
+		return new SV_WC_Payment_Gateway_Integration_Subscriptions( $this );
+	}
+
+
+	/**
+	 * Get the Subscriptions integration class instance
+	 *
+	 * @since 4.0.1-2
+	 * @return \SV_WC_Payment_Gateway_Integration_Subscriptions|null
+	 */
+	public function get_subscriptions_integration() {
+
+		return isset( $this->integrations[ self::INTEGRATION_SUBSCRIPTIONS ] ) ? $this->integrations[ self::INTEGRATION_SUBSCRIPTIONS ] : null;
+	}
+
+
+	/**
+	 * A factory method to build and return the Pre-Orders class instance.
+	 * Concrete classes can override this method to return a custom
+	 * implementation.
+	 *
+	 * @since 4.0.1-2
+	 * @return \SV_WC_Payment_Gateway_Integration_Pre_Orders
+	 */
+	protected function build_pre_orders_integration() {
+
+		return new SV_WC_Payment_Gateway_Integration_Pre_Orders( $this );
+	}
+
+
+	/**
+	 * Get the Pre-Orders integration class instance
+	 *
+	 * @since 4.0.1-2
+	 * @return \SV_WC_Payment_Gateway_Integration_Pre_Orders|null
+	 */
+	public function get_pre_orders_integration() {
+
+		return isset( $this->integrations[ self::INTEGRATION_PRE_ORDERS ] ) ? $this->integrations[ self::INTEGRATION_PRE_ORDERS ] : null;
+	}
+
+
+	/**
+	 * A gateway supports Subscriptions if all of the following are true:
+	 *
+	 * + Subscriptions is active
+	 * + tokenization is supported
+	 * + tokenization is enabled
+	 *
+	 * Concrete gateways can override this to conditionally support Subscriptions
+	 * based on certain settings (e.g. only when CSC is not required, etc.)
 	 *
 	 * @since 1.0.0
 	 * @return boolean true if the gateway supports subscriptions
 	 */
 	public function supports_subscriptions() {
-		return $this->supports( self::FEATURE_SUBSCRIPTIONS ) && $this->supports_tokenization() && $this->tokenization_enabled();
+
+		return $this->get_plugin()->is_subscriptions_active() && $this->supports_tokenization() && $this->tokenization_enabled();
 	}
 
 
 	/**
-	 * Adds support for subscriptions by hooking in some necessary actions
+	 * A gateway supports Pre-Orders if all of the following are true:
 	 *
-	 * @since 1.0.0
-	 */
-	public function add_subscriptions_support() {
-
-		// bail if subscriptions are not supported by this gateway or its current configuration
-		if ( ! $this->supports_subscriptions() ) {
-			// note: no longer throwing an exception due to a weird race condition with multiple instances
-			// of this class, with action callbacks getting mixed up, and stale data causing problems
-			return;
-		}
-
-		// force tokenization when needed
-		add_filter( 'wc_payment_gateway_' . $this->get_id() . '_tokenization_forced', array( $this, 'subscriptions_tokenization_forced' ) );
-
-		// add subscriptions data to the order object
-		add_filter( 'wc_payment_gateway_' . $this->get_id() . '_get_order', array( $this, 'subscriptions_get_order' ) );
-
-		// process scheduled subscription payments
-		add_action( 'scheduled_subscription_payment_' . $this->get_id(), array( $this, 'process_subscription_renewal_payment' ), 10, 3 );
-
-		// prevent unnecessary order meta from polluting parent renewal orders
-		add_filter( 'woocommerce_subscriptions_renewal_order_meta_query', array( $this, 'remove_subscription_renewal_order_meta' ), 10, 4 );
-
-		// display the current payment method used for a subscription in the "My Subscriptions" table
-		add_filter( 'woocommerce_my_subscriptions_recurring_payment_method', array( $this, 'maybe_render_subscription_payment_method' ), 10, 3 );
-	}
-
-
-	/**
-	 * Force tokenization for subscriptions, this can be forced either during checkout
-	 * or when the payment method for a subscription is being changed
+	 * + Pre-Orders is active
+	 * + tokenization is supported
+	 * + tokenization is enabled
 	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Payment_Gateway::tokenization_forced()
-	 * @param bool $force_tokenization whether tokenization should be forced
-	 * @return bool true if tokenization should be forced, false otherwise
-	 */
-	public function subscriptions_tokenization_forced( $force_tokenization ) {
-
-		// pay page with subscription?
-		$pay_page_subscription = false;
-		if ( $this->is_pay_page_gateway() ) {
-
-			$order_id = $this->get_checkout_pay_page_order_id();
-
-			if ( $order_id ) {
-				$pay_page_subscription = WC_Subscriptions_Order::order_contains_subscription( $order_id );
-			}
-
-		}
-
-		if ( WC_Subscriptions_Cart::cart_contains_subscription() ||
-			WC_Subscriptions_Change_Payment_Gateway::$is_request_to_change_payment ||
-			$pay_page_subscription ) {
-			$force_tokenization = true;
-		}
-
-		return $force_tokenization;
-	}
-
-
-	/**
-	 * Adds subscriptions data to the order object
-	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Payment_Gateway::get_order()
-	 * @param WC_Order $order the order
-	 * @return WC_Order the orders
-	 */
-	public function subscriptions_get_order( $order ) {
-
-		// bail if the gateway doesn't support subscriptions or the order doesn't contain a subscription
-		if ( ! $this->supports_subscriptions() || ! WC_Subscriptions_Order::order_contains_subscription( $order->id ) )
-			return $order;
-
-		// subscriptions total, ensuring that we have a decimal point, even if it's 1.00
-		$order->payment_total = number_format( (double) WC_Subscriptions_Order::get_total_initial_payment( $order ), 2, '.', '' );
-
-		// load any required members that we might not have
-		if ( ! isset( $order->payment->token ) || ! $order->payment->token )
-			$order->payment->token = $this->get_order_meta( $order->id, 'payment_token' );
-
-		if ( ! isset( $order->customer_id ) || ! $order->customer_id )
-			$order->customer_id = $this->get_order_meta( $order->id, 'customer_id' );
-
-		// ensure the payment token is still valid
-		if ( ! $this->has_payment_token( $order->get_user_id(), $order->payment->token ) ) {
-			$order->payment->token = null;
-		} else {
-
-			// get the token object
-			$token = $this->get_payment_token( $order->get_user_id(), $order->payment->token );
-
-			if ( ! isset( $order->payment->account_number ) || ! $order->payment->account_number )
-				$order->payment->account_number = $token->get_last_four();
-
-			if ( $this->is_credit_card_gateway() ) {
-
-				// credit card token
-
-				if ( ! isset( $order->payment->card_type ) || ! $order->payment->card_type )
-					$order->payment->card_type = $token->get_card_type();
-
-				if ( ! isset( $order->payment->exp_month ) || ! $order->payment->exp_month )
-					$order->payment->exp_month = $token->get_exp_month();
-
-				if ( ! isset( $order->payment->exp_year ) || ! $order->payment->exp_year )
-					$order->payment->exp_year = $token->get_exp_year();
-
-			} elseif ( $this->is_echeck_gateway() ) {
-
-				// check token
-
-				if ( ! isset( $order->payment->account_type ) || ! $order->payment->account_type )
-					$order->payment->account_type = $token->get_account_type();
-
-			}
-
-		}
-
-		return $order;
-	}
-
-
-	/**
-	 * Process subscription renewal
-	 *
-	 * @since 1.0.0
-	 * @param float $amount_to_charge subscription amount to charge, could include multiple renewals if they've previously failed and the admin has enabled it
-	 * @param WC_Order $order original order containing the subscription
-	 * @param int $product_id the subscription product id
-	 */
-	public function process_subscription_renewal_payment( $amount_to_charge, $order, $product_id ) {
-
-		try {
-
-			// set order defaults
-			$order = $this->get_order( $order->id );
-
-			// zero-dollar subscription renewal.  weird, but apparently it happens
-			if ( 0 == $amount_to_charge ) {
-
-				// add order note
-				$order->add_order_note( sprintf( _x( '%s0 Subscription Renewal Approved', 'Supports direct credit card subscriptions', $this->text_domain ), get_woocommerce_currency_symbol() ) );
-
-				// update subscription
-				WC_Subscriptions_Manager::process_subscription_payments_on_order( $order, $product_id );
-
-				return;
-			}
-
-			// set the amount to charge, ensuring that we have a decimal point, even if it's 1.00
-			$order->payment_total = number_format( (double) $amount_to_charge, 2, '.', '' );
-
-			// required
-			if ( ! $order->payment->token || ! $order->get_user_id() ) {
-				throw new SV_WC_Payment_Gateway_Exception( 'Subscription Renewal: Payment Token or User ID is missing/invalid.' );
-			}
-
-			// get the token, we've already verified it's good
-			$token = $this->get_payment_token( $order->get_user_id(), $order->payment->token );
-
-			// perform the transaction
-			if ( $this->is_credit_card_gateway() ) {
-
-				if ( $this->perform_credit_card_charge() ) {
-					$response = $this->get_api()->credit_card_charge( $order );
-				} else {
-					$response = $this->get_api()->credit_card_authorization( $order );
-				}
-
-			} elseif ( $this->is_echeck_gateway() ) {
-				$response = $this->get_api()->check_debit( $order );
-			}
-
-			// check for success
-			if ( $response->transaction_approved() ) {
-
-				// order note based on gateway type
-				if ( $this->is_credit_card_gateway() ) {
-					$message = sprintf(
-						_x( '%s %s Subscription Renewal Payment Approved: %s ending in %s (expires %s)', 'Supports direct credit card subscriptions', $this->text_domain ),
-						$this->get_method_title(),
-						$this->perform_credit_card_authorization() ? 'Authorization' : 'Charge',
-						$token->get_card_type() ? $token->get_type_full() : 'card',
-						$token->get_last_four(),
-						$token->get_exp_month() . '/' . $token->get_exp_year()
-					);
-				} elseif ( $this->is_echeck_gateway() ) {
-
-					// there may or may not be an account type (checking/savings) available, which is fine
-					$message = sprintf( _x( '%s Check Subscription Renewal Payment Approved: %s account ending in %s', 'Supports direct cheque subscriptions', $this->text_domain ), $this->get_method_title(), $token->get_account_type(), $token->get_last_four() );
-				}
-
-				// add order note
-				$order->add_order_note( $message );
-
-				// update subscription
-				WC_Subscriptions_Manager::process_subscription_payments_on_order( $order, $product_id );
-
-			} else {
-
-				// failure
-				throw new SV_WC_Payment_Gateway_Exception( sprintf( '%s: %s', $response->get_status_code(), $response->get_status_message() ) );
-			}
-
-		} catch ( SV_WC_Plugin_Exception $e ) {
-
-			$this->mark_order_as_failed( $order, $e->getMessage() );
-
-			// update subscription
-			WC_Subscriptions_Manager::process_subscription_payment_failure_on_order( $order, $product_id );
-		}
-	}
-
-
-	/**
-	 * Don't copy over gateway-specific order meta when creating a parent renewal order.
-	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Payment_Gateway::get_remove_subscription_renewal_order_meta_fragment()
-	 * @param array $order_meta_query MySQL query for pulling the metadata
-	 * @param int $original_order_id Post ID of the order being used to purchased the subscription being renewed
-	 * @param int $renewal_order_id Post ID of the order created for renewing the subscription
-	 * @param string $new_order_role The role the renewal order is taking, one of 'parent' or 'child'
-	 * @return string MySQL meta query for pulling the metadata, excluding data added by this gateway
-	 */
-	public function remove_subscription_renewal_order_meta( $order_meta_query, $original_order_id, $renewal_order_id, $new_order_role ) {
-
-		// all required and optional
-		if ( 'parent' == $new_order_role ) {
-			$order_meta_query .= $this->get_remove_subscription_renewal_order_meta(
-				array(
-					$this->get_order_meta_prefix() . 'trans_id',
-					$this->get_order_meta_prefix() . 'trans_date',
-					$this->get_order_meta_prefix() . 'payment_token',
-					$this->get_order_meta_prefix() . 'account_four',
-					$this->get_order_meta_prefix() . 'card_expiry_date',
-					$this->get_order_meta_prefix() . 'card_type',
-					$this->get_order_meta_prefix() . 'authorization_code',
-					$this->get_order_meta_prefix() . 'auth_can_be_captured',
-					$this->get_order_meta_prefix() . 'charge_captured',
-					$this->get_order_meta_prefix() . 'capture_trans_id',
-					$this->get_order_meta_prefix() . 'account_type',
-					$this->get_order_meta_prefix() . 'check_number',
-					$this->get_order_meta_prefix() . 'environment',
-					$this->get_order_meta_prefix() . 'customer_id',
-					$this->get_order_meta_prefix() . 'retry_count',
-				)
-			);
-		}
-
-		return $order_meta_query;
-	}
-
-
-	/**
-	 * Returns the query fragment to remove the given subscription renewal order meta
-	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Payment_Gateway::remove_subscription_renewal_order_meta()
-	 * @param array $meta_names array of string meta names to remove
-	 * @return string query fragment
-	 */
-	protected function get_remove_subscription_renewal_order_meta_fragment( $meta_names ) {
-
-		return " AND `meta_key` NOT IN ( '" . join( "', '", $meta_names ) . "' )";
-	}
-
-
-	/**
-	 * Adds support for subscriptions by hooking in some necessary actions
-	 *
-	 * @since 1.0.0
-	 */
-	public function add_subscription_payment_method_change_support() {
-
-		// bail if subscriptions or subscription payment method changes are not supported by this gateway or its current configuration
-		if ( ! $this->supports_subscriptions() || ! $this->supports( self::FEATURE_SUBSCRIPTION_PAYMENT_METHOD_CHANGE ) ) {
-			return;
-		}
-
-		// update the customer/token ID on the original order when making payment for a failed automatic renewal order
-		add_action( 'woocommerce_subscriptions_changed_failing_payment_method_' . $this->get_id(), array( $this, 'update_failing_payment_method' ), 10, 2 );
-	}
-
-
-	/**
-	 * Update the payment token and optional customer ID for a subscription after a customer
-	 * uses this gateway to successfully complete the payment for an automatic
-	 * renewal payment which had previously failed.
-	 *
-	 * @since 1.0.0
-	 * @param WC_Order $original_order the original order in which the subscription was purchased.
-	 * @param WC_Order $renewal_order the order which recorded the successful payment (to make up for the failed automatic payment).
-	 */
-	public function update_failing_payment_method( WC_Order $original_order, WC_Order $renewal_order ) {
-
-		if ( $this->get_order_meta( $renewal_order->id, 'customer_id' ) ) {
-			$this->update_order_meta( $original_order->id, 'customer_id',   $this->get_order_meta( $renewal_order->id, 'customer_id' ) );
-		}
-
-		$this->update_order_meta( $original_order->id, 'payment_token', $this->get_order_meta( $renewal_order->id, 'payment_token' ) );
-	}
-
-
-	/**
-	 * Render the payment method used for a subscription in the "My Subscriptions" table
-	 *
-	 * @since 1.0.0
-	 * @param string $payment_method_to_display the default payment method text to display
-	 * @param array $subscription_details the subscription details
-	 * @param WC_Order $order the order containing the subscription
-	 * @return string the subscription payment method
-	 */
-	public function maybe_render_subscription_payment_method( $payment_method_to_display, $subscription_details, WC_Order $order ) {
-
-		// bail for other payment methods
-		if ( $this->get_id() !== $order->recurring_payment_method )
-			return $payment_method_to_display;
-
-		$token = $this->get_payment_token( $order->get_user_id(), $this->get_order_meta( $order->id, 'payment_token' ) );
-
-		if ( is_object( $token )  )
-			$payment_method_to_display = sprintf( _x( 'Via %s ending in %s', 'Supports direct payment method subscriptions', $this->text_domain ), $token->get_type_full(), $token->get_last_four() );
-
-		return $payment_method_to_display;
-	}
-
-
-	/** Pre-Orders feature ******************************************************/
-
-
-	/**
-	 * Returns true if this gateway with its current configuration supports pre-orders
+	 * Concrete gateways can override this to conditionally support Pre-Orders
+	 * based on certain settings (e.g. only when CSC is not required, etc.)
 	 *
 	 * @since 1.0.0
 	 * @return boolean true if the gateway supports pre-orders
 	 */
 	public function supports_pre_orders() {
 
-		return $this->supports( self::FEATURE_PRE_ORDERS ) && $this->supports_tokenization() && $this->tokenization_enabled();
-
+		return $this->get_plugin()->is_pre_orders_active() && $this->supports_tokenization() && $this->tokenization_enabled();
 	}
 
 
-	/**
-	 * Adds support for pre-orders by hooking in some necessary actions
-	 *
-	 * @since 1.0.0
-	 */
-	public function add_pre_orders_support() {
-
-		// bail
-		if ( ! $this->supports_pre_orders() ) {
-			return;
-		}
-
-		// force tokenization when needed
-		add_filter( 'wc_payment_gateway_' . $this->get_id() . '_tokenization_forced', array( $this, 'pre_orders_tokenization_forced' ) );
-
-		// add pre-orders data to the order object
-		add_filter( 'wc_payment_gateway_' . $this->get_id() . '_get_order', array( $this, 'pre_orders_get_order' ) );
-
-		// process pre-order initial payment as needed
-		add_filter( 'wc_payment_gateway_' . $this->get_id() . '_process_payment', array( $this, 'process_pre_order_payment' ), 10, 2 );
-
-		// process batch pre-order payments
-		add_action( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->get_id(), array( $this, 'process_pre_order_release_payment' ) );
-
-	}
-
-	/**
-	 * Force tokenization for pre-orders
-	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Payment_Gateway::tokenization_forced()
-	 * @param boolean $force_tokenization whether tokenization should be forced
-	 * @return boolean true if tokenization should be forced, false otherwise
-	 */
-	public function pre_orders_tokenization_forced( $force_tokenization ) {
-
-		// pay page with pre-order?
-		$pay_page_pre_order = false;
-		if ( $this->is_pay_page_gateway() ) {
-
-			$order_id  = $this->get_checkout_pay_page_order_id();
-
-			if ( $order_id ) {
-				$pay_page_pre_order = WC_Pre_Orders_Order::order_contains_pre_order( $order_id ) && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Order::get_pre_order_product( $order_id ) );
-			}
-
-		}
-
-		if ( ( WC_Pre_Orders_Cart::cart_contains_pre_order() && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() ) ) ||
-			$pay_page_pre_order ) {
-
-			// always tokenize the card for pre-orders that are charged upon release
-			$force_tokenization = true;
-
-		}
-
-		return $force_tokenization;
-
-	}
-
-
-	/**
-	 * Adds pre-orders data to the order object.  Filtered onto SV_WC_Payment_Gateway::get_order()
-	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Payment_Gateway::get_order()
-	 * @param WC_Order $order the order
-	 * @return WC_Order the orders
-	 */
-	public function pre_orders_get_order( $order ) {
-
-		// bail if order doesn't contain a pre-order
-		if ( ! WC_Pre_Orders_Order::order_contains_pre_order( $order ) )
-			return $order;
-
-		if ( WC_Pre_Orders_Order::order_requires_payment_tokenization( $order ) ) {
-
-			// normally a guest user wouldn't be assigned a customer id, but for a pre-order requiring tokenization, it might be
-			if ( 0 == $order->get_user_id() && false !== ( $customer_id = $this->get_guest_customer_id( $order ) ) )
-				$order->customer_id = $customer_id;
-
-		} elseif ( WC_Pre_Orders_Order::order_has_payment_token( $order ) ) {
-
-			// if this is a pre-order release payment with a tokenized payment method, get the payment token to complete the order
-
-			// retrieve the payment token
-			$order->payment->token = $this->get_order_meta( $order->id, 'payment_token' );
-
-			// retrieve the optional customer id
-			$order->customer_id = $this->get_order_meta( $order->id, 'customer_id' );
-
-			// verify that this customer still has the token tied to this order.
-			if ( ! $this->has_payment_token( $order->get_user_id(), $order->payment->token ) ) {
-
-				$order->payment->token = null;
-
-			} else {
-				// Push expected payment data into the order, from the payment token when possible,
-				//  or from the order object otherwise.  The theory is that the token will have the
-				//  most up-to-date data, while the meta attached to the order is a second best
-
-				// for a guest transaction with a gateway that doesn't support "tokenization get" this will return null and the token data will be pulled from the order meta
-				$token = $this->get_payment_token( $order->get_user_id(), $order->payment->token );
-
-				// account last four
-				$order->payment->account_number = $token && $token->get_last_four() ? $token->get_last_four() : $this->get_order_meta( $order->id, 'account_four' );
-
-				if ( $this->is_credit_card_gateway() ) {
-
-					$order->payment->card_type = $token && $token->get_card_type() ? $token->get_card_type() : $this->get_order_meta( $order->id, 'card_type' );
-
-					if ( $token && $token->get_exp_month() && $token->get_exp_year() ) {
-						$order->payment->exp_month  = $token->get_exp_month();
-						$order->payment->exp_year   = $token->get_exp_year();
-					} else {
-						list( $exp_year, $exp_month ) = explode( '-', $this->get_order_meta( $order->id, 'card_expiry_date' ) );
-						$order->payment->exp_month  = $exp_month;
-						$order->payment->exp_year   = $exp_year;
-					}
-
-				} elseif ( $this->is_echeck_gateway() ) {
-
-					// set the account type if available (checking/savings)
-					$order->payment->account_type = $token && $token->get_account_type ? $token->get_account_type() : $this->get_order_meta( $order->id, 'account_type' );
-				}
-			}
-		}
-
-		return $order;
-	}
-
-
-	/**
-	 * Handle the pre-order initial payment/tokenization, or defer back to the normal payment
-	 * processing flow
-	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Payment_Gateway::process_payment()
-	 * @param boolean $result the result of this pre-order payment process
-	 * @param int $order_id the order identifier
-	 * @return true|array true to process this payment as a regular transaction, otherwise
-	 *         return an array containing keys 'result' and 'redirect'
-	 */
-	public function process_pre_order_payment( $result, $order_id ) {
-
-		assert( $this->supports_pre_orders() );
-
-		if ( WC_Pre_Orders_Order::order_contains_pre_order( $order_id ) &&
-			WC_Pre_Orders_Order::order_requires_payment_tokenization( $order_id ) ) {
-
-			$order = $this->get_order( $order_id );
-
-			try {
-
-				// using an existing tokenized payment method
-				if ( isset( $order->payment->token ) && $order->payment->token ) {
-
-					// save the tokenized card info for completing the pre-order in the future
-					$this->add_transaction_data( $order );
-
-				} else {
-
-					// otherwise tokenize the payment method
-					$order = $this->create_payment_token( $order );
-				}
-
-				// mark order as pre-ordered / reduce order stock
-				WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );
-
-				// empty cart
-				WC()->cart->empty_cart();
-
-				// redirect to thank you page
-				return array(
-					'result'   => 'success',
-					'redirect' => $this->get_return_url( $order ),
-				);
-
-			} catch( SV_WC_Payment_Gateway_Exception $e ) {
-
-				$this->mark_order_as_failed( $order, sprintf( _x( 'Pre-Order Tokenization attempt failed (%s)', 'Supports direct payment method pre-orders', $this->text_domain ), $this->get_method_title(), $e->getMessage() ) );
-
-			}
-		}
-
-		// processing regular product
-		return $result;
-	}
-
-
-	/**
-	 * Process a pre-order payment when the pre-order is released
-	 *
-	 * @since 1.0.0
-	 * @param WC_Order $order original order containing the pre-order
-	 */
-	public function process_pre_order_release_payment( $order ) {
-
-		try {
-
-			// set order defaults
-			$order = $this->get_order( $order->id );
-
-			// order description
-			$order->description = sprintf( _x( '%s - Pre-Order Release Payment for Order %s', 'Supports direct payment method pre-orders', $this->text_domain ), esc_html( get_bloginfo( 'name' ) ), $order->get_order_number() );
-
-			// token is required
-			if ( ! $order->payment->token ) {
-				throw new SV_WC_Payment_Gateway_Exception( _x( 'Payment token missing/invalid.', 'Supports direct payment method pre-orders', $this->text_domain ) );
-			}
-
-			// perform the transaction
-			if ( $this->is_credit_card_gateway() ) {
-
-				if ( $this->perform_credit_card_charge() ) {
-					$response = $this->get_api()->credit_card_charge( $order );
-				} else {
-					$response = $this->get_api()->credit_card_authorization( $order );
-				}
-
-			} elseif ( $this->is_echeck_gateway() ) {
-				$response = $this->get_api()->check_debit( $order );
-			}
-
-			// success! update order record
-			if ( $response->transaction_approved() ) {
-
-				$last_four = substr( $order->payment->account_number, -4 );
-
-				// order note based on gateway type
-				if ( $this->is_credit_card_gateway() ) {
-
-					$message = sprintf(
-						_x( '%s %s Pre-Order Release Payment Approved: %s ending in %s (expires %s)', 'Supports direct payment method pre-orders', $this->text_domain ),
-						$this->get_method_title(),
-						$this->perform_credit_card_authorization() ? 'Authorization' : 'Charge',
-						SV_WC_Payment_Gateway_Helper::payment_type_to_name( ( ! empty( $order->payment->card_type ) ? $order->payment->card_type : 'card' ) ),
-						$last_four,
-						$order->payment->exp_month . '/' . substr( $order->payment->exp_year, -2 )
-					);
-
-				} elseif ( $this->is_echeck_gateway() ) {
-
-					// account type (checking/savings) may or may not be available, which is fine
-					$message = sprintf( _x( '%s eCheck Pre-Order Release Payment Approved: %s ending in %s', 'Supports direct payment method pre-orders', $this->text_domain ), $this->get_method_title(), SV_WC_Payment_Gateway_Helper::payment_type_to_name( ( ! empty( $order->payment->account_type ) ? $order->payment->account_type : 'bank' ) ), $last_four );
-
-				}
-
-				// adds the transaction id (if any) to the order note
-				if ( $response->get_transaction_id() ) {
-					$message .= ' ' . sprintf( _x( '(Transaction ID %s)', 'Supports direct payment method pre-orders', $this->text_domain ), $response->get_transaction_id() );
-				}
-
-				$order->add_order_note( $message );
-			}
-
-			if ( $response->transaction_approved() || $response->transaction_held() ) {
-
-				// add the standard transaction data
-				$this->add_transaction_data( $order, $response );
-
-				// allow the concrete class to add any gateway-specific transaction data to the order
-				$this->add_payment_gateway_transaction_data( $order, $response );
-
-				// if the transaction was held (ie fraud validation failure) mark it as such
-				if ( $response->transaction_held() || ( $this->supports( self::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->perform_credit_card_authorization() ) ) {
-
-					$this->mark_order_as_held( $order, $this->supports( self::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->perform_credit_card_authorization() ? _x( 'Authorization only transaction', 'Supports direct payment method pre-orders', $this->text_domain ) : $response->get_status_message(), $response );
-					$order->reduce_order_stock(); // reduce stock for held orders, but don't complete payment
-
-				} else {
-					// otherwise complete the order
-					$order->payment_complete();
-				}
-
-			} else {
-
-				// failure
-				throw new SV_WC_Payment_Gateway_Exception( sprintf( '%s: %s', $response->get_status_code(), $response->get_status_message() ) );
-
-			}
-
-		} catch ( SV_WC_Plugin_Exception $e ) {
-
-			// Mark order as failed
-			$this->mark_order_as_failed( $order, sprintf( _x( 'Pre-Order Release Payment Failed: %s', 'Supports direct payment method pre-orders', $this->text_domain ), $e->getMessage() ) );
-
-		}
-	}
-
-
-	/** Tokenization feature ******************************************************/
+	/** Tokenization feature **************************************************/
 
 
 	/**
@@ -1642,7 +1111,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * @return WC_Order the order object
 	 * @throws SV_WC_Payment_Gateway_Exception on network error or request error
 	 */
-	protected function create_payment_token( $order, $response = null, $environment_id = null ) {
+	public function create_payment_token( $order, $response = null, $environment_id = null ) {
 
 		assert( $this->supports_tokenization() );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -938,7 +938,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	/**
 	 * Initialize supported integrations
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 */
 	public function init_integrations() {
 
@@ -957,7 +957,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	/**
 	 * Return an array of available integration objects
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return array
 	 */
 	public function get_integrations() {
@@ -969,7 +969,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	/**
 	 * Get the integration object for the given ID
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param string $id the integration ID, e.g. subscriptions
 	 * @return \SV_WC_Payment_Gateway_Integration|null
 	 */
@@ -984,7 +984,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * Concrete classes can override this method to return a custom
 	 * implementation.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return \SV_WC_Payment_Gateway_Integration_Subscriptions
 	 */
 	protected function build_subscriptions_integration() {
@@ -996,7 +996,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	/**
 	 * Get the Subscriptions integration class instance
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return \SV_WC_Payment_Gateway_Integration_Subscriptions|null
 	 */
 	public function get_subscriptions_integration() {
@@ -1010,7 +1010,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * Concrete classes can override this method to return a custom
 	 * implementation.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return \SV_WC_Payment_Gateway_Integration_Pre_Orders
 	 */
 	protected function build_pre_orders_integration() {
@@ -1022,7 +1022,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	/**
 	 * Get the Pre-Orders integration class instance
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return \SV_WC_Payment_Gateway_Integration_Pre_Orders|null
 	 */
 	public function get_pre_orders_integration() {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -493,7 +493,7 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * @param WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response|null $response optional transaction response
 	 */
-	protected function add_transaction_data( $order, $response = null ) {
+	public function add_transaction_data( $order, $response = null ) {
 
 		// add parent transaction data
 		parent::add_transaction_data( $order, $response );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -147,6 +147,13 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 				add_action( 'admin_footer-edit.php', array( $this, 'maybe_add_capture_charge_bulk_order_action' ) );
 				add_action( 'load-edit.php',         array( $this, 'process_capture_charge_bulk_order_action' ) );
 			}
+
+			if ( $this->is_subscriptions_active() ) {
+
+				// filter the payment gateway table on the checkout settings screen to indicate if a gateway can support Subscriptions but requires tokenization to be enabled
+				add_action( 'admin_print_styles-woocommerce_page_wc-settings', array( $this, 'subscriptions_add_renewal_support_status_inline_style' ) );
+				add_filter( 'woocommerce_payment_gateways_renewal_support_status_html', array( $this, 'subscriptions_maybe_edit_renewal_support_status' ), 10, 2 );
+			}
 		}
 
 		// Add classes to WC Payment Methods
@@ -214,8 +221,21 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		require_once( $payment_gateway_framework_path . '/api/class-sv-wc-payment-gateway-api-response-message-helper.php' );
 		require_once( $payment_gateway_framework_path . '/class-sv-wc-payment-gateway-helper.php' );
 
+		// integrations
+		require_once( $payment_gateway_framework_path . '/integrations/abstract-sv-wc-payment-gateway-integration.php' );
+
+		// subscriptions
+		if ( $this->is_subscriptions_active() ) {
+			require_once( $payment_gateway_framework_path . '/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php' );
+		}
+
+		// pre-orders
+		if ( $this->is_pre_orders_active() ) {
+			require_once( $payment_gateway_framework_path . '/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php' );
+		}
+
+		// admin user edit handler
 		if ( is_admin() ) {
-			// load admin notice handler
 			require_once( $payment_gateway_framework_path . '/admin/class-sv-wc-payment-gateway-admin-user-edit-handler.php' );
 			$this->get_admin_user_edit_handler();
 		}
@@ -244,6 +264,36 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 
 	/** Admin methods ******************************************************/
+
+
+	/**
+	 * Return the plugin action links.  This will only be called if the plugin
+	 * is active.
+	 *
+	 * @since 1.0.0
+	 * @see SV_WC_Plugin::plugin_action_links()
+	 * @param array $actions associative array of action names to anchor tags
+	 * @return array associative array of plugin action links
+	 */
+	public function plugin_action_links( $actions ) {
+
+		$actions = parent::plugin_action_links( $actions );
+
+		// remove the configure plugin link if it exists, since we'll be adding a link per available gateway
+		if ( isset( $actions['configure'] ) ) {
+			unset( $actions['configure'] );
+		}
+
+		// a configure link per gateway
+		$custom_actions = array();
+
+		foreach ( $this->get_gateway_ids() as $gateway_id ) {
+			$custom_actions[ 'configure_' . $gateway_id ] = $this->get_settings_link( $gateway_id );
+		}
+
+		// add the links to the front of the actions list
+		return array_merge( $custom_actions, $actions );
+	}
 
 
 	/**
@@ -384,6 +434,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	}
 
 
+	/** Integration methods ***************************************************/
+
+
 	/**
 	 * Checks if a supported integration is activated (Subscriptions or Pre-Orders)
 	 * and adds a notice if a gateway supports the integration *and* tokenization,
@@ -401,18 +454,17 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 				$tokenization_supported_but_not_enabled = $gateway->supports_tokenization() && ! $gateway->tokenization_enabled();
 
 				// subscriptions
-				if ( $this->is_subscriptions_active() && $gateway->is_enabled() && $gateway->supports( SV_WC_Payment_Gateway_Direct::FEATURE_SUBSCRIPTIONS ) && $tokenization_supported_but_not_enabled ) {
+				if ( $this->is_subscriptions_active() && $gateway->is_enabled() && $tokenization_supported_but_not_enabled ) {
 
 					$message = sprintf( __( '%1$s is inactive for subscription transactions. Please <a href="%2$s">enable tokenization</a> to activate %1$s for Subscriptions.', $this->get_text_domain() ),
 						$gateway->get_method_title(), $this->get_payment_gateway_configuration_url( get_class( $gateway ) ) );
 
 					// add notice -- allow it to be dismissed even on the settings page as the admin may not want to use subscriptions with a particular gateway
 					$this->get_admin_notice_handler()->add_admin_notice( $message, 'subscriptions-tokenization-' . $gateway->get_id(), array( 'always_show_on_settings' => false ) );
-
 				}
 
 				// pre-orders
-				if ( $this->is_pre_orders_active() && $gateway->is_enabled() && $gateway->supports( SV_WC_Payment_Gateway_Direct::FEATURE_PRE_ORDERS ) && $tokenization_supported_but_not_enabled ) {
+				if ( $this->is_pre_orders_active() && $gateway->is_enabled() && $tokenization_supported_but_not_enabled ) {
 
 					$message = sprintf( __( '%1$s is inactive for pre-order transactions. Please <a href="%2$s">enable tokenization</a> to activate %1$s for Pre-Orders.', $this->get_text_domain() ),
 						$gateway->get_method_title(), $this->get_payment_gateway_configuration_url( get_class( $gateway ) ) );
@@ -426,32 +478,45 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 
 	/**
-	 * Return the plugin action links.  This will only be called if the plugin
-	 * is active.
+	 * Edit the Subscriptions automatic renewal payments support column content
+	 * when a gateway supports subscriptions (via tokenization) but tokenization
+	 * is not enabled
 	 *
-	 * @since 1.0.0
-	 * @see SV_WC_Plugin::plugin_action_links()
-	 * @param array $actions associative array of action names to anchor tags
-	 * @return array associative array of plugin action links
+	 * @since 4.0.1-2
+	 * @param string $html column content
+	 * @param \WC_Payment_Gateway|\SV_WC_Payment_Gateway $gateway payment gateway being checked for support
+	 * @return string html
 	 */
-	public function plugin_action_links( $actions ) {
+	public function subscriptions_maybe_edit_renewal_support_status( $html, $gateway ) {
 
-		$actions = parent::plugin_action_links( $actions );
-
-		// remove the configure plugin link if it exists, since we'll be adding a link per available gateway
-		if ( isset( $actions['configure'] ) ) {
-			unset( $actions['configure'] );
+		// only for our gateways
+		if ( ! in_array( $gateway->id, $this->get_gateway_ids() ) ) {
+			return $html;
 		}
 
-		// a configure link per gateway
-		$custom_actions = array();
+		if ( $gateway->is_enabled() && $gateway->supports_tokenization() && ! $gateway->tokenization_enabled() ) {
 
-		foreach ( $this->get_gateway_ids() as $gateway_id ) {
-			$custom_actions[ 'configure_' . $gateway_id ] = $this->get_settings_link( $gateway_id );
+			$tool_tip = esc_attr__( 'You must enable tokenization for this gateway in order to support automatic renewal payments with the WooCommerce Subscriptions extension.', $this->get_text_domain() );
+			$status   = esc_html__( 'Inactive', $this->get_text_domain() );
+
+			$html = sprintf( '<a href="%1$s"><span class="sv-wc-payment-gateway-renewal-status-inactive tips" data-tip="%2$s">%3$s</span></a>',
+						esc_url( SV_WC_Payment_Gateway_Helper::get_payment_gateway_configuration_url( $this->get_gateway_class_name( $gateway->get_id() ) ) ),
+						$tool_tip, $status );
 		}
 
-		// add the links to the front of the actions list
-		return array_merge( $custom_actions, $actions );
+		return $html;
+	}
+
+
+	/**
+	 * Add some inline CSS to render the failed order status icon for the
+	 * automatic renewal payment support status column
+	 *
+	 * @since 4.0.1-2
+	 */
+	public function subscriptions_add_renewal_support_status_inline_style() {
+
+		wp_add_inline_style( 'woocommerce_admin_styles', '.sv-wc-payment-gateway-renewal-status-inactive{font-size:1.4em;display:block;text-indent:-9999px;position:relative;height:1em;width:1em;cursor:pointer}.sv-wc-payment-gateway-renewal-status-inactive:before{line-height:1;margin:0;position:absolute;width:100%;height:100%;content:"\e016";color:#ffba00;font-family:WooCommerce;speak:none;font-weight:400;font-variant:normal;text-transform:none;-webkit-font-smoothing:antialiased;text-indent:0;top:0;left:0;text-align:center}' );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -482,7 +482,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 * when a gateway supports subscriptions (via tokenization) but tokenization
 	 * is not enabled
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param string $html column content
 	 * @param \WC_Payment_Gateway|\SV_WC_Payment_Gateway $gateway payment gateway being checked for support
 	 * @return string html
@@ -512,7 +512,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 * Add some inline CSS to render the failed order status icon for the
 	 * automatic renewal payment support status column
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 */
 	public function subscriptions_add_renewal_support_status_inline_style() {
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -2754,7 +2754,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	/**
 	 * Remove support for the named feature or features
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param string|array $feature feature name or names not supported by this gateway
 	 */
 	public function remove_support( $feature ) {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -2752,6 +2752,27 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 
 
 	/**
+	 * Remove support for the named feature or features
+	 *
+	 * @since 4.0.1-2
+	 * @param string|array $feature feature name or names not supported by this gateway
+	 */
+	public function remove_support( $feature ) {
+
+		if ( ! is_array( $feature ) ) {
+			$feature = array( $feature );
+		}
+
+		foreach ( $feature as $name ) {
+
+			unset( $this->supports[ array_search( $name, $this->supports ) ] );
+
+			do_action( 'wc_payment_gateway_' . $this->get_id() . '_removed_support_' . str_replace( '-', '_', $name ), $this, $name );
+		}
+	}
+
+
+	/**
 	 * Set all features supported
 	 *
 	 * @since 1.0.0

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1184,7 +1184,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 		// payment type (credit_card/check/etc)
 		$order->payment->type = str_replace( '-', '_', $this->get_payment_type() );
 
-		$order->description = sprintf( _x( '%s - Order %s', 'Order description', $this->text_domain ), esc_html( get_bloginfo( 'name' ) ), $order->get_order_number() );
+		$order->description = sprintf( _x( '%s - Order %s', 'Order description', $this->text_domain ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
 
 		$order = $this->get_order_with_unique_transaction_ref( $order );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1164,7 +1164,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param int|\WC_Order $order the order or order ID being processed
 	 * @return \WC_Order object with payment and transaction information attached
 	 */
-	protected function get_order( $order ) {
+	public function get_order( $order ) {
 
 		if ( is_numeric( $order ) ) {
 			$order = wc_get_order( $order );
@@ -1418,7 +1418,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @since 3.1.0
 	 * @param WC_Order $order order object
 	 */
-	protected function mark_order_as_refunded( $order ) {
+	public function mark_order_as_refunded( $order ) {
 
 		$order_note = sprintf( _x( '%s Order completely refunded.', 'Refunded order note', $this->text_domain ), $this->get_method_title() );
 
@@ -1580,7 +1580,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @since 3.1.0
 	 * @param WC_Order $order order object
 	 */
-	protected function mark_order_as_voided( $order, $response ) {
+	public function mark_order_as_voided( $order, $response ) {
 
 		$message = sprintf(
 			_x( '%s Void in the amount of %s approved.', 'Supports voids', $this->text_domain ),
@@ -1735,7 +1735,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response|null $response optional transaction response
 	 */
-	protected function add_transaction_data( $order, $response = null ) {
+	public function add_transaction_data( $order, $response = null ) {
 
 		// transaction id if available
 		if ( $response && $response->get_transaction_id() ) {
@@ -1757,6 +1757,8 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 		if ( $this->supports_customer_id() ) {
 			$this->add_customer_data( $order, $response );
 		}
+
+		do_action( 'wc_payment_gateway_' . $this->get_id() . '_add_transaction_data', $order, $response, $this );
 	}
 
 
@@ -1767,7 +1769,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Customer_Response $response the transaction response
 	 */
-	protected function add_payment_gateway_transaction_data( $order, $response ) {
+	public function add_payment_gateway_transaction_data( $order, $response ) {
 		// Optional method
 	}
 
@@ -1814,7 +1816,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param string $message a message to display within the order note
 	 * @param SV_WC_Payment_Gateway_API_Response optional $response the transaction response object
 	 */
-	protected function mark_order_as_held( $order, $message, $response = null ) {
+	public function mark_order_as_held( $order, $message, $response = null ) {
 
 		$order_note = sprintf( __( '%s Transaction Held for Review (%s)', $this->text_domain ), $this->get_method_title(), $message );
 
@@ -1888,7 +1890,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param string $error_message a message to display inside the "Payment Failed" order note
 	 * @param SV_WC_Payment_Gateway_API_Response optional $response the transaction response object
 	 */
-	protected function mark_order_as_failed( $order, $error_message, $response = null ) {
+	public function mark_order_as_failed( $order, $error_message, $response = null ) {
 
 		$order_note = sprintf( _x( '%s Payment Failed (%s)', 'Order Note: (Payment method) Payment failed (error)', $this->text_domain ), $this->get_method_title(), $error_message );
 
@@ -1921,7 +1923,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param string $error_message a message to display inside the "Payment Cancelled" order note
 	 * @param SV_WC_Payment_Gateway_API_Response optional $response the transaction response object
 	 */
-	protected function mark_order_as_cancelled( $order, $message, $response = null ) {
+	public function mark_order_as_cancelled( $order, $message, $response = null ) {
 
 		$order_note = sprintf( _x( '%s Transaction Cancelled (%s)', 'Cancelled order note', $this->text_domain ), $this->get_method_title(), $message );
 
@@ -2562,7 +2564,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param bool $unique
 	 * @return bool|int
 	 */
-	protected function add_order_meta( $order_id, $key, $value, $unique = false ) {
+	public function add_order_meta( $order_id, $key, $value, $unique = false ) {
 
 		return add_post_meta( $order_id, $this->get_order_meta_prefix() . $key, $value, $unique );
 	}
@@ -2578,7 +2580,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param string $key meta key
 	 * @return mixed
 	 */
-	protected function get_order_meta( $order_id, $key ) {
+	public function get_order_meta( $order_id, $key ) {
 
 		return get_post_meta( $order_id, $this->get_order_meta_prefix() . $key, true );
 	}
@@ -2593,7 +2595,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param mixed $value meta value
 	 * @return bool|int
 	 */
-	protected function update_order_meta( $order_id, $key, $value ) {
+	public function update_order_meta( $order_id, $key, $value ) {
 
 		return update_post_meta( $order_id, $this->get_order_meta_prefix() . $key, $value );
 	}
@@ -2607,7 +2609,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @param string $key meta key
 	 * @return bool
 	 */
-	protected function delete_order_meta( $order_id, $key ) {
+	public function delete_order_meta( $order_id, $key ) {
 		return delete_post_meta( $order_id, $this->get_order_meta_prefix() . $key );
 	}
 
@@ -2620,7 +2622,7 @@ abstract class SV_WC_Payment_Gateway extends WC_Payment_Gateway {
 	 * @since 2.2.0
 	 * @return string
 	 */
-	protected function get_order_meta_prefix() {
+	public function get_order_meta_prefix() {
 		return '_wc_' . $this->get_id() . '_';
 	}
 

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'SV_WC_Payment_Gateway_Integration' ) ) :
 /**
  * Abstract Integration
  *
- * @since 4.0.1-2
+ * @since 4.1.0
  */
 abstract class SV_WC_Payment_Gateway_Integration {
 
@@ -41,7 +41,7 @@ abstract class SV_WC_Payment_Gateway_Integration {
 	/**
 	 * Boostrap class
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param \SV_WC_Payment_Gateway_Direct $gateway direct gateway instance
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Direct $gateway ) {
@@ -53,7 +53,7 @@ abstract class SV_WC_Payment_Gateway_Integration {
 	/**
 	 * Return the gateway for the integration
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return \SV_WC_Payment_Gateway_Direct
 	 */
 	public function get_gateway() {

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2015, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Integration' ) ) :
+
+/**
+ * Abstract Integration
+ *
+ * @since 4.0.1-2
+ */
+abstract class SV_WC_Payment_Gateway_Integration {
+
+
+	/** @var \SV_WC_Payment_Gateway_Direct direct gateway instance */
+	protected $gateway;
+
+
+	/**
+	 * Boostrap class
+	 *
+	 * @since 4.0.1-2
+	 * @param \SV_WC_Payment_Gateway_Direct $gateway direct gateway instance
+	 */
+	public function __construct( SV_WC_Payment_Gateway_Direct $gateway ) {
+
+		$this->gateway = $gateway;
+	}
+
+
+	/**
+	 * Return the gateway for the integration
+	 *
+	 * @since 4.0.1-2
+	 * @return \SV_WC_Payment_Gateway_Direct
+	 */
+	public function get_gateway() {
+
+		return $this->gateway;
+	}
+
+
+}
+
+
+endif;  // class exists check

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2015, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
+
+/**
+ * Pre-Orders Integration
+ *
+ * @since 4.0.1-2
+ */
+class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway_Integration {
+
+
+	/**
+	 * Bootstrap class
+	 *
+	 * @since 4.0.1-2
+	 * @param \SV_WC_Payment_Gateway_Direct $gateway
+	 */
+	public function __construct( SV_WC_Payment_Gateway_Direct $gateway ) {
+
+		parent::__construct( $gateway );
+
+		// add hooks
+		$this->add_support();
+	}
+
+
+	/**
+	 * Adds support for pre-orders by hooking in some necessary actions
+	 *
+	 * @since 1.0.0
+	 */
+	public function add_support() {
+
+		$this->get_gateway()->add_support( array( 'pre-orders' ) );
+
+		// force tokenization when needed
+		add_filter( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_tokenization_forced', array( $this, 'maybe_force_tokenization' ) );
+
+		// add pre-orders data to the order object
+		add_filter( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_get_order', array( $this, 'get_order' ) );
+
+		// process pre-order initial payment as needed
+		add_filter( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_process_payment', array( $this, 'process_payment' ), 10, 2 );
+
+		// process batch pre-order payments
+		add_action( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->get_gateway()->get_id(), array( $this, 'process_release_payment' ) );
+	}
+
+
+	/**
+	 * Force tokenization for pre-orders
+	 *
+	 * @since 1.0.0
+	 * @see SV_WC_Payment_Gateway::tokenization_forced()
+	 * @param boolean $force_tokenization whether tokenization should be forced
+	 * @return boolean true if tokenization should be forced, false otherwise
+	 */
+	public function maybe_force_tokenization( $force_tokenization ) {
+
+		// pay page with pre-order?
+		$pay_page_pre_order = false;
+		if ( $this->get_gateway()->is_pay_page_gateway() ) {
+
+			$order_id  = $this->get_gateway()->get_checkout_pay_page_order_id();
+
+			if ( $order_id ) {
+				$pay_page_pre_order = WC_Pre_Orders_Order::order_contains_pre_order( $order_id ) && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Order::get_pre_order_product( $order_id ) );
+			}
+		}
+
+		if ( ( WC_Pre_Orders_Cart::cart_contains_pre_order() && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() ) ) ||
+			 $pay_page_pre_order ) {
+
+			// always tokenize the card for pre-orders that are charged upon release
+			$force_tokenization = true;
+		}
+
+		return $force_tokenization;
+	}
+
+
+	/**
+	 * Adds pre-orders data to the order object.  Filtered onto SV_WC_Payment_Gateway::get_order()
+	 *
+	 * @since 1.0.0
+	 * @see SV_WC_Payment_Gateway::get_order()
+	 * @param WC_Order $order the order
+	 * @return WC_Order the orders
+	 */
+	public function get_order( $order ) {
+
+		// bail if order doesn't contain a pre-order
+		if ( ! WC_Pre_Orders_Order::order_contains_pre_order( $order ) ) {
+			return $order;
+		}
+
+		if ( WC_Pre_Orders_Order::order_requires_payment_tokenization( $order ) ) {
+
+			// normally a guest user wouldn't be assigned a customer id, but for a pre-order requiring tokenization, it might be
+			if ( 0 == $order->get_user_id() && false !== ( $customer_id = $this->get_gateway()->get_guest_customer_id( $order ) ) )
+				$order->customer_id = $customer_id;
+
+		} elseif ( WC_Pre_Orders_Order::order_has_payment_token( $order ) ) {
+
+			// if this is a pre-order release payment with a tokenized payment method, get the payment token to complete the order
+
+			// retrieve the payment token
+			$order->payment->token = $this->get_gateway()->get_order_meta( $order->id, 'payment_token' );
+
+			// retrieve the optional customer id
+			$order->customer_id = $this->get_gateway()->get_order_meta( $order->id, 'customer_id' );
+
+			// verify that this customer still has the token tied to this order.
+			if ( ! $this->get_gateway()->has_payment_token( $order->get_user_id(), $order->payment->token ) ) {
+
+				$order->payment->token = null;
+
+			} else {
+				// Push expected payment data into the order, from the payment token when possible,
+				//  or from the order object otherwise.  The theory is that the token will have the
+				//  most up-to-date data, while the meta attached to the order is a second best
+
+				// for a guest transaction with a gateway that doesn't support "tokenization get" this will return null and the token data will be pulled from the order meta
+				$token = $this->get_gateway()->get_payment_token( $order->get_user_id(), $order->payment->token );
+
+				// account last four
+				$order->payment->account_number = $token && $token->get_last_four() ? $token->get_last_four() : $this->get_gateway()->get_order_meta( $order->id, 'account_four' );
+
+				if ( $this->get_gateway()->is_credit_card_gateway() ) {
+
+					$order->payment->card_type = $token && $token->get_card_type() ? $token->get_card_type() : $this->get_gateway()->get_order_meta( $order->id, 'card_type' );
+
+					if ( $token && $token->get_exp_month() && $token->get_exp_year() ) {
+						$order->payment->exp_month  = $token->get_exp_month();
+						$order->payment->exp_year   = $token->get_exp_year();
+					} else {
+						list( $exp_year, $exp_month ) = explode( '-', $this->get_gateway()->get_order_meta( $order->id, 'card_expiry_date' ) );
+						$order->payment->exp_month  = $exp_month;
+						$order->payment->exp_year   = $exp_year;
+					}
+
+				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
+
+					// set the account type if available (checking/savings)
+					$order->payment->account_type = $token && $token->get_account_type ? $token->get_account_type() : $this->get_gateway()->get_order_meta( $order->id, 'account_type' );
+				}
+			}
+		}
+
+		return $order;
+	}
+
+
+	/**
+	 * Handle the pre-order initial payment/tokenization, or defer back to the normal payment
+	 * processing flow
+	 *
+	 * @since 1.0.0
+	 * @see SV_WC_Payment_Gateway::process_payment()
+	 * @param boolean $result the result of this pre-order payment process
+	 * @param int $order_id the order identifier
+	 * @return true|array true to process this payment as a regular transaction, otherwise
+	 *         return an array containing keys 'result' and 'redirect'
+	 */
+	public function process_payment( $result, $order_id ) {
+
+		if ( WC_Pre_Orders_Order::order_contains_pre_order( $order_id ) &&
+			 WC_Pre_Orders_Order::order_requires_payment_tokenization( $order_id ) ) {
+
+			$order = $this->get_gateway()->get_order( $order_id );
+
+			try {
+
+				// using an existing tokenized payment method
+				if ( isset( $order->payment->token ) && $order->payment->token ) {
+
+					// save the tokenized card info for completing the pre-order in the future
+					$this->get_gateway()->add_transaction_data( $order );
+
+				} else {
+
+					// otherwise tokenize the payment method
+					$order = $this->get_gateway()->create_payment_token( $order );
+				}
+
+				// mark order as pre-ordered / reduce order stock
+				WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );
+
+				// empty cart
+				WC()->cart->empty_cart();
+
+				// redirect to thank you page
+				return array(
+					'result'   => 'success',
+					'redirect' => $this->get_gateway()->get_return_url( $order ),
+				);
+
+			} catch( SV_WC_Payment_Gateway_Exception $e ) {
+
+				$this->get_gateway()->mark_order_as_failed( $order, sprintf( _x( 'Pre-Order Tokenization attempt failed (%s)', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ), $this->get_gateway()->get_method_title(), $e->getMessage() ) );
+			}
+		}
+
+		// processing regular product
+		return $result;
+	}
+
+
+	/**
+	 * Process a pre-order payment when the pre-order is released
+	 *
+	 * @since 1.0.0
+	 * @param \WC_Order $order original order containing the pre-order
+	 */
+	public function process_release_payment( $order ) {
+
+		try {
+
+			// set order defaults
+			$order = $this->get_gateway()->get_order( $order->id );
+
+			// order description
+			$order->description = sprintf( _x( '%s - Pre-Order Release Payment for Order %s', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ), esc_html( get_bloginfo( 'name' ) ), $order->get_order_number() );
+
+			// token is required
+			if ( ! $order->payment->token ) {
+				throw new SV_WC_Payment_Gateway_Exception( _x( 'Payment token missing/invalid.', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ) );
+			}
+
+			// perform the transaction
+			if ( $this->get_gateway()->is_credit_card_gateway() ) {
+
+				if ( $this->get_gateway()->perform_credit_card_charge() ) {
+					$response = $this->get_gateway()->get_api()->credit_card_charge( $order );
+				} else {
+					$response = $this->get_gateway()->get_api()->credit_card_authorization( $order );
+				}
+
+			} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
+				$response = $this->get_gateway()->get_api()->check_debit( $order );
+			}
+
+			// success! update order record
+			if ( $response->transaction_approved() ) {
+
+				$last_four = substr( $order->payment->account_number, -4 );
+
+				// order note based on gateway type
+				if ( $this->get_gateway()->is_credit_card_gateway() ) {
+
+					$message = sprintf(
+						_x( '%s %s Pre-Order Release Payment Approved: %s ending in %s (expires %s)', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ),
+						$this->get_gateway()->get_method_title(),
+						$this->get_gateway()->perform_credit_card_authorization() ? 'Authorization' : 'Charge',
+						SV_WC_Payment_Gateway_Helper::payment_type_to_name( ( ! empty( $order->payment->card_type ) ? $order->payment->card_type : 'card' ) ),
+						$last_four,
+						$order->payment->exp_month . '/' . substr( $order->payment->exp_year, -2 )
+					);
+
+				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
+
+					// account type (checking/savings) may or may not be available, which is fine
+					$message = sprintf( _x( '%s eCheck Pre-Order Release Payment Approved: %s ending in %s', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ), $this->get_gateway()->get_method_title(), SV_WC_Payment_Gateway_Helper::payment_type_to_name( ( ! empty( $order->payment->account_type ) ? $order->payment->account_type : 'bank' ) ), $last_four );
+
+				}
+
+				// adds the transaction id (if any) to the order note
+				if ( $response->get_transaction_id() ) {
+					$message .= ' ' . sprintf( _x( '(Transaction ID %s)', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ), $response->get_transaction_id() );
+				}
+
+				$order->add_order_note( $message );
+			}
+
+			if ( $response->transaction_approved() || $response->transaction_held() ) {
+
+				// add the standard transaction data
+				$this->get_gateway()->add_transaction_data( $order, $response );
+
+				// allow the concrete class to add any gateway-specific transaction data to the order
+				$this->get_gateway()->add_payment_gateway_transaction_data( $order, $response );
+
+				// if the transaction was held (ie fraud validation failure) mark it as such
+				if ( $response->transaction_held() || ( $this->get_gateway()->supports( SV_WC_Payment_Gateway::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->get_gateway()->perform_credit_card_authorization() ) ) {
+
+					$this->get_gateway()->mark_order_as_held( $order, $this->get_gateway()->supports( SV_WC_Payment_Gateway::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->get_gateway()->perform_credit_card_authorization() ? _x( 'Authorization only transaction', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ) : $response->get_status_message(), $response );
+					$order->reduce_order_stock(); // reduce stock for held orders, but don't complete payment
+
+				} else {
+					// otherwise complete the order
+					$order->payment_complete();
+				}
+
+			} else {
+
+				// failure
+				throw new SV_WC_Payment_Gateway_Exception( sprintf( '%s: %s', $response->get_status_code(), $response->get_status_message() ) );
+
+			}
+
+		} catch ( SV_WC_Plugin_Exception $e ) {
+
+			// Mark order as failed
+			$this->get_gateway()->mark_order_as_failed( $order, sprintf( _x( 'Pre-Order Release Payment Failed: %s', 'Supports direct payment method pre-orders', $this->get_gateway()->get_text_domain() ), $e->getMessage() ) );
+
+		}
+	}
+}
+
+
+endif;  // class exists check

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -52,7 +52,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Adds support for pre-orders by hooking in some necessary actions
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 */
 	public function add_support() {
 
@@ -75,7 +75,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Force tokenization for pre-orders
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @see SV_WC_Payment_Gateway::tokenization_forced()
 	 * @param boolean $force_tokenization whether tokenization should be forced
 	 * @return boolean true if tokenization should be forced, false otherwise
@@ -107,7 +107,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Adds pre-orders data to the order object.  Filtered onto SV_WC_Payment_Gateway::get_order()
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @see SV_WC_Payment_Gateway::get_order()
 	 * @param WC_Order $order the order
 	 * @return WC_Order the orders
@@ -180,7 +180,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	 * Handle the pre-order initial payment/tokenization, or defer back to the normal payment
 	 * processing flow
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @see SV_WC_Payment_Gateway::process_payment()
 	 * @param boolean $result the result of this pre-order payment process
 	 * @param int $order_id the order identifier
@@ -234,7 +234,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Process a pre-order payment when the pre-order is released
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @param \WC_Order $order original order containing the pre-order
 	 */
 	public function process_release_payment( $order ) {

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
 /**
  * Pre-Orders Integration
  *
- * @since 4.0.1-2
+ * @since 4.1.0
  */
 class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway_Integration {
 
@@ -37,7 +37,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Bootstrap class
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param \SV_WC_Payment_Gateway_Direct $gateway
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Direct $gateway ) {
@@ -52,7 +52,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Adds support for pre-orders by hooking in some necessary actions
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 */
 	public function add_support() {
 
@@ -75,7 +75,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Force tokenization for pre-orders
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::tokenization_forced()
 	 * @param boolean $force_tokenization whether tokenization should be forced
 	 * @return boolean true if tokenization should be forced, false otherwise
@@ -107,7 +107,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Adds pre-orders data to the order object.  Filtered onto SV_WC_Payment_Gateway::get_order()
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::get_order()
 	 * @param WC_Order $order the order
 	 * @return WC_Order the orders
@@ -180,7 +180,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	 * Handle the pre-order initial payment/tokenization, or defer back to the normal payment
 	 * processing flow
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::process_payment()
 	 * @param boolean $result the result of this pre-order payment process
 	 * @param int $order_id the order identifier
@@ -234,7 +234,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	/**
 	 * Process a pre-order payment when the pre-order is released
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param \WC_Order $order original order containing the pre-order
 	 */
 	public function process_release_payment( $order ) {

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -214,7 +214,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 */
 	public function get_order( $order ) {
 
-		$order->description = sprintf( esc_html__( '%1$s - Subscription Renewal Order %2$s', $this->get_gateway()->get_text_domain() ), get_bloginfo( 'name' ), $order->get_order_number() );
+		$order->description = sprintf( esc_html__( '%1$s - Subscription Renewal Order %2$s', $this->get_gateway()->get_text_domain() ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
 
 		// override the payment total with the amount to charge given by Subscriptions
 		$order->payment_total = $this->renewal_payment_total;

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -99,6 +99,11 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 			// don't copy over order-specific meta to the new WC_Subscription object during upgrade to 2.0.x
 			add_filter( 'wcs_upgrade_subscription_meta_to_copy', array( $this, 'do_not_copy_order_meta_during_upgrade' ) );
 
+			// allow concrete gateways to define additional order-specific meta keys to exclude
+			if ( is_callable( array( $this->get_gateway(), 'subscriptions_get_excluded_order_meta_keys' ) ) ) {
+				add_filter( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_subscriptions_order_specific_meta_keys', array( $this->get_gateway(), 'subscriptions_get_excluded_order_meta_keys' ) );
+			}
+
 			/* Admin Change Payment Method support */
 
 			// framework defaults - payment_token and customer_id

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -520,7 +520,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * Force tokenization for subscriptions, this can be forced either during checkout
 	 * or when the payment method for a subscription is being changed
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @see SV_WC_Payment_Gateway::tokenization_forced()
 	 * @param bool $force_tokenization whether tokenization should be forced
 	 * @return bool true if tokenization should be forced, false otherwise
@@ -552,7 +552,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Adds subscriptions data to the order object
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @see SV_WC_Payment_Gateway::get_order()
 	 * @param WC_Order $order the order
 	 * @return WC_Order the orders
@@ -618,7 +618,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Process subscription renewal
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @param float $amount_to_charge subscription amount to charge, could include multiple renewals if they've previously failed and the admin has enabled it
 	 * @param WC_Order $order original order containing the subscription
 	 * @param int $product_id the subscription product id
@@ -715,7 +715,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Don't copy over gateway-specific order meta when creating a parent renewal order.
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @see SV_WC_Payment_Gateway::get_remove_subscription_renewal_order_meta_fragment()
 	 * @param array $order_meta_query MySQL query for pulling the metadata
 	 * @param int $original_order_id Post ID of the order being used to purchased the subscription being renewed
@@ -755,7 +755,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Returns the query fragment to remove the given subscription renewal order meta
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @see SV_WC_Payment_Gateway::remove_subscription_renewal_order_meta()
 	 * @param array $meta_names array of string meta names to remove
 	 * @return string query fragment
@@ -771,7 +771,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * uses this gateway to successfully complete the payment for an automatic
 	 * renewal payment which had previously failed.
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @param WC_Order $original_order the original order in which the subscription was purchased.
 	 * @param WC_Order $renewal_order the order which recorded the successful payment (to make up for the failed automatic payment).
 	 */
@@ -788,7 +788,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Render the payment method used for a subscription in the "My Subscriptions" table
 	 *
-	 * @since 1.0.0
+	 * @since 4.0.1-2
 	 * @param string $payment_method_to_display the default payment method text to display
 	 * @param array $subscription_details the subscription details
 	 * @param WC_Order $order the order containing the subscription

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
 /**
  * Subscriptions Integration
  *
- * @since 4.0.1-2
+ * @since 4.1.0
  */
 class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gateway_Integration {
 
@@ -41,7 +41,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Bootstrap class
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param \SV_WC_Payment_Gateway_Direct $gateway
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Direct $gateway ) {
@@ -56,7 +56,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Adds support for subscriptions by hooking in some necessary actions
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 */
 	public function add_support() {
 
@@ -131,7 +131,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * Force tokenization for subscriptions, this can be forced either during checkout
 	 * or when the payment method for a subscription is being changed
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::tokenization_forced()
 	 * @param bool $force_tokenization whether tokenization should be forced
 	 * @return bool true if tokenization should be forced, false otherwise
@@ -165,7 +165,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * this is primarily used for the payment token and customer ID which are then
 	 * copied over to a renewal order prior to payment processing.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param \WC_Order $order order
 	 */
 	public function save_payment_meta( $order ) {
@@ -189,7 +189,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Process a subscription renewal payment
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param float $amount_to_charge subscription amount to charge, could include multiple renewals if they've previously failed and the admin has enabled it
 	 * @param \WC_Order $order original order containing the subscription
 	 */
@@ -222,7 +222,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * + renewal payment total
 	 * + token and associated data (last four, type, etc)
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway_Direct::get_order()
 	 * @param \WC_Order $order renewal order
 	 * @return \WC_Order renewal order with payment token data set
@@ -269,7 +269,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * copied during the upgrade (see do_not_copy_order_meta_during_upgrade()), so
 	 * this method is more of a fallback in case meta accidentially is copied.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param array $order_meta order meta to copy
 	 * @return array
 	 */
@@ -293,7 +293,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * upgrade to 2.0.x. This only allows the `payment_token` and `customer_id`
 	 * meta to be copied.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param array $order_meta order meta to copy
 	 * @return array
 	 */
@@ -316,7 +316,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * thus some order-specific meta is added that is undesirable to have copied
 	 * over to renewal orders.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param array $result process_payment() result, unused
 	 * @param \WC_Subscription $subscription subscription object
 	 * @return array
@@ -343,7 +343,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * uses this gateway to successfully complete the payment for an automatic
 	 * renewal payment which had previously failed.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param \WC_Subscription $subscription subscription being updated
 	 * @param \WC_Order $renewal_order order which recorded the successful payment (to make up for the failed automatic payment).
 	 */
@@ -361,7 +361,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * Get the order-specific meta keys that should not be copied to the WC_Subscription
 	 * object during upgrade to 2.0.x or during change payment method actions
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @return array
 	 */
 	protected function get_order_specific_meta_keys() {
@@ -394,7 +394,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		 * to the WC_Subscriptions object during renewal payments, the
 		 * change payment method action, or the upgrade to 2.0.x.
 		 *
-		 * @since 4.0.1-2
+		 * @since 4.1.0
 		 * @param array $keys meta keys, with gateway order meta prefix included
 		 * @param \SV_WC_Payment_Gateway_Integration_Subscriptions $this subscriptions integration class instance
 		 */
@@ -405,7 +405,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Render the payment method used for a subscription in the "My Subscriptions" table
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param string $payment_method_to_display the default payment method text to display
 	 * @param \WC_Subscription $subscription
 	 * @return string the subscription payment method
@@ -432,7 +432,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * payments so that store managers can manually set up automatic recurring
 	 * payments for a customer via the Edit Subscriptions screen in 2.0.x
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param array $meta associative array of meta data required for automatic payments
 	 * @param \WC_Subscription $subscription subscription object
 	 * @return array
@@ -463,7 +463,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * payments so that store managers can manually set up automatic recurring
 	 * payments for a customer via the Edit Subscriptions screen in 2.0.x
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param array $meta associative array of meta data required for automatic payments
 	 * @throws Exception if payment token or customer ID is missing or blank
 	 */
@@ -489,7 +489,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Adds support for subscriptions 1.5.x
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 */
 	public function add_support_1_5() {
 
@@ -519,7 +519,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * Force tokenization for subscriptions, this can be forced either during checkout
 	 * or when the payment method for a subscription is being changed
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::tokenization_forced()
 	 * @param bool $force_tokenization whether tokenization should be forced
 	 * @return bool true if tokenization should be forced, false otherwise
@@ -551,7 +551,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Adds subscriptions data to the order object
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::get_order()
 	 * @param WC_Order $order the order
 	 * @return WC_Order the orders
@@ -617,7 +617,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Process subscription renewal
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param float $amount_to_charge subscription amount to charge, could include multiple renewals if they've previously failed and the admin has enabled it
 	 * @param WC_Order $order original order containing the subscription
 	 * @param int $product_id the subscription product id
@@ -714,7 +714,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Don't copy over gateway-specific order meta when creating a parent renewal order.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::get_remove_subscription_renewal_order_meta_fragment()
 	 * @param array $order_meta_query MySQL query for pulling the metadata
 	 * @param int $original_order_id Post ID of the order being used to purchased the subscription being renewed
@@ -754,7 +754,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Returns the query fragment to remove the given subscription renewal order meta
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @see SV_WC_Payment_Gateway::remove_subscription_renewal_order_meta()
 	 * @param array $meta_names array of string meta names to remove
 	 * @return string query fragment
@@ -770,7 +770,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * uses this gateway to successfully complete the payment for an automatic
 	 * renewal payment which had previously failed.
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param WC_Order $original_order the original order in which the subscription was purchased.
 	 * @param WC_Order $renewal_order the order which recorded the successful payment (to make up for the failed automatic payment).
 	 */
@@ -787,7 +787,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Render the payment method used for a subscription in the "My Subscriptions" table
 	 *
-	 * @since 4.0.1-2
+	 * @since 4.1.0
 	 * @param string $payment_method_to_display the default payment method text to display
 	 * @param array $subscription_details the subscription details
 	 * @param WC_Order $order the order containing the subscription

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -477,8 +477,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 			throw new Exception( sprintf( __( '%s is required.', $this->get_gateway()->get_text_domain() ), $meta['post_meta'][ $prefix . 'payment_token' ]['label'] ) );
 		}
 
-		// customer ID
-		if ( empty( $meta['post_meta'][ $prefix . 'customer_id' ]['value'] ) ) {
+		// customer ID - optional for some gateways so check if it's set first
+		if ( isset( $meta['post_meta'][ $prefix . 'customer_id'] ) && empty( $meta['post_meta'][ $prefix . 'customer_id' ]['value'] ) ) {
 			throw new Exception( sprintf( __( '%s is required.', $this->get_gateway()->get_text_domain() ), $meta['post_meta'][ $prefix . 'customer_id' ]['label'] ) );
 		}
 	}


### PR DESCRIPTION
This adds support for Subscriptions 2.0 (and 1.5.x) and does a bit of refactoring around the Subscriptions/Pre-Orders handling to better separate them from the direct gateway class.

closes #80 and part of #86 