### PR TITLE
Load Admin Notice and Admin Message Handlers in the WP-CLI environment

### DIFF
--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -134,7 +134,7 @@ abstract class SV_WC_Plugin {
 		$this->load_hook_deprecator();
 
 		// Admin
-		if ( is_admin() && ! is_ajax() ) {
+		if ( ( is_admin() && ! is_ajax() ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 
 			// admin message handler
 			require_once( $this->get_framework_path() . '/class-sv-wp-admin-message-handler.php' );
@@ -259,7 +259,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function lib_includes() {
 
-		if ( is_admin() ) {
+		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			// instantiate the admin notice handler
 			$this->get_admin_notice_handler();
 		}


### PR DESCRIPTION
Allow WP-CLI to access Admin Notice Handler and Admin Message Handler functionality. This lays the groundwork for WP-CLI commands to be able to functionally piggyback existing plugin code that utilizes these handlers. Some context: I'm working on building the functionality of [woocommerce-memberships-cli-import](https://github.com/mudtar/woocommerce-memberships-cli-import) into woocommerce-memberships itself rather than hackily piggybacking it, and this is a prerequisite.