### PR TITLE
5.1: Plugin review prompts

### DIFF
--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -102,8 +102,6 @@ class Lifecycle {
 		// display any milestone notices
 		foreach ( $this->get_milestone_messages() as $id => $message ) {
 
-			// TODO: detect upgrades so existing installs don't display these notices {CW 2018-01-30}
-
 			// bail if this notice was already dismissed
 			if ( ! $this->get_plugin()->get_admin_notice_handler()->should_display_notice( $id ) ) {
 				continue;
@@ -135,6 +133,13 @@ class Lifecycle {
 
 	/**
 	 * Triggers a milestone.
+	 *
+	 * This will only be triggered if the install's "milestone version" is lower
+	 * than $since. Plugins can specify $since as the version at which a
+	 * milestone's feature was added. This prevents existing installs from
+	 * triggering notices for milestones that have long passed, like a payment
+	 * gateway's first successful payment. Omitting $since will assume the
+	 * milestone has always existed and should only trigger for fresh installs.
 	 *
 	 * @since 5.1.0-dev
 	 *

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2018, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_0_1\Plugin;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_0_1\\Plugin\\Lifecycle' ) ) :
+
+/**
+ * Plugin lifecycle handler.
+ *
+ * Registers and displays milestone notice prompts and eventually the plugin
+ * install, upgrade, activation, and deactivation routines.
+ *
+ * @since 5.1.0-dev
+ */
+class Lifecycle {
+
+
+	/** @var \SkyVerge\WooCommerce\PluginFramework\v5_0_1\SV_WC_Plugin plugin instance */
+	private $plugin;
+
+
+	/**
+	 * Constructs the class.
+	 *
+	 * @since 5.1.0-dev
+	 *
+	 * @param \SkyVerge\WooCommerce\PluginFramework\v5_0_1\SV_WC_Plugin $plugin plugin instance
+	 */
+	public function __construct( \SkyVerge\WooCommerce\PluginFramework\v5_0_1\SV_WC_Plugin $plugin ) {
+
+		$this->plugin = $plugin;
+
+		$this->add_hooks();
+	}
+
+
+	/**
+	 * Adds the action & filter hooks.
+	 *
+	 * @since 5.1.0-dev
+	 */
+	protected function add_hooks() {
+
+		add_action( 'init', array( $this, 'add_admin_notices' ) );
+
+		add_action( 'wc_' . $this->get_plugin()->get_id() . '_milestone_reached', array( $this, 'register_milestone_message' ), 10, 2 );
+	}
+
+
+	/**
+	 * Adds any lifecycle admin notices.
+	 *
+	 * @since 5.1.0-dev
+	 */
+	public function add_admin_notices() {
+
+		// display any milestone notices
+		foreach ( $this->get_milestone_messages() as $id => $message ) {
+
+			// TODO: detect upgrades so existing installs don't display these notices {CW 2018-01-30}
+
+			// bail if this notice was already dismissed
+			if ( ! $this->get_plugin()->get_admin_notice_handler()->should_display_notice( $id ) ) {
+				continue;
+			}
+
+			/**
+			 * Filters a milestone notice message.
+			 *
+			 * @since 5.1.0-dev
+			 *
+			 * @param string $message message text to be used for the milestone notice
+			 * @param string $id milestone ID
+			 */
+			$message = apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_milestone_message', $this->generate_milestone_notice_message( $message ), $id );
+
+			if ( $message ) {
+
+				$this->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $id );
+
+				// only display one notice at a time
+				break;
+			}
+		}
+	}
+
+
+	/** Milestone Methods *****************************************************/
+
+
+	/**
+	 * Generates a milestone notice message.
+	 *
+	 * @since 5.1.0-dev
+	 *
+	 * @param string $custom_message custom text that notes what milestone was completed.
+	 * @return string
+	 */
+	protected function generate_milestone_notice_message( $custom_message ) {
+
+		$message = '';
+
+		if ( $this->get_plugin()->get_reviews_url() ) {
+
+			// to be prepended at random to each milestone notice
+			$exclamations = array(
+				__( 'Awesome', 'woocommerce-plugin-framework' ),
+				__( 'Fantastic', 'woocommerce-plugin-framework' ),
+				__( 'Cowabunga', 'woocommerce-plugin-framework' ),
+				__( 'Congratulations', 'woocommerce-plugin-framework' ),
+				__( 'Hot dog', 'woocommerce-plugin-framework' ),
+			);
+
+			$message = $exclamations[ array_rand( $exclamations ) ] . ', ' . esc_html( $custom_message ) . ' ';
+
+			$message .= sprintf(
+				/* translators: Placeholders: %1$s - plugin name, %2$s - <a> tag, %3$s - </a> tag, %4$s - <a> tag, %5$s - </a> tag */
+				__( 'Are you having a great experience with %1$s so far? Please consider %2$sleaving a review%3$s! If things aren\'t going quite as expected, we\'re happy to help -- please %4$sreach out to our support team%5$s.', 'woocommerce-plugin-framework' ),
+				'<strong>' . esc_html( $this->get_plugin()->get_plugin_name() ) . '</strong>',
+				'<a href="' . esc_url( $this->get_plugin()->get_reviews_url() ) . '">', '</a>',
+				'<a href="' . esc_url( $this->get_plugin()->get_support_url() ) . '">', '</a>'
+			);
+		}
+
+		return $message;
+	}
+
+
+	/**
+	 * Registers a milestone message to be displayed in the admin.
+	 *
+	 * @since 5.1.0-dev
+	 * @see Lifecycle::generate_milestone_notice_message()
+	 *
+	 * @param string $id milestone ID
+	 * @param string $message message to display to the user
+	 * @return bool whether the message was successfully registered
+	 */
+	public function register_milestone_message( $id, $message ) {
+
+		$messages = $this->get_milestone_messages();
+
+		$messages[ $id ] = $message;
+
+		return update_option( 'wc_' . $this->get_plugin()->get_id() . '_milestone_messages', $messages );
+	}
+
+
+	/**
+	 * Gets the registered milestone messages.
+	 *
+	 * @since 5.1.0-dev
+	 *
+	 * @return array
+	 */
+	protected function get_milestone_messages() {
+
+		return get_option( 'wc_' . $this->get_plugin()->get_id() . '_milestone_messages', array() );
+	}
+
+
+	/** Utility Methods *******************************************************/
+
+
+	/**
+	 * Gets the plugin instance.
+	 *
+	 * @since 5.1.0-dev
+	 *
+	 * @return \SkyVerge\WooCommerce\PluginFramework\v5_0_1\SV_WC_Plugin
+	 */
+	private function get_plugin() {
+
+		return $this->plugin;
+	}
+
+
+}
+
+endif;

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -162,7 +162,13 @@ class Lifecycle {
 	 */
 	public function register_milestone_message( $id, $message ) {
 
-		$messages = $this->get_milestone_messages();
+		$messages          = $this->get_milestone_messages();
+		$dismissed_notices = array_keys( $this->get_plugin()->get_admin_notice_handler()->get_dismissed_notices() );
+
+		// if the user has dismissed more than three milestone messages already, don't add any more
+		if ( count( array_intersect( array_keys( $messages ), $dismissed_notices ) ) > 3 ) {
+			return false;
+		}
 
 		$messages[ $id ] = $message;
 

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -146,6 +146,7 @@ class Lifecycle {
 	 * @param string $id milestone ID
 	 * @param string $message message to display to the user
 	 * @param string $since the version since this milestone has existed in the plugin
+	 * @return bool
 	 */
 	public function trigger_milestone( $id, $message, $since = '1.0.0' ) {
 
@@ -154,7 +155,7 @@ class Lifecycle {
 			return false;
 		}
 
-		$this->register_milestone_message( $id, $message );
+		return $this->register_milestone_message( $id, $message );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -534,6 +534,11 @@ abstract class SV_WC_Plugin {
 			$custom_actions['support'] = sprintf( '<a href="%s">%s</a>', $this->get_support_url(), esc_html_x( 'Support', 'noun', 'woocommerce-plugin-framework' ) );
 		}
 
+		// review url if any
+		if ( $this->get_reviews_url() ) {
+			$custom_actions['review'] = sprintf( '<a href="%s">%s</a>', $this->get_reviews_url(), esc_html_x( 'Review', 'verb', 'woocommerce-plugin-framework' ) );
+		}
+
 		// add the links to the front of the actions list
 		return array_merge( $custom_actions, $actions );
 	}
@@ -1050,6 +1055,34 @@ abstract class SV_WC_Plugin {
 	public function get_support_url() {
 
 		return null;
+	}
+
+
+	/**
+	 * Gets the plugin sales page URL.
+	 *
+	 * @since 5.1.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_sales_page_url() {
+
+		return '';
+	}
+
+
+	/**
+	 * Gets the plugin reviews page URL.
+	 *
+	 * Used for the 'Reviews' plugin action and review prompts.
+	 *
+	 * @since 5.1.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_reviews_url() {
+
+		return ( $this->get_sales_page_url() ) ? $this->get_sales_page_url() . '#comments' : '';
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -71,6 +71,9 @@ abstract class SV_WC_Plugin {
 	/** @var string the plugin text domain */
 	private $text_domain;
 
+	/** @var Plugin\Lifecycle lifecycle handler */
+	private $lifecycle_handler;
+
 	/** @var SV_WC_Admin_Notice_Handler the admin notice handler class */
 	private $admin_notice_handler;
 
@@ -276,6 +279,11 @@ abstract class SV_WC_Plugin {
 		// JSON API base
 		require_once( $framework_path . '/api/abstract-sv-wc-api-json-request.php' );
 		require_once( $framework_path . '/api/abstract-sv-wc-api-json-response.php' );
+
+		// Lifecycle handler
+		require_once( $framework_path . '/Lifecycle.php' );
+
+		$this->get_lifecycle_handler();
 
 		if ( is_admin() ) {
 			// instantiate the admin notice handler
@@ -884,6 +892,21 @@ abstract class SV_WC_Plugin {
 	 * @return string plugin name
 	 */
 	abstract public function get_plugin_name();
+
+
+	/**
+	 * Gets the lifecycle handler instance.
+	 *
+	 * @since 5.1.0-dev
+	 */
+	public function get_lifecycle_handler() {
+
+		if ( is_null( $this->lifecycle_handler ) ) {
+			$this->lifecycle_handler = new Plugin\Lifecycle( $this );
+		}
+
+		return $this->lifecycle_handler;
+	}
 
 
 	/**

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -1278,9 +1278,26 @@ abstract class SV_WC_Plugin {
 		if ( version_compare( $installed_version, $this->get_version(), '<' ) ) {
 
 			if ( ! $installed_version ) {
+
 				$this->install();
+
+				/**
+				 * Fires after the plugin has been installed.
+				 *
+				 * @since 5.1.0-dev
+				 */
+				do_action( 'wc_' . $this->get_id() . '_installed' );
+
 			} else {
+
 				$this->upgrade( $installed_version );
+
+				/**
+				 * Fires after the plugin has been updated.
+				 *
+				 * @since 5.1.0-dev
+				 */
+				do_action( 'wc_' . $this->get_id() . '_updated' );
 			}
 
 			// new version number

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -314,6 +314,28 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		// add API request logging
 		$this->add_api_request_logging();
+
+		// add milestone action hooks
+		$this->add_milestone_hooks();
+	}
+
+
+	/**
+	 * Adds the various milestone hooks like "payment processed".
+	 *
+	 * @since 5.1.0-dev
+	 */
+	protected function add_milestone_hooks() {
+
+		// first successful payment
+		add_action( 'wc_payment_gateway_' . $this->get_id() . '_payment_processed', function( $order ) {
+			$this->get_plugin()->get_lifecycle_handler()->trigger_milestone( 'payment-processed', __( 'you successfully processed a payment!', 'woocommerce-plugin-framework' ) );
+		} );
+
+		// first successful refund
+		add_action( 'wc_payment_gateway_' . $this->get_id() . '_refund_processed', function( $order ) {
+			$this->get_plugin()->get_lifecycle_handler()->trigger_milestone( 'refund-processed', __( 'you successfully processed a refund!', 'woocommerce-plugin-framework' ) );
+		} );
 	}
 
 
@@ -1993,6 +2015,16 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 					$this->mark_order_as_refunded( $order );
 				}
+
+				/**
+				 * Fires after a refund is successfully processed.
+				 *
+				 * @since 5.1.0-dev
+				 *
+				 * @param \WC_Order $order order object
+				 * @param SV_WC_Payment_Gateway $gateway payment gateway instance
+				 */
+				do_action( 'wc_payment_gateway_' . $this->get_id() . '_refund_processed', $order, $this );
 
 				return true;
 


### PR DESCRIPTION
- [x] Allow plugins to define their own sales/review page URLs
- [x] Add a "Review" link to plugin action links
- [x] Allow easy registration of plugin milestone events and display review prompts when needed
- [x] Add standard gateway milestones like first payment and first refund
- [x] Detect upgrades so milestone messages are only displayed for first-time installs
- [x] Determine if we should limit the number of messages to display, i.e. if the user has dismissed x number of review prompts, don't add any more for later milestones

The approach I took here is to only display milestones for new installs. This prevents existing users from seeing "first payment!" notices if they've been processing payments for a long time.

Plugins can call `Lifecycle::trigger_milestone( $id, $message, $since );` to register a notice when a milestone is reached. They can also omit `$since` for milestones that have existed in the plugin all along, like refunds in gateways, so that those messages are only displayed to brand new users. We don't have a great way to detect new vs. existing users, so we consider [all upgrades](https://github.com/skyverge/wc-plugin-framework/blob/5.1-plugin-review-prompts-258/woocommerce/Lifecycle.php#L86-L92) as existing users. This may leave out a subset of users who for some reason upgrade the plugin without having ever completed early milestones, but I think that's an okay compromise to make sure we don't bug existing users.

Otherwise, specifying `$since` can be used for new features so that even existing users get the notice. So if Memberships adds a totally new export feature in v1.11, we can pass `$since = '1.11.0'` and all users will see that when it first happens.

We also limit the number of milestone notices that can be added to 3 so that users aren't bombarded with review prompts if a plugin has a lot of milestones.

Closes #258