### PR TITLE
Prevent error in older gateways that don't yet extend the API base class

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -434,7 +434,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 					break;
 				}
 
-			} elseif ( $gateway->get_api() && $gateway->get_api()->require_tls_1_2() && ! $gateway->get_api()->is_tls_1_2_available() ) {
+			} elseif ( $gateway->get_api() && is_callable( array( $gateway->get_api(), 'require_tls_1_2' ) ) && is_callable( array( $gateway->get_api(), 'is_tls_1_2_available' ) ) && $gateway->get_api()->require_tls_1_2() && ! $gateway->get_api()->is_tls_1_2_available() ) {
 
 				/* translators: Placeholders: %s - payment gateway name */
 				$message = sprintf( esc_html__( "%s requires TLS v1.2 support to process transactions. Please contact your hosting provider to update your environment to support the latest security standards.", 'woocommerce-plugin-framework' ), '<strong>' . $gateway->get_method_title() . '</strong>' );


### PR DESCRIPTION
Gateways that define their own `get_api()` method but don’t yet extend
the API base class will log a fatal error in the admin footer when
trying to check for TLS 1.2 support on the gateway settings page.