### PR TITLE
Improve the PHP version notice wording and add date handling

### DIFF
--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -477,23 +477,49 @@ abstract class SV_WC_Plugin {
 			}
 		}
 
-		// add the PHP 5.3+ notice
-		if ( ! $sv_wc_php_notice_added && $this->display_php_notice && version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
+		// add the PHP 5.6+ notice
+		if ( ! $sv_wc_php_notice_added && $this->display_php_notice && version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
 
-			$message = sprintf(
-				/* translators: Placeholders: %1$s - <p>, %2$s - </p>, %3$s - <strong>, %4$s - </strong>, %5$s - plugin name, %6$s - <a> link, %7$s - </a> */
-				__( '%1$sHey there! We\'ve noticed that your server is running %3$san outdated version of PHP%4$s, which is the programming language that WooCommerce and its extensions are built on.
-					The PHP version that is currently used for your site is no longer maintained, nor %3$sreceives security updates%4$s; newer versions are faster and more secure.%2$s
-					%1$sAs a result, %5$s will no longer support this version on July 1, so you should upgrade PHP prior to this date. Your hosting provider can do this for you.
-					%6$sHere are some resources to help you upgrade%7$s and to explain PHP versions further.%2$s', 'woocommerce-plugin-framework' ),
-				'<p>', '</p>',
-				'<strong>', '</strong>',
-				$this->get_plugin_name(),
+			$message = '<p>';
+
+			$message .= sprintf(
+				/* translators: Placeholders: %1$s - <strong>, %2$s - </strong> */
+				__( 'Hey there! We\'ve noticed that your server is running %1$san outdated version of PHP%2$s, which is the programming language that WooCommerce and its extensions are built on.
+					The PHP version that is currently used for your site is no longer maintained, nor %1$sreceives security updates%2$s; newer versions are faster and more secure.', 'woocommerce-plugin-framework' ),
+				'<strong>', '</strong>'
+			);
+
+			$message .= '</p><p>';
+
+			$deadline = strtotime( 'May 2017' );
+
+			if ( time() < $deadline ) {
+
+				$message .= sprintf(
+					/* translators: Placeholders: %1$s - WooCommerce plugin name, %2$s - a month and year, such as May 2018 */
+					__( 'As a result, %1$s will no longer support this version starting %2$s and you should upgrade PHP prior to this date.', 'woocommerce-plugin-framework' ),
+					$this->get_plugin_name(),
+					'<strong>' . date_i18n( 'F Y', $deadline ) . '</strong>'
+				);
+
+			} else {
+
+				$message .= sprintf(
+					/* translators: Placeholders: %s - WooCommerce plugin name */
+					__( 'As a result, %s no longer supports this version and you should upgrade PHP as soon as possible.', 'woocommerce-plugin-framework' ),
+					$this->get_plugin_name()
+				);
+			}
+
+			$message .= ' ' . sprintf(
+				/* translators: Placeholders: %1$s - <a>, %2$s - </a> */
+				__( 'Your hosting provider can do this for you. %1$sHere are some resources to help you upgrade%2$s and to explain PHP versions further.', 'woocommerce-plugin-framework' ),
 				'<a href="http://skyver.ge/upgradephp">', '</a>'
 			);
 
+			$message .= '</p>';
+
 			$this->get_admin_notice_handler()->add_admin_notice( $message, 'sv-wc-outdated-php-version', array(
-				'dismissible'  => false,
 				'notice_class' => 'error',
 			) );
 


### PR DESCRIPTION
Changed to v5.6 by May 2018.

@bekarice mind taking a look at the wording here? Before May 1 next year:

![php-notice](http://cloud.skyver.ge/1D411V1G0E2n/Screen%20Shot%202017-10-04%20at%203.17.52%20PM.png)

After:

![php-notice-after](http://cloud.skyver.ge/1p1N2w370t0P/Screen%20Shot%202017-10-04%20at%203.18.11%20PM.png)

The notice is also now dismissible except on the plugin settings page if there is one.