### PR TITLE
Fix handling for guest pre-orders

### DIFF
--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -135,39 +135,53 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 			// retrieve the optional customer id
 			$order->customer_id = $this->get_gateway()->get_order_meta( $order->id, 'customer_id' );
 
-			// verify that this customer still has the token tied to this order.
-			if ( ! $this->get_gateway()->has_payment_token( $order->get_user_id(), $order->payment->token ) ) {
+			// set token data on order
+			if ( $this->get_gateway()->has_payment_token( $order->get_user_id(), $order->payment->token ) ) {
 
-				$order->payment->token = null;
-
-			} else {
-				// Push expected payment data into the order, from the payment token when possible,
-				//  or from the order object otherwise.  The theory is that the token will have the
-				//  most up-to-date data, while the meta attached to the order is a second best
-
-				// for a guest transaction with a gateway that doesn't support "tokenization get" this will return null and the token data will be pulled from the order meta
+				// an existing registered user with a saved payment token
 				$token = $this->get_gateway()->get_payment_token( $order->get_user_id(), $order->payment->token );
 
 				// account last four
-				$order->payment->account_number = $token && $token->get_last_four() ? $token->get_last_four() : $this->get_gateway()->get_order_meta( $order->id, 'account_four' );
+				$order->payment->account_number = $token->get_last_four();
 
 				if ( $this->get_gateway()->is_credit_card_gateway() ) {
 
-					$order->payment->card_type = $token && $token->get_card_type() ? $token->get_card_type() : $this->get_gateway()->get_order_meta( $order->id, 'card_type' );
+					// card type
+					$order->payment->card_type = $token->get_card_type();
 
-					if ( $token && $token->get_exp_month() && $token->get_exp_year() ) {
-						$order->payment->exp_month  = $token->get_exp_month();
-						$order->payment->exp_year   = $token->get_exp_year();
-					} else {
-						list( $exp_year, $exp_month ) = explode( '-', $this->get_gateway()->get_order_meta( $order->id, 'card_expiry_date' ) );
+					// exp month/year
+					$order->payment->exp_month  = $token->get_exp_month();
+					$order->payment->exp_year   = $token->get_exp_year();
+
+				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
+
+					// account type (checking/savings)
+					$order->payment->account_type = $token->get_account_type();
+				}
+
+			} else {
+
+				// a guest user means that token data must be set from the original order
+
+				// account number
+				$order->payment->account_number = $this->get_gateway()->get_order_meta( $order->id, 'account_four' );
+
+				if ( $this->get_gateway()->is_credit_card_gateway() ) {
+
+					// card type
+					$order->payment->card_type = $this->get_gateway()->get_order_meta( $order->id, 'card_type' );
+
+					// expiry date
+					if ( $expiry_date = $this->get_gateway()->get_order_meta( $order->id, 'card_expiry_date' ) ) {
+						list( $exp_year, $exp_month ) = explode( '-', $expiry_date );
 						$order->payment->exp_month  = $exp_month;
 						$order->payment->exp_year   = $exp_year;
 					}
 
 				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
 
-					// set the account type if available (checking/savings)
-					$order->payment->account_type = $token && $token->get_account_type ? $token->get_account_type() : $this->get_gateway()->get_order_meta( $order->id, 'account_type' );
+					// account type
+					$order->payment->account_type = $this->get_gateway()->get_order_meta( $order->id, 'account_type' );
 				}
 			}
 		}
@@ -189,6 +203,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	 */
 	public function process_payment( $result, $order_id ) {
 
+		// processing pre-order
 		if ( WC_Pre_Orders_Order::order_contains_pre_order( $order_id ) &&
 			 WC_Pre_Orders_Order::order_requires_payment_tokenization( $order_id ) ) {
 
@@ -215,18 +230,22 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 				WC()->cart->empty_cart();
 
 				// redirect to thank you page
-				return array(
-					'result'   => 'success',
-					'redirect' => $this->get_gateway()->get_return_url( $order ),
+				$result = array(
+						'result'   => 'success',
+						'redirect' => $this->get_gateway()->get_return_url( $order ),
 				);
 
 			} catch( SV_WC_Payment_Gateway_Exception $e ) {
 
 				$this->get_gateway()->mark_order_as_failed( $order, sprintf( __( 'Pre-Order Tokenization attempt failed (%s)', 'woocommerce-plugin-framework' ), $this->get_gateway()->get_method_title(), $e->getMessage() ) );
+
+				$result = array(
+						'result'  => 'failure',
+						'message' => $e->getMessage(),
+				);
 			}
 		}
 
-		// processing regular product
 		return $result;
 	}
 
@@ -274,12 +293,12 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 				if ( $this->get_gateway()->is_credit_card_gateway() ) {
 
 					$message = sprintf(
-						__( '%s %s Pre-Order Release Payment Approved: %s ending in %s (expires %s)', 'woocommerce-plugin-framework' ),
-						$this->get_gateway()->get_method_title(),
-						$this->get_gateway()->perform_credit_card_authorization() ? 'Authorization' : 'Charge',
-						SV_WC_Payment_Gateway_Helper::payment_type_to_name( ( ! empty( $order->payment->card_type ) ? $order->payment->card_type : 'card' ) ),
-						$last_four,
-						$order->payment->exp_month . '/' . substr( $order->payment->exp_year, -2 )
+							__( '%s %s Pre-Order Release Payment Approved: %s ending in %s (expires %s)', 'woocommerce-plugin-framework' ),
+							$this->get_gateway()->get_method_title(),
+							$this->get_gateway()->perform_credit_card_authorization() ? 'Authorization' : 'Charge',
+							SV_WC_Payment_Gateway_Helper::payment_type_to_name( ( ! empty( $order->payment->card_type ) ? $order->payment->card_type : 'card' ) ),
+							$last_four,
+							( ! empty( $order->payment->exp_month) && ! empty( $order->payment->exp_year ) ? $order->payment->exp_month . '/' . substr( $order->payment->exp_year, -2 ) : 'n/a' )
 					);
 
 				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
@@ -326,7 +345,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 		} catch ( SV_WC_Plugin_Exception $e ) {
 
 			// Mark order as failed
-			$this->get_gateway()->mark_order_as_failed( $order, sprintf( __( 'Pre-Order Release Payment Failed: %s', 'woocommerce-plugin-framework' ) ), $e->getMessage() );
+			$this->get_gateway()->mark_order_as_failed( $order, sprintf( __( 'Pre-Order Release Payment Failed: %s', 'woocommerce-plugin-framework' ), $e->getMessage() ) );
 
 		}
 	}


### PR DESCRIPTION
failures that occurred during initial tokenization could result in the initial transaction being processed immediately, rather than upon release.

In addition, the pre-orders get_order() method failed to account for the situation where a guest pre-order would contain a token that didn’t exist on the gateway. Likely a legacy issue that didn’t keep pace with
development on the rest of the framework.