### PR TITLE
Fix: unhook WC nonce manipulation when validating background jobs

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2017.nn.nn - version 4.7.3-dev
+ * Fix - Conflict with WooCommerce filtering of nonce checks for background jobs
+
 2017.09.12 - version 4.7.2
  * Fix - Ensure failed Pre-Orders can be paid with a new method by bypassing the failed order's stored token
  * Fix - Use the parameters passed to SV_WP_Admin_Message_Handler::show_messages()


### PR DESCRIPTION
OP Updated for clarify {BR 2017-09-26}

See [ZD ticket 691522](https://woothemes.zendesk.com/agent/tickets/691522)

1. WC loads the session handler [in a cron context](https://github.com/woocommerce/woocommerce/blob/c16acc6b5104acb0ed082e7df1c63dfd77598459/woocommerce.php#L432-L436).
1. This means tries to create a session for the server when a cron job is fired. It's not _really_ creating a session, but it thinks it is 😸 
1. The problem arises when we dispatch a job by doing a `GET` request. The [nonce is created before sending this request](https://github.com/skyverge/wc-plugin-framework/blob/3f730f88d5a8afa150ce60faa4f356a16c0699a2/woocommerce/utilities/class-sv-wp-async-request.php#L86-L98) in a cron context.
1. Sending the request prompts the session handler to try to create session for the server. It also fires the `wp-ajax` action we're hooked into in `maybe_handle()`
1. When this all happens in a single request, even though WooCommerce can't _really_ set a cookie / create a session, _it thinks it has_ [because it sets a flag in the constructor](https://github.com/woocommerce/woocommerce/blob/c16acc6b5104acb0ed082e7df1c63dfd77598459/includes/class-wc-session-handler.php#L45-L48) for `has_cookie`. The fact that **this all uses the same instance of the class** is what brings up an issue for us here, as that flag is now true, which means `has_session()` returns `true`.
1. The `WC_Session_Handler ` now thinks there's a session (for the server) and the user is logged out (which the server obviously is), so it then [filters all logged-out nonces on the site](https://github.com/woocommerce/woocommerce/blob/c16acc6b5104acb0ed082e7df1c63dfd77598459/includes/class-wc-session-handler.php#L67-L69) -- though, it passes back a hashed customer session ID instead of (int) [user ID as expected](https://developer.wordpress.org/reference/hooks/nonce_user_logged_out/). It also does not scope this filter to its own nonces, but does so globally for **every single logged-out user's nonce**.
1. This means that, in the scope of that same request, when `maybe_handle()` [now goes to validate the nonce](https://github.com/skyverge/wc-plugin-framework/blob/8dfa87ea55638cdbde17ef9b7a18a27dba1beb11/woocommerce/utilities/class-sv-wp-background-job-handler.php#L109-L134), WooCommerce is filtering the user ID for the nonce to its customer session ID as seen above. Because the nonce was created with UID 0, but is now validating against WC's "customer ID", this check fails and the job isn't handled.

I'm not 100% sure why we don't see this issue on all servers where the same session handler instance is used through the entire request, but we can force the issue by removing the nonce filtering until we've validated our own nonce.