### PR TITLE
POC: Transaction Objects

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -37,6 +37,24 @@ if ( ! class_exists( 'SV_WC_Payment_Gateway_Helper' ) ) :
 class SV_WC_Payment_Gateway_Helper {
 
 
+	/** Sends through sale and request for funds to be charged to cardholder's credit card. */
+	const TRANSACTION_TYPE_CHARGE = 'charge';
+
+	/** Sends through a request for funds to be "reserved" on the cardholder's credit card. A standard authorization is reserved for 2-5 days. Reservation times are determined by cardholder's bank. */
+	const TRANSACTION_TYPE_AUTHORIZATION = 'authorization';
+
+	const TRANSACTION_TYPE_CAPTURE = 'capture';
+
+	const TRANSACTION_TYPE_REFUND = 'refund';
+
+	const TRANSACTION_TYPE_VOID = 'void';
+
+	const TRANSACTION_STATUS_APPROVED = 'approved';
+
+	const TRANSACTION_STATUS_HELD = 'held';
+
+	const TRANSACTION_STATUS_FAILED = 'failed';
+
 	/** @var string the Visa card type ID **/
 	const CARD_TYPE_VISA = 'visa';
 

--- a/woocommerce/payment-gateway/transactions/abstract-sv-wc-payment-gateway-payment-transaction.php
+++ b/woocommerce/payment-gateway/transactions/abstract-sv-wc-payment-gateway-payment-transaction.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2016, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Payment_Transaction' ) ) :
+
+
+/**
+ * The base payment transaction class.
+ *
+ * @since 4.7.0-dev
+ */
+abstract class SV_WC_Payment_Gateway_Payment_Transaction extends SV_WC_Payment_Gateway_Transaction {
+
+
+	/** @var the attached payment method */
+	protected $payment_method = null;
+
+
+	/**
+	 * Gets the payment method object.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return \SV_WC_Payment_Gateway_Transaction_Payment_Method|null
+	 */
+	public function get_payment_method() {
+
+		return $this->payment_method;
+	}
+
+
+	/**
+	 * Sets the payment method object.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param \SV_WC_Payment_Gateway_Transaction_Payment_Method $payment_method payment method object
+	 */
+	public function set_payment_method( SV_WC_Payment_Gateway_Transaction_Payment_Method $payment_method ) {
+
+		$this->payment_method = $payment_method;
+
+		$this->get_payment_method()->set_transaction( $this );
+	}
+
+
+	/* CRUD methods ***********************************************************/
+
+
+	public function save() {
+
+		parent::save();
+
+		$this->get_payment_method()->save( $this->get_order_id() );
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/abstract-sv-wc-payment-gateway-transaction.php
+++ b/woocommerce/payment-gateway/transactions/abstract-sv-wc-payment-gateway-transaction.php
@@ -1,0 +1,558 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2016, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Transaction' ) ) :
+
+/**
+ * The base payment gateway transaction class.
+ *
+ * @since 4.7.0-dev
+ *
+ * @see \WC_Data
+ */
+abstract class SV_WC_Payment_Gateway_Transaction extends WC_Data {
+
+
+	/** @var string the object type, for storage */
+	protected $object_type = 'transaction'; // TODO: conflicts?
+
+	/** @var array the core properties */
+	protected $data = array(
+		'external_id'        => '',
+		'date_created'       => null,
+		'status'             => '',
+		'amount'             => '0.00',
+		'currency'           => '',
+		'authorization_code' => '',
+		'retry_count'        => 0,
+		'parent_id'          => 0,
+		'gateway_id'         => '',
+		'order_id'           => 0,
+		'customer_id'        => '',
+		'user_id'            => 0,
+		'environment'        => '',
+	);
+
+
+	/* Getter methods *********************************************************/
+
+
+	/**
+	 * Gets the external transaction ID.
+	 *
+	 * This is usually defined by the gateway, and provides a way for our own
+	 * separate database ID to be stored in the future.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_external_id( $context = 'view' ) {
+
+		return $this->get_prop( 'external_id', $context );
+	}
+
+
+	/**
+	 * Gets the date the transaction was created.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return \WC_DateTime
+	 */
+	public function get_date_created( $context = 'view' ) {
+
+		return $this->get_prop( 'date_created', $context );
+	}
+
+
+	/**
+	 * Gets the status.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_status( $context = 'view' ) {
+
+		return $this->get_prop( 'status', $context );
+	}
+
+
+	/**
+	 * Gets the amount.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_amount( $context = 'view' ) {
+
+		return $this->get_prop( 'amount', $context );
+	}
+
+
+	/**
+	 * Gets the currency.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_currency( $context = 'view' ) {
+
+		return $this->get_prop( 'currency', $context );
+	}
+
+
+	/**
+	 * Gets the authorization code.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_authorization_code( $context = 'view' ) {
+
+		return $this->get_prop( 'authorization_code', $context );
+	}
+
+
+	/**
+	 * Gets the retry count.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return int
+	 */
+	public function get_retry_count( $context = 'view' ) {
+
+		return $this->get_prop( 'retry_count', $context );
+	}
+
+
+	/**
+	 * Gets the parent transaction ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return int
+	 */
+	public function get_parent_id( $context = 'view' ) {
+
+		return $this->get_prop( 'parent_id', $context );
+	}
+
+
+	/**
+	 * Gets the payment gateway ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_gateway_id( $context = 'view' ) {
+
+		return $this->get_prop( 'gateway_id', $context );
+	}
+
+
+	/**
+	 * Gets the ID for the order that created this transaction.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return int
+	 */
+	public function get_order_id( $context = 'view' ) {
+
+		return $this->get_prop( 'order_id', $context );
+	}
+
+
+	/**
+	 * Gets the customer ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_customer_id( $context = 'view' ) {
+
+		return $this->get_prop( 'customer_id', $context );
+	}
+
+
+	/**
+	 * Gets the user ID, if any.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return int
+	 */
+	public function get_user_id( $context = 'view' ) {
+
+		return $this->get_prop( 'user_id', $context );
+	}
+
+
+	/**
+	 * Gets the payment gateway environment.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_environment( $context = 'view' ) {
+
+		return $this->get_prop( 'environment', $context );
+	}
+
+
+	/**
+	 * Gets a transaction property.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @see \WC_Data::get_prop()
+	 *
+	 * @param string $prop transaction property to get
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return mixed
+	 */
+	protected function get_prop( $prop, $context = 'view' ) {
+
+		// Let WC core do its base filtering
+		$value = parent::get_prop( $prop, $context );
+
+		if ( 'view' === $context && $this->get_gateway_id() ) {
+
+			/**
+			 * Filters a transaction property in the 'view' context.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param mixed $value transaction property value
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_gateway_hook_prefix() . $prop, $value, $this );
+		}
+
+		return $value;
+	}
+
+
+	/**
+	 * Gets the hook prefix specific to this transaction's gateway ID.
+	 *
+	 * i.e. 'wc_authorize_net_cim_transaction_get_status'
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	protected function get_gateway_hook_prefix() {
+
+		return 'woocommerce_' . $this->get_gateway_id() . '_' . $this->object_type . '_get_';
+	}
+
+
+	/**
+	 * Gets the transaction type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	abstract public function get_type();
+
+
+	/**
+	 * Gets the description.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	abstract public function get_description( $context = 'view' );
+
+
+	/* Setter methods *********************************************************/
+
+
+	/**
+	 * Sets the external ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value external ID
+	 */
+	public function set_external_id( $value ) {
+
+		$this->set_prop( 'external_id', $value );
+	}
+
+
+	/**
+	 * Sets the date the transaction was created.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value date created
+	 */
+	public function set_date_created( $value ) {
+
+		$this->set_prop( 'date_created', $value );
+	}
+
+
+	/**
+	 * Sets the status.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value status
+	 */
+	public function set_status( $value ) {
+
+		$this->set_prop( 'status', $value );
+	}
+
+
+	/**
+	 * Sets the amount.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string|float|int $value dollar amount
+	 */
+	public function set_amount( $value ) {
+
+		$this->set_prop( 'amount', SV_WC_Helper::number_format( $value ) );
+	}
+
+
+	/**
+	 * Sets the currency code.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value currency code
+	 */
+	public function set_currency( $value ) {
+
+		if ( $value && ! in_array( $value, array_keys( get_woocommerce_currencies() ), true ) ) {
+			$this->error( 'sv_wc_transaction_invalid_currency', __( 'Invalid currency code', 'woocommerce-plugin-framework' ) );
+		}
+
+		$this->set_prop( 'currency', $value );
+	}
+
+
+	/**
+	 * Sets the authorization code.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value authorization code
+	 */
+	public function set_authorization_code( $value ) {
+
+		$this->set_prop( 'authorization_code', $value );
+	}
+
+
+	/**
+	 * Sets the retry count.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value retry count
+	 */
+	public function set_retry_count( $value ) {
+
+		$this->set_prop( 'retry_count', (int) $value );
+	}
+
+
+	/**
+	 * Sets the parent transaction ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value parent transaction ID
+	 */
+	public function set_parent_id( $value ) {
+
+		// TODO: validate this ID when/if we end up storing transactions
+
+		$this->set_prop( 'parent_id', (int) $value );
+	}
+
+
+	/**
+	 * Sets the payment gateway ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value payment gateway ID
+	 */
+	public function set_gateway_id( $value ) {
+
+		// TODO: validate?
+
+		$this->set_prop( 'gateway_id', $value );
+	}
+
+
+	/**
+	 * Sets the order ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param int $value WooCommerce order ID
+	 */
+	public function set_order_id( $value ) {
+
+		if ( $value && ! wc_get_order( $value ) ) {
+			$this->error( 'sv_wc_transaction_invalid_order_id', __( 'Invalid order ID', 'woocommerce-plugin-framework' ) );
+		}
+
+		$this->set_prop( 'order_id', (int) $value );
+	}
+
+
+	/**
+	 * Sets the customer ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value customer ID
+	 */
+	public function set_customer_id( $value ) {
+
+		$this->set_prop( 'customer_id', $value );
+	}
+
+
+	/**
+	 * Sets the user ID.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param int $value WordPress user ID
+	 */
+	public function set_user_id( $value ) {
+
+		if ( $value && ! get_userdata( $value ) ) {
+			$this->error( 'sv_wc_transaction_invalid_user_id', __( 'Invalid user ID', 'woocommerce-plugin-framework' ) );
+		}
+
+		$this->set_prop( 'user_id', (int) $value );
+	}
+
+
+	/**
+	 * Sets the gateway environment.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value gateway environment slug/ID
+	 */
+	public function set_environment( $value ) {
+
+		$this->set_prop( 'environment', $value );
+	}
+
+
+	/* CRUD methods ***********************************************************/
+
+
+	public function save() {
+
+		if ( $order_id = $this->get_order_id() ) {
+
+			foreach ( $thi->get_meta_data_to_save() as $key => $value ) {
+				update_post_meta( $order_id, $this->get_meta_prefix() . $key, $value );
+			}
+		}
+	}
+
+
+	protected function get_meta_data_to_save() {
+
+		return array(
+			'trans_id'     => $this->get_external_id( 'edit' ),
+			'trans_date'   => $this->get_date_created( 'edit' ),
+			'trans_status' => $this->get_status( 'edit' ),
+			'type'         => $this->get_type( 'edit' ),
+			'amount'       => $this->get_amount( 'edit' ),
+			'auth_code'    => $this->get_authorization_code( 'edit' ),
+			'customer_id'  => $this->get_customer_id( 'edit' ),
+			'retry_count'  => $this->get_retry_count( 'edit' ),
+			'environment'  => $this->get_environment( 'edit' ),
+		);
+	}
+
+
+	protected function get_meta_prefix() {
+
+		return '_wc_' . $this->get_gateway_id() . '_' . $this->get_type() . '_';
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-authorization-transaction.php
+++ b/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-authorization-transaction.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2016, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Authorization_Transaction' ) ) :
+
+
+/**
+ * The payment authorization transaction class.
+ *
+ * @since 4.7.0-dev
+ */
+class SV_WC_Payment_Gateway_Authorization_Transaction extends SV_WC_Payment_Gateway_Payment_Transaction {
+
+
+	/**
+	 * Gets the transaction type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+
+		return SV_WC_Payment_Gateway_Helper::TRANSACTION_TYPE_AUTHORIZATION;
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-capture-transaction.php
+++ b/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-capture-transaction.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2016, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Capture_Transaction' ) ) :
+
+
+/**
+ * The payment capture transaction class.
+ *
+ * @since 4.7.0-dev
+ */
+abstract class SV_WC_Payment_Gateway_Capture_Transaction extends SV_WC_Payment_Gateway_Transaction {
+
+
+	/**
+	 * Gets the transaction type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+
+		return SV_WC_Payment_Gateway_Helper::TRANSACTION_TYPE_CAPTURE;
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-charge-transaction.php
+++ b/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-charge-transaction.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2016, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Charge_Transaction' ) ) :
+
+
+/**
+ * The payment charge transaction class.
+ *
+ * @since 4.7.0-dev
+ */
+class SV_WC_Payment_Gateway_Charge_Transaction extends SV_WC_Payment_Gateway_Payment_Transaction {
+
+
+	/**
+	 * Gets the transaction type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+
+		return SV_WC_Payment_Gateway_Helper::TRANSACTION_TYPE_CHARGE;
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-refund-transaction.php
+++ b/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-refund-transaction.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2016, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Refund_Transaction' ) ) :
+
+
+/**
+ * The payment refund transaction class.
+ *
+ * @since 4.7.0-dev
+ */
+class SV_WC_Payment_Gateway_Refund_Transaction extends SV_WC_Payment_Gateway_Transaction {
+
+
+	/** @var array extra data specific to this transaction type */
+	protected $extra_data = array(
+		'reason' => '',
+	);
+
+
+	/**
+	 * Gets the refund reason.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_reason( $context = 'view' ) {
+
+		return $this->get_prop( 'reason', $context );
+	}
+
+
+	/**
+	 * Gets the transaction type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+
+		return SV_WC_Payment_Gateway_Helper::TRANSACTION_TYPE_REFUND;
+	}
+
+
+	/**
+	 * Sets the refund reason.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $reason refund reason
+	 */
+	public function set_reason( $reason ) {
+
+		return $this->set_prop( 'reason', $reason );
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-void-transaction.php
+++ b/woocommerce/payment-gateway/transactions/class-sv-wc-payment-gateway-void-transaction.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2016, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Void_Transaction' ) ) :
+
+
+/**
+ * The payment void transaction class.
+ *
+ * @since 4.7.0-dev
+ */
+class SV_WC_Payment_Gateway_Void_Transaction extends SV_WC_Payment_Gateway_Transaction {
+
+
+	/**
+	 * Gets the transaction type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+
+		return SV_WC_Payment_Gateway_Helper::TRANSACTION_TYPE_VOID;
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/payment-methods/abstract-sv-wc-payment-gateway-transaction-payment-method.php
+++ b/woocommerce/payment-gateway/transactions/payment-methods/abstract-sv-wc-payment-gateway-transaction-payment-method.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2017, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Transaction_Payment_Method' ) ) :
+
+/**
+ * The base gateway transaction payment method class.
+ *
+ * @since 4.7.0-dev
+ */
+abstract class SV_WC_Payment_Gateway_Transaction_Payment_Method {
+
+
+	/** @var array payment method properties */
+	protected $data = array(
+		'account_number' => '',
+		'last_four'      => '',
+		'nonce'          => '',
+	);
+
+	/** @var array extra data specific to this payment method type */
+	protected $extra_data = array();
+
+	/** @var array properties that should never be stored or filtered */
+	protected $sensitive_data = array(
+		'account_number' => '',
+	);
+
+	/** @var \SV_WC_Payment_Gateway_Payment_Token the token associated with this method */
+	protected $token;
+
+	/** @var string \SV_WC_Payment_Gateway_Transaction transaction object */
+	protected $transaction;
+
+
+	/**
+	 * Constructs the class.
+	 *
+	 * @since 4.7.0-dev
+	 */
+	public function __construct() {
+
+		$this->data = array_merge( $this->data, $this->extra_data );
+	}
+
+
+	/* Getter methods *********************************************************/
+
+
+	/**
+	 * Gets the token associated with this method.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return \SV_WC_Payment_Gateway_Payment_Token|null
+	 */
+	public function get_token() {
+
+		return $this->token;
+	}
+
+
+	/**
+	 * Gets the method's account number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_account_number() {
+
+		return $this->get_prop( 'account_number', 'edit' );
+	}
+
+
+	/**
+	 * Gets the last four characters of the account number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_last_four( $context = 'view' ) {
+
+		$last_four = $this->get_prop( 'last_four', $context );
+
+		if ( ! $last_four && $account_number = $this->get_account_number() ) {
+
+			$last_four = substr( $account_number, -4 );
+
+			$this->set_last_four( $last_four );
+		}
+
+		return $last_four;
+	}
+
+
+	/**
+	 * Gets the nonce.
+	 *
+	 * This can be a token set by gateways that implement client-side JS
+	 * tokenization to keep the method's sensitive details off the server.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_nonce() {
+
+		return $this->get_prop( 'nonce', 'edit' );
+	}
+
+
+	/**
+	 * Gets a property.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $prop property to get
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return mixed
+	 */
+	protected function get_prop( $prop, $context = 'view' ) {
+
+		$value = null;
+
+		$token = $this->get_token();
+
+		if ( $token && is_callable( array( $token, "get_{$prop}" ) ) ) {
+			$value = $token->{"get_{$prop}"}();
+		} elseif ( isset( $this->data[ $prop ] ) ) {
+			$value = $this->data[ $prop ];
+		}
+
+		if ( $value && 'view' === $context && ! in_array( $prop, $this->sensitive_data, true ) ) {
+
+			/**
+			 * Filters the payment method property.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param mixed $value property value
+			 * @param \SV_WC_Payment_Gateway_Transaction_Payment_Method $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_hook_prefix() . $prop, $value, $this, $this->get_transaction() );
+
+			/**
+			 * Filters the payment method property.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param mixed $value property value
+			 * @param \SV_WC_Payment_Gateway_Transaction_Payment_Method $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_gateway_hook_prefix() . $prop, $value, $this, $this->get_transaction() );
+		}
+
+		return $value;
+	}
+
+
+	/**
+	 * Gets the hook prefix for filtering property values.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	protected function get_hook_prefix() {
+
+		return 'woocommerce_transaction_' . $this->get_type() . '_get_';
+	}
+
+
+	/**
+	 * Gets the gateway-specific hook prefix for filtering property values.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	protected function get_gateway_hook_prefix() {
+
+		return 'wc_' . $this->get_transaction()->get_gateway_id() . '_transaction_' . $this->get_type() . '_get_';
+	}
+
+
+	/**
+	 * Gets the transaction associated with this payment method.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return \SV_WC_Payment_Gateway_Transaction
+	 */
+	protected function get_transaction() {
+
+		return $this->transaction;
+	}
+
+
+	/**
+	 * Gets the payment method type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	abstract public function get_type();
+
+
+	/* Setter methods *********************************************************/
+
+
+	/**
+	 * Sets the token associated with this method.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param \SV_WC_Payment_Gateway_Payment_Token $token payment method token object
+	 */
+	public function set_token( SV_WC_Payment_Gateway_Payment_Token $token ) {
+
+		$this->token = $token;
+	}
+
+
+	/**
+	 * Sets the account number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value account number
+	 */
+	public function set_account_number( $value ) {
+
+		$this->set_prop( 'account_number', $value );
+	}
+
+
+	/**
+	 * Sets the nonce.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value nonce
+	 */
+	public function set_nonce( $value ) {
+
+		$this->set_prop( 'nonce', $value );
+	}
+
+
+	/**
+	 * Sets the last four characters of the account number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value last four characters of the account number
+	 */
+	public function set_last_four( $value ) {
+
+		$this->set_prop( 'last_four', $value );
+	}
+
+
+	/**
+	 * Sets a property.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $prop the property to set
+	 * @param string|array $value the property value
+	 */
+	protected function set_prop( $prop, $value ) {
+
+		$token = $this->get_token();
+
+		if ( $token && is_callable( array( $token, "set_{$prop}" ) ) ) {
+			$token->{"set_{$prop}"}( $value );
+		} elseif ( array_key_exists( $prop, $this->data ) ) {
+			$this->data[ $prop ] = $value;
+		}
+	}
+
+
+	/**
+	 * Sets the transaction object.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+	 */
+	public function set_transaction( $transaction ) {
+
+		$this->transaction = $transaction;
+	}
+
+
+	/* CRUD methods ***********************************************************/
+
+
+	public function save( $order_id ) {
+
+		foreach ( $this->data as $key => $value ) {
+
+			if ( ! in_array( $key, $this->sensitive_data, true ) ) {
+				update_post_meta( $order_id, '_wc_' . $this->get_transaction()->get_gateway_id() . '_' . $key, $value );
+			}
+		}
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/payment-methods/class-sv-wc-payment-gateway-transaction-credit-card.php
+++ b/woocommerce/payment-gateway/transactions/payment-methods/class-sv-wc-payment-gateway-transaction-credit-card.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions\Payment-Methods
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2017, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Transaction_Credit_Card' ) ) :
+
+/**
+ * The transaction credit card class.
+ *
+ * @since 4.7.0-dev
+ */
+class SV_WC_Payment_Gateway_Transaction_Credit_Card extends SV_WC_Payment_Gateway_Transaction_Payment_Method {
+
+
+	/** @var array extra data specific to credit cards */
+	protected $extra_data = array(
+		'exp_month' => '',
+		'exp_year'  => '',
+		'csc'       => '',
+		'card_type' => '',
+	);
+
+	/** @var array properties that should never be stored or filtered */
+	protected $sensitive_data = array(
+		'account_number' => '',
+		'csc'            => '',
+	);
+
+
+	/* Getter methods *********************************************************/
+
+
+	/**
+	 * Gets the card number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_card_number() {
+
+		return $this->get_account_number();
+	}
+
+
+	/**
+	 * Gets the formatted expiration date.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_exp_date( $context = 'view' ) {
+
+		$value =  $this->get_exp_month() . '/' . substr( $this->get_exp_year(), -2 );
+
+		if ( 'view' === $context ) {
+
+			/**
+			 * Filters a transaction's credit card expiration date.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param string $exp_date expiration date
+			 * @param \SV_WC_Payment_Gateway_Transaction_Credit_Card $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_hook_prefix() . 'exp_date', $value, $this, $this->get_transaction() );
+
+			/**
+			 * Filters a transaction's credit card expiration date.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param string $exp_date expiration date
+			 * @param \SV_WC_Payment_Gateway_Transaction_Credit_Card $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_gateway_hook_prefix() . 'exp_date', $value, $this, $this->get_transaction() );
+		}
+
+		return $value;
+	}
+
+
+	/**
+	 * Gets the expiration month.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_exp_month( $context = 'view' ) {
+
+		return $this->get_prop( 'exp_month', $context );
+	}
+
+
+	/**
+	 * Gets the expiration year.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_exp_year( $context = 'view' ) {
+
+		return $this->get_prop( 'exp_year', $context );
+	}
+
+
+	/**
+	 * Gets the card CSC.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_csc() {
+
+		return $this->get_prop( 'csc', 'edit' );
+	}
+
+
+	/**
+	 * Gets the card type name.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_card_type_name( $context = 'view' ) {
+
+		$value = SV_WC_Payment_Gateway_Helper::payment_type_to_name( $this->get_card_type() );
+
+		if ( 'view' === $context ) {
+
+			/**
+			 * Filters a transaction's credit card type name.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param string $name card type name
+			 * @param \SV_WC_Payment_Gateway_Transaction_Credit_Card $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_hook_prefix() . 'card_type_name', $value, $this, $this->get_transaction() );
+
+			/**
+			 * Filters a gateway-specific transaction's credit card type name.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param string $name card type name
+			 * @param \SV_WC_Payment_Gateway_Transaction_Credit_Card $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_gateway_hook_prefix() . 'card_type_name', $value, $this, $this->get_transaction() );
+		}
+
+		return $value;
+	}
+
+
+	/**
+	 * Gets the card type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_card_type( $context = 'view' ) {
+
+		return $this->get_prop( 'card_type', $context );
+	}
+
+
+	/**
+	 * Gets the payment method type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+
+		return 'credit_card'; // TODO: underscore?
+	}
+
+
+	/* Setter methods *********************************************************/
+
+
+	/**
+	 * Sets the card number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value card number
+	 */
+	public function set_card_number( $value ) {
+
+		$this->set_account_number( $value );
+	}
+
+
+	/**
+	 * Sets the expiration month.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value expiration month
+	 */
+	public function set_exp_month( $value ) {
+
+		$this->set_prop( 'exp_year', $value );
+	}
+
+
+	/**
+	 * Sets the expiration year.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value expiration year
+	 */
+	public function set_exp_year( $value ) {
+
+		$this->set_prop( 'exp_year', $value );
+	}
+
+
+	/**
+	 * Sets the card CSC.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value card CSC
+	 */
+	public function set_csc( $value ) {
+
+		$this->set_prop( 'csc', $value );
+	}
+
+
+	/**
+	 * Sets the card type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value card type
+	 */
+	public function set_card_type( $value ) {
+
+		$this->set_prop( 'card_type', $value );
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/transactions/payment-methods/class-sv-wc-payment-gateway-transaction-echeck.php
+++ b/woocommerce/payment-gateway/transactions/payment-methods/class-sv-wc-payment-gateway-transaction-echeck.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Transactions\Payment-Methods
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2017, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( 'SV_WC_Payment_Gateway_Transaction_eCheck' ) ) :
+
+/**
+ * The transaction eCheck class.
+ *
+ * @since 4.7.0-dev
+ */
+class SV_WC_Payment_Gateway_Transaction_eCheck extends SV_WC_Payment_Gateway_Transaction_Payment_Method {
+
+
+	/** @var array extra data specific to echecks */
+	protected $extra_data = array(
+		'id_number'      => '',
+		'id_type'        => '',
+		'check_number'   => '',
+		'account_type'   => '',
+	);
+
+	/** @var array properties that should never be stored or filtered */
+	protected $sensitive_data = array(
+		'account_number' => '',
+		'id_number'      => '',
+	);
+
+
+	/* Getter methods *********************************************************/
+
+
+	/**
+	 * Gets the ID number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_id_number() {
+
+		return $this->get_prop( 'id_number', 'edit' );
+	}
+
+
+	/**
+	 * Gets the ID type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_id_type( $context = 'view' ) {
+
+		return $this->get_prop( 'id_type', $context );
+	}
+
+
+	/**
+	 * Gets the check number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_check_number( $context = 'view' ) {
+
+		return $this->get_prop( 'check_number', $context );
+	}
+
+
+	/**
+	 * Gets the account type name.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_account_type_name( $context = 'view' ) {
+
+		$value = SV_WC_Payment_Gateway_Helper::payment_type_to_name( $this->get_account_type() );
+
+		if ( 'view' === $context ) {
+
+			/**
+			 * Filters a transaction's eCheck account type name.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param string $name account type name
+			 * @param \SV_WC_Payment_Gateway_Transaction_eCheck $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_hook_prefix() . 'account_type_name', $value, $this, $this->get_transaction() );
+
+			/**
+			 * Filters a transaction's eCheck account type name.
+			 *
+			 * @since 4.7.0-dev
+			 *
+			 * @param string $exp_date expiration date
+			 * @param \SV_WC_Payment_Gateway_Transaction_eCheck $payment_method payment method object
+			 * @param \SV_WC_Payment_Gateway_Transaction $transaction transaction object
+			 */
+			$value = apply_filters( $this->get_gateway_hook_prefix() . 'account_type_name', $value, $this, $this->get_transaction() );
+		}
+
+		return $value;
+	}
+
+
+	/**
+	 * Gets the account type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $context output context - 'view' will be filtered
+	 *
+	 * @return string
+	 */
+	public function get_account_type( $context = 'view' ) {
+
+		return $this->get_prop( 'account_type', $context );
+	}
+
+
+	/**
+	 * Gets the payment method type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+
+		return 'echeck';
+	}
+
+
+	/* Setter methods *********************************************************/
+
+
+	/**
+	 * Sets the ID number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value ID number
+	 */
+	public function set_id_number( $value ) {
+
+		$this->set_prop( 'id_number', $value );
+	}
+
+
+	/**
+	 * Sets the ID type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value ID type
+	 */
+	public function set_id_type( $value ) {
+
+		$this->set_prop( 'id_type', $value );
+	}
+
+
+	/**
+	 * Sets the check number.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value check number
+	 */
+	public function set_check_number( $value ) {
+
+		$this->set_prop( 'check_number', $value );
+	}
+
+
+	/**
+	 * Sets the account type.
+	 *
+	 * @since 4.7.0-dev
+	 *
+	 * @param string $value account type
+	 */
+	public function set_account_type( $value ) {
+
+		$this->set_prop( 'account_type', $value );
+	}
+
+
+}
+
+endif;


### PR DESCRIPTION
POC only, DO NOT MERGE

# Objective

Provide a new way for gateways to pass transaction data around throughout the payment, capture, and refund processes that's more reliable and testable, and cut down the size of our gateway classes.

## Problem

Currently, transaction data is added directly to `WC_Order` objects by assigning new properties that often become their own `stdClass` objects which hold various bits of data. This can be credit card information or previous transaction details in the case of refunds. Historically, this has been a fine way to make important data available before and after calling a gateway's API. However, this may not to be so reliable in the future as we've seen with WooCommerce 3.0 compatibility and the move away from directly accessing `WC_Order` properties.

## Solution

This PR introduces **transaction objects**. The purpose here is to decouple our gateway-specific data from `WC_Order` and have a consistent set of objects that are passed around instead, with the order merely being one of many properties associated with a single transaction. In this PR you will see a few familiar transaction types:

* Payment
    * Authorization
    * Charge
* Capture
* Refund
* Void

All of these types would have a set of common properties accessible via getters and setters, which gateways would set as they become available, like `transaction_id`, and get as needed when adding order notes, etc... Right now these are mostly based on the meta we currently save to orders, as well as what's available via the [Shopify API](https://help.shopify.com/api/reference/transaction)

### Payment Methods

Another object added here is **payment method**. These would live inside the transaction object for any transaction type that requires payment information. Like transactions themselves, these would have getters and setters specific to their type, like `set_csc()` or `set_check_number()`. One of the biggest benefits here is cleaning up some of the logic within the gateway classes surrounding credit cards vs. eChecks, keep the transaction objects themselves clear of specific payment types, as well as autofilling a lot of these properties if a token is present.

## Implementation

Within `process_payment()`, we could simply call a method such as `$transaction = $this->create_payment_transaction()`, which would generate a new transaction object, which would be overrideable by the concrete gateway in case they need their own properties. We'd then go about setting various properties like `amount`, `currency`, etc...

In the case of direct payment transactions, we could similarly generate a payment method object and set it's properties like so:

``` php
protected function set_posted_credit_card_data( SV_WC_Payment_Gateway_Transaction_Credit_Card $payment_method ) {

	$card_number = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-account-number' );
	$card_type   = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-card-type' );
	$exp_month   = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-exp-month' );
	$exp_year    = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-exp-year' );
	$csc         = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-csc' );

	// add card type for gateways that don't require it displayed at checkout
	if ( empty( $card_type ) ) {
		$card_type = SV_WC_Payment_Gateway_Helper::card_type_from_account_number( $card_number );
	}

	// handle single expiry field formatted like "MM / YY" or "MM / YYYY"
	if ( $expiry = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-expiry' ) ) {
		list( $exp_month, $exp_year ) = array_map( 'trim', explode( '/', $expiry ) );
	}

	$payment_method->set_card_number( $card_number );
	$payment_method->set_card_type( $card_type );
	$payment_method->set_exp_month( $exp_month );
	$payment_method->set_exp_year( $exp_year );
	$payment_method->set_csc( $csc );

	return $payment_method;
}
```

Then add that to the trasaction object: `$transaction->set_payment_method( $payment_method );`

All of this fantastic data would then be available down the line as we make API calls:

``` php
$api_data = array(
    'description' => $transaction->get_description(),
    'cc_number'   => $transaction->get_payment_method()->get_card_number(),
    // etc...
);
```

## The Future

For now these would live and die only during the payment/capture/refund/void process, but eventually they could handle storing data via a `save()` method. This could be order meta as we do now, or if we wanted to store each transaction in a custom table down the line. With that we could extend the order admin with a more detailed list of transaction events, or make each transaction available via the REST API like Shopify.

Eventually this could be a candidate for a core contribution if dealing with transactions in this manner proves useful.

What do y'all think? Any glaring problems or omissions you see here? I would love some feedback before going any further with actual gateway implementation.