### PR TITLE
Object of class Requests_Utility_CaseInsensitiveDictionary could not be converted to string

### DIFF
--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -469,7 +469,9 @@ abstract class SV_WC_Plugin {
 		$messages = array();
 
 		$messages[] = isset( $data['uri'] ) && $data['uri'] ? 'Request' : 'Response';
-
+		if (is_object( $value ) && 'stdClass' != get_class( $value )) {
+                	$value = json_decode($value);
+            	}
 		foreach ( (array) $data as $key => $value ) {
 			$messages[] = sprintf( '%s: %s', $key, is_array( $value ) || ( is_object( $value ) && 'stdClass' == get_class( $value ) ) ? print_r( (array) $value, true ) : $value );
 		}

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -469,10 +469,13 @@ abstract class SV_WC_Plugin {
 		$messages = array();
 
 		$messages[] = isset( $data['uri'] ) && $data['uri'] ? 'Request' : 'Response';
-		if (is_object( $value ) && 'stdClass' != get_class( $value )) {
-                	$value = json_decode($value);
-            	}
+
 		foreach ( (array) $data as $key => $value ) {
+			
+			if (is_object( $value ) && 'stdClass' != get_class( $value )) {
+				$value = json_decode($value);
+			}
+			
 			$messages[] = sprintf( '%s: %s', $key, is_array( $value ) || ( is_object( $value ) && 'stdClass' == get_class( $value ) ) ? print_r( (array) $value, true ) : $value );
 		}
 


### PR DESCRIPTION
Fix issue related to PHP Catchable fatal error: Object of class Requests_Utility_CaseInsensitiveDictionary could not be converted to string in .../wp-content/plugins/woocommerce-gateway-authorize-net-cim/lib/skyverge/woocommerce/class-sv-wc-plugin.php on line 438