### PR TITLE
Improve TLS Notice

### DIFF
--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -805,7 +805,7 @@ abstract class SV_WC_API_Base {
 
 			$versions = curl_version();
 
-			// cURL is considered the minimum version that supports TLS 1.2
+			// cURL 7.34.0 is considered the minimum version that supports TLS 1.2
 			if ( version_compare( $versions['version'], '7.34.0', '<' ) ) {
 				$is_available = false;
 			}

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -797,28 +797,29 @@ abstract class SV_WC_API_Base {
 	 */
 	public function is_tls_1_2_available() {
 
-		// nothing we can do if cURL is not installed
-		if ( ! extension_loaded( 'curl' ) ) {
-			return true;
-		}
-
-		$versions     = curl_version();
-		$curl_version = $versions['version'];
-
-		// get the SSL details
-		list( $ssl_type, $ssl_version ) = explode( '/', $versions['ssl_version'] );
-
-		$ssl_version = substr( $ssl_version, 0, -1 );
-
-		// if cURL and/or OpenSSL aren't up to the challenge, bail
-		if ( ! version_compare( $curl_version, '7.34.0', '>=' ) || ( 'OpenSSL' === $ssl_type && ! version_compare( $ssl_version, '1.0.1', '>=' ) ) ) {
-			return false;
-		}
-
-		// TODO: anything we can do to check for other SSL types? {CW 2017-06-16}
-
 		// assume availability to avoid notices for unknown SSL types
-		return true;
+		$is_available = true;
+
+		// check the cURL version if installed
+		if ( is_callable( 'curl_version' ) ) {
+
+			$versions = curl_version();
+
+			// cURL is considered the minimum version that supports TLS 1.2
+			if ( version_compare( $versions['version'], '7.34.0', '<' ) ) {
+				$is_available = false;
+			}
+		}
+
+		/**
+		 * Filters whether TLS 1.2 is available.
+		 *
+		 * @since 4.7.1-dev
+		 *
+		 * @param bool $is_available whether TLS 1.2 is available
+		 * @param \SV_WC_API_Base $api API class instance
+		 */
+		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_api_is_tls_1_2_available', $is_available, $this );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -527,10 +527,11 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 			} elseif ( $gateway->get_api() && is_callable( array( $gateway->get_api(), 'require_tls_1_2' ) ) && is_callable( array( $gateway->get_api(), 'is_tls_1_2_available' ) ) && $gateway->get_api()->require_tls_1_2() && ! $gateway->get_api()->is_tls_1_2_available() ) {
 
 				/* translators: Placeholders: %s - payment gateway name */
-				$message = sprintf( esc_html__( "%s requires TLS v1.2 support to process transactions. Please contact your hosting provider to update your environment to support the latest security standards.", 'woocommerce-plugin-framework' ), '<strong>' . $gateway->get_method_title() . '</strong>' );
+				$message = sprintf( esc_html__( "%s will soon require TLS 1.2 support to process transactions and your server environment may need to be updated. Please contact your hosting provider to confirm that your site can send and receive TLS 1.2 connections and request they make any necessary updates.", 'woocommerce-plugin-framework' ), '<strong>' . $gateway->get_method_title() . '</strong>' );
 
 				$this->get_admin_notice_handler()->add_admin_notice( $message, 'tls-1-2-required', array(
-					'notice_class' => 'error',
+					'notice_class'            => 'notice-warning',
+					'always_show_on_settings' => false,
 				) );
 
 				// just show the message once for plugins with multiple gateway support


### PR DESCRIPTION
This removes some unreliable version checking, and softens the notice's impact so folks won't be as alarmed.

There is still the potential for false-positives, since the check for cURL version 7.34+ remains, but that's the best indicator I can come up with when deciding whether to show the notice.

Even with those cURL false-positives, the notice's new wording and appearance here should be a little more forgiving.

Closes #230 