### PR TITLE
Add order date compatibility methods

### DIFF
--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -49,6 +49,38 @@ class SV_WC_Plugin_Compatibility {
 
 
 	/**
+	 * Formats a date for output.
+	 *
+	 * Backports WC 3.0.0's wc_format_datetime() to older versions.
+	 *
+	 * @since  4.6.0-dev
+	 *
+	 * @param \WC_DateTime|\SV_WC_DateTime $date date object
+	 * @param string $format date format
+	 * @return string
+	 */
+	public static function wc_format_datetime( $date, $format = '' ) {
+
+		if ( self::is_wc_version_gte_3_0() ) {
+
+			return wc_format_datetime( $date, $format );
+
+		} else {
+
+			if ( ! $format ) {
+				$format = wc_date_format();
+			}
+
+			if ( ! is_a( $date, 'SV_WC_DateTime' ) ) {
+				return '';
+			}
+
+			return $date->date_i18n( $format );
+		}
+	}
+
+
+	/**
 	 * Backports wc_checkout_is_https() to 2.4.x
 	 *
 	 * @since 4.3.0

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -273,6 +273,9 @@ abstract class SV_WC_Plugin {
 		require_once( $framework_path . '/compatibility/class-sv-wc-order-compatibility.php' );
 		require_once( $framework_path . '/compatibility/class-sv-wc-product-compatibility.php' );
 
+		// TODO: Remove this when WC 3.x can be required {CW 2017-03-16}
+		require_once( $framework_path . '/compatibility/class-sv-wc-datetime.php' );
+
 		// generic API base
 		require_once( $framework_path . '/api/class-sv-wc-api-exception.php' );
 		require_once( $framework_path . '/api/class-sv-wc-api-base.php' );

--- a/woocommerce/compatibility/class-sv-wc-datetime.php
+++ b/woocommerce/compatibility/class-sv-wc-datetime.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Compatibility
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2017, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_DateTime' ) ) :
+
+/**
+ * Backports the \WC_DateTime class to WooCommerce pre-3.0.0
+ *
+ * TODO: Remove this when WC 3.x can be required {CW 2017-03-16}
+ *
+ * @since 4.6.0-dev
+ */
+class SV_WC_DateTime extends DateTime {
+
+
+	/**
+	 * Outputs an ISO 8601 date string in local timezone.
+	 *
+	 * @since 4.6.0-dev
+	 * @return string
+	 */
+	public function __toString() {
+
+		return $this->format( DATE_ATOM );
+	}
+
+
+	/**
+	 * Gets the UTC timestamp.
+	 *
+	 * Missing in PHP 5.2.
+	 *
+	 * @since 4.6.0-dev
+	 * @return int
+	 */
+	public function getTimestamp() {
+
+		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
+	}
+
+
+	/**
+	 * Gets the timestamp with the WordPress timezone offset added or subtracted.
+	 *
+	 * @since 4.6.0-dev
+	 * @return int
+	 */
+	public function getOffsetTimestamp() {
+
+		return $this->getTimestamp() + $this->getOffset();
+	}
+
+
+	/**
+	 * Gets a date based on the offset timestamp.
+	 *
+	 * @since 4.6.0-dev
+	 * @param  string $format date format
+	 * @return string
+	 */
+	public function date( $format ) {
+
+		return gmdate( $format, $this->getOffsetTimestamp() );
+	}
+
+
+	/**
+	 * Gets a localised date based on offset timestamp.
+	 *
+	 * @since 4.6.0-dev
+	 * @param  string $format date format
+	 * @return string
+	 */
+	public function date_i18n( $format = 'Y-m-d' ) {
+
+		return date_i18n( $format, $this->getOffsetTimestamp() );
+	}
+
+
+}
+
+endif;


### PR DESCRIPTION
Here we have it! Date compatibility methods for handling WooCommerce 3.0+ order dates.

### New methods:
- `SV_WC_Order_Compatibility::get_date_created( $order, $context = 'edit' );`
- `SV_WC_Order_Compatibility::get_date_modified( $order, $context = 'edit' );`
- `SV_WC_Order_Compatibility::get_date_paid( $order, $context = 'edit' );`
- `SV_WC_Order_Compatibility::get_date_completed( $order, $context = 'edit' );`

## Expected behavior

In all support WC versions, these `SV_WC_Order_Compatibility::get_date_*()` methods will return a `DateTime` object that you can use to manipulate the date format/output. For WC 3.0+, this object will be `WC_DateTime`. For WC 2.5.5 & 2.6.x, this adds the `SV_WC_DateTime` which mimics the latter so we can stick with a single implementation without version checks in the plugin.

## Implementation

As with our other 3.0 compatibility methods, these default to the `edit` context to avoid filters since previous uses of `$order->order_date`, etc... were similarly unfiltered. Be sure to look at the context of where you're using these. If it's decided that filtering is beneficial, you can set the `$context` param to `view`.

Here are a few ways to handle order dates using these methods.

```php
$order = wc_get_order( 123 );

// ISO 8601 date string
echo SV_WC_Order_Compatibility::get_date_created( $order );

// UTC timestamp
echo SV_WC_Order_Compatibility::get_date_created( $order )->getTimestamp();

// Timestamp offset to the shop timezone
echo SV_WC_Order_Compatibility::get_date_created( $order )->getOffsetTimestamp();

// Formatted date string, offset to the shop timezone
echo SV_WC_Order_Compatibility::get_date_created( $order )->date( 'Y-m-d' );

// Localized date string, offset to the shop timezone
echo SV_WC_Order_Compatibility::get_date_created( $order )->date_i18n( 'Y-m-d' );

// Any other format - http://php.net/manual/en/function.date.php
echo SV_WC_Order_Compatibility::get_date_created( $order )->format( 'c' );

// Order not completed? null - non-existent date
echo SV_WC_Order_Compatibility::get_date_completed( $order );
```

Also added is a helper method that makes it quicker to get a date string in the default WC format:
`SV_WC_Plugin_Compatibility::wc_format_datetime( $date );`

As we implement this in plugins we'll need to make sure and test across WC versions and not just in WC 3.0-RC.

### Question

Is the naming of the `SV_WC_DateTime` class too wonky? Shouldn't need to check for `WC_DateTime` specifically in plugins so I went with the SV namespace initially just in case, though it makes the docblocks a little funky since both `SV_WC_DateTime` & `WC_DateTime` could be accepted/returned depending on the WC version.

Would love some 👀 here on the code and QA to make sure everything's covered as it should be.