### PR TITLE
Delete token meta from admin editor regardless of API response

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2017.02.03 - version 4.5.3-dev
+ * Fix - Always delete a token from user meta when removed using the admin token editor
+
 2017.01.06 - version 4.5.2
  * Fix - Include Curaçao when converting country codes
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -34,13 +34,13 @@ if ( ! class_exists( 'SV_WC_Plugin' ) ) :
  * plugin.  This class handles all the "non-feature" support tasks such
  * as verifying dependencies are met, loading the text domain, etc.
  *
- * @version 4.5.2
+ * @version 4.5.3-dev
  */
 abstract class SV_WC_Plugin {
 
 
 	/** Plugin Framework Version */
-	const VERSION = '4.5.2';
+	const VERSION = '4.5.3-dev';
 
 	/** @var object single instance of plugin */
 	protected static $instance;

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -308,7 +308,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 	 */
 	protected function remove_token( $user_id, $token_id ) {
 
-		return $this->get_gateway()->get_payment_tokens_handler()->remove_token( $user_id, $token_id, $this->get_gateway()->get_environment() );
+		return $this->get_gateway()->get_payment_tokens_handler()->remove_token( $user_id, $token_id, $this->get_gateway()->get_environment(), true );
 	}
 
 


### PR DESCRIPTION
Previously, invalid tokens could not be removed using the admin token editor.