### PR TITLE
Improve phpdocs for handling exceptions and return types

### DIFF
--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -1290,7 +1290,7 @@ abstract class Setup_Wizard {
 	 *
 	 * @since 5.2.2
 	 *
-	 * @return Framework\SV_WC_Plugin
+	 * @return Framework\SV_WC_Plugin|Framework\SV_WC_Payment_Gateway_Plugin
 	 */
 	protected function get_plugin() {
 

--- a/woocommerce/api/abstract-sv-wc-api-xml-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-response.php
@@ -39,7 +39,7 @@ abstract class SV_WC_API_XML_Response implements SV_WC_API_Response {
 	/** @var string string representation of this response */
 	protected $raw_response_xml;
 
-	/** @var SimpleXMLElement XML object */
+	/** @var \SimpleXMLElement XML object */
 	protected $response_xml;
 
 	/** @var array|mixed|object XML data after conversion into an usable object */

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -57,7 +57,7 @@ abstract class SV_WC_API_Base {
 	/** @var string request duration */
 	protected $request_duration;
 
-	/** @var object request */
+	/** @var SV_WC_API_Request|object request */
 	protected $request;
 
 	/** @var string response code */
@@ -75,7 +75,7 @@ abstract class SV_WC_API_Base {
 	/** @var string response handler class name */
 	protected $response_handler;
 
-	/** @var object response */
+	/** @var SV_WC_API_Response|object response */
 	protected $response;
 
 
@@ -83,10 +83,10 @@ abstract class SV_WC_API_Base {
 	 * Perform the request and return the parsed response
 	 *
 	 * @since 2.2.0
-	 * @param object $request class instance which implements \SV_WC_API_Request
-	 * @throws Exception
-	 * @throws \SV_WC_API_Exception
-	 * @return object class instance which implements \SV_WC_API_Response
+	 *
+	 * @param SV_WC_API_Request|object $request class instance which implements SV_WC_API_Request
+	 * @return SV_WC_API_Response|object class instance which implements SV_WC_API_Response
+	 * @throws SV_WC_API_Exception may be thrown in implementations
 	 */
 	protected function perform_request( $request ) {
 
@@ -132,11 +132,13 @@ abstract class SV_WC_API_Base {
 	 * cURL implementation
 	 *
 	 * @since 2.2.0
+	 *
 	 * @param string $request_uri
 	 * @param string $request_args
-	 * @return array|WP_Error
+	 * @return array|\WP_Error
 	 */
 	protected function do_remote_request( $request_uri, $request_args ) {
+
 		return wp_safe_remote_request( $request_uri, $request_args );
 	}
 
@@ -145,9 +147,9 @@ abstract class SV_WC_API_Base {
 	 * Handle and parse the response
 	 *
 	 * @since 2.2.0
-	 * @param array|WP_Error $response response data
-	 * @throws \SV_WC_API_Exception network issues, timeouts, API errors, etc
-	 * @return object request class instance that implements SV_WC_API_Request
+	 * @param array|\WP_Error $response response data
+	 * @throws SV_WC_API_Exception network issues, timeouts, API errors, etc
+	 * @return SV_WC_API_Request|object request class instance that implements SV_WC_API_Request
 	 */
 	protected function handle_response( $response ) {
 
@@ -232,7 +234,7 @@ abstract class SV_WC_API_Base {
 	 *
 	 * @since 2.2.0
 	 * @param string $raw_response_body
-	 * @return object response class instance which implements SV_WC_API_Request
+	 * @return object|SV_WC_API_Request response class instance which implements SV_WC_API_Request
 	 */
 	protected function get_parsed_response( $raw_response_body ) {
 
@@ -287,7 +289,7 @@ abstract class SV_WC_API_Base {
 		 *     @type string $headers response HTTP headers
 		 *     @type string $body response body
 		 * }
-		 * @param \SV_WC_API_Base $this instance
+		 * @param SV_WC_API_Base $this instance
 		 */
 		do_action( 'wc_' . $this->get_api_id() . '_api_request_performed', $request_data, $response_data, $this );
 	}
@@ -345,8 +347,9 @@ abstract class SV_WC_API_Base {
 		 * method.
 		 *
 		 * @since 4.1.0
+		 *
 		 * @param string $uri current request URI
-		 * @param \SV_WC_API_Base class instance
+		 * @param SV_WC_API_Base class instance
 		 */
 		return apply_filters( 'wc_' . $this->get_api_id() . '_api_request_uri', $uri, $this );
 	}
@@ -393,7 +396,8 @@ abstract class SV_WC_API_Base {
 	 * Get the request arguments in the format required by wp_remote_request()
 	 *
 	 * @since 2.2.0
-	 * @return mixed|void
+	 *
+	 * @return array
 	 */
 	protected function get_request_args() {
 
@@ -419,7 +423,7 @@ abstract class SV_WC_API_Base {
 		 *
 		 * @since 2.2.0
 		 * @param array $args request arguments
-		 * @param \SV_WC_API_Base class instance
+		 * @param SV_WC_API_Base class instance
 		 */
 		return apply_filters( 'wc_' . $this->get_api_id() . '_http_request_args', $args, $this );
 	}
@@ -617,25 +621,27 @@ abstract class SV_WC_API_Base {
 
 
 	/**
-	 * Returns the most recent request object
+	 * Returns the most recent request object.
 	 *
 	 * @since 2.2.0
-	 * @see \SV_WC_API_Request
-	 * @return object the most recent request object
+	 *
+	 * @return SV_WC_API_Request|object the most recent request object
 	 */
 	public function get_request() {
+
 		return $this->request;
 	}
 
 
 	/**
-	 * Returns the most recent response object
+	 * Returns the most recent response object.
 	 *
 	 * @since 2.2.0
-	 * @see \SV_WC_API_Response
-	 * @return object the most recent response object
+	 *
+	 * @return SV_WC_API_Response|object the most recent response object
 	 */
 	public function get_response() {
+
 		return $this->response;
 	}
 
@@ -662,8 +668,9 @@ abstract class SV_WC_API_Base {
 	 * to self::perform_request() by your concrete API methods
 	 *
 	 * @since 2.2.0
+	 *
 	 * @param array $args optional request arguments
-	 * @return \SV_WC_API_Request
+	 * @return SV_WC_API_Request|object
 	 */
 	abstract protected function get_new_request( $args = array() );
 
@@ -677,7 +684,8 @@ abstract class SV_WC_API_Base {
 	 * as the plugin name used for the default user agent.
 	 *
 	 * @since 2.2.0
-	 * @return \SV_WC_Plugin
+	 *
+	 * @return SV_WC_Plugin
 	 */
 	abstract protected function get_plugin();
 
@@ -756,10 +764,11 @@ abstract class SV_WC_API_Base {
 	 * Note the class should implement SV_WC_API
 	 *
 	 * @since 2.2.0
+	 *
 	 * @param string $handler handle class name
-	 * @return array
 	 */
 	protected function set_response_handler( $handler ) {
+
 		$this->response_handler = $handler;
 	}
 
@@ -768,6 +777,10 @@ abstract class SV_WC_API_Base {
 	 * Maybe force TLS v1.2 requests.
 	 *
 	 * @since 4.4.0
+	 *
+	 * @param resource $handle the cURL handle returned by curl_init() (passed by reference)
+	 * @param array $r the HTTP request arguments
+	 * @param $url string the request URL
 	 */
 	public function set_tls_1_2_request( $handle, $r, $url ) {
 
@@ -821,7 +834,7 @@ abstract class SV_WC_API_Base {
 		 * @since 4.7.1
 		 *
 		 * @param bool $is_available whether TLS 1.2 is available
-		 * @param \SV_WC_API_Base $api API class instance
+		 * @param SV_WC_API_Base $api API class instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_api_is_tls_1_2_available', $is_available, $this );
 	}

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -309,7 +309,6 @@ class SV_WC_Admin_Notice_Handler {
 	 * @since 3.0.0
 	 * @param string $message_id the message identifier
 	 * @param int $user_id optional user identifier, defaults to current user
-	 * @return boolean true if the message has been dismissed by the admin user
 	 */
 	public function dismiss_notice( $message_id, $user_id = null ) {
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -220,8 +220,9 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_WC_He
 		 * pattern definitions from http://www.regular-expressions.info/unicode.html
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $string
-		 * @return mixed
+		 * @return string
 		 */
 		public static function str_to_sane_utf8( $string ) {
 
@@ -464,7 +465,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_WC_He
 		 *
 		 * @since 3.0.0
 		 * @param \WC_Order $order
-		 * @return array
+		 * @return \stdClass[] array of line item objects
 		 */
 		public static function get_order_line_items( $order ) {
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -108,7 +108,7 @@ class SV_WC_Plugin_Compatibility {
 	 *
 	 * @since  4.6.0
 	 *
-	 * @param \WC_DateTime|\SV_WC_DateTime $date date object
+	 * @param \WC_DateTime|SV_WC_DateTime $date date object
 	 * @param string $format date format
 	 * @return string
 	 */

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -201,7 +201,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @since 4.6.0
 	 * @param \WC_Order $object the order object
 	 * @param array $props the new properties as $key => $value
-	 * @return \WC_Order
+	 * @return \WC_Data|\WC_Order
 	 */
 	public static function set_props( $object, $props, $compat_props = array() ) {
 

--- a/woocommerce/compatibility/class-sv-wc-product-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-product-compatibility.php
@@ -77,7 +77,7 @@ class SV_WC_Product_Compatibility extends SV_WC_Data_Compatibility {
 	 *
 	 * @param \WC_Product $object the product object
 	 * @param array $props the new properties as $key => $value
-	 * @return \WC_Product
+	 * @return \WC_Data|\WC_Product
 	 */
 	public static function set_props( $object, $props, $compat_props = array() ) {
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -36,15 +36,16 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_WC_Pa
 class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 
-	/** @var \SV_WC_Payment_Gateway_Direct the gateway object **/
+	/** @var SV_WC_Payment_Gateway_Direct the gateway object **/
 	protected $gateway;
 
 
 	/**
-	 * Construct the editor.
+	 * Constructs the editor.
 	 *
 	 * @since 4.3.0
-	 * @param \SV_WC_Payment_Gateway_Direct the gateway object
+	 *
+	 * @param SV_WC_Payment_Gateway_Direct the gateway object
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Direct $gateway ) {
 
@@ -304,10 +305,11 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 	 * See Authorize.net CIM for an example.
 	 *
 	 * @since 4.3.0
+	 *
 	 * @param int $user_id the user ID
 	 * @param string $token_id the token ID
 	 * @param array $data the token data
-	 * @return \SV_WC_Payment_Gateway_Payment_Token the payment token object
+	 * @return SV_WC_Payment_Gateway_Payment_Token the payment token object
 	 */
 	protected function build_token( $user_id, $token_id, $data ) {
 
@@ -452,11 +454,12 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 		}
 
 		/**
-		 * Filter the token editor name.
+		 * Filters the token editor name.
 		 *
 		 * @since 4.3.0
+		 *
 		 * @param string $title the editor title
-		 * @param \SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
+		 * @param SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_token_editor_title', $title, $this );
 	}
@@ -481,11 +484,12 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 		$columns['actions'] = '';
 
 		/**
-		 * Filter the admin token editor columns.
+		 * Filters the admin token editor columns.
 		 *
 		 * @since 4.3.0
+		 *
 		 * @param array $columns
-		 * @param \SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
+		 * @param SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
 		 */
 		$columns = apply_filters( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_token_editor_columns', $columns, $this );
 
@@ -585,11 +589,12 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 		}
 
 		/**
-		 * Filter the admin token editor fields.
+		 * Filters the admin token editor fields.
 		 *
 		 * @since 4.3.0
+		 *
 		 * @param array $fields
-		 * @param \SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
+		 * @param SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
 		 */
 		$fields = apply_filters( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_token_editor_fields', $fields, $this );
 
@@ -662,11 +667,12 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 		$actions['save'] = __( 'Save', 'woocommerce-plugin-framework' );
 
 		/**
-		 * Filter the payment token editor actions.
+		 * Filters the payment token editor actions.
 		 *
 		 * @since 4.3.0
+		 *
 		 * @param array $actions the actions
-		 * @param \SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
+		 * @param SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_token_editor_actions', $actions, $this );
 	}
@@ -685,25 +691,30 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 		);
 
 		/**
-		 * Filter the token actions.
+		 * Filters the token actions.
 		 *
 		 * @since 4.3.0
+		 *
 		 * @param array $actions the token actions
-		 * @param \SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
+		 * @param SV_WC_Payment_Gateway_Admin_Payment_Token_Editor $editor the editor object
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_token_editor_token_actions', $actions, $this );
 	}
 
 
 	/**
-	 * Get the gateway object.
+	 * Gets the gateway object.
 	 *
 	 * @since 4.3.0
-	 * @return \SV_WC_Payment_Gateway_Direct the gateway object
+	 *
+	 * @return SV_WC_Payment_Gateway_Direct the gateway object
 	 */
 	protected function get_gateway() {
+
 		return $this->gateway;
 	}
+
+
 }
 
 endif;

--- a/woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php
+++ b/woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php
@@ -43,7 +43,8 @@
 			 * Allow actors to add info the start of the gateway system status section.
 			 *
 			 * @since 4.3.0
-			 * @param \SV_WC_Payment_Gateway $gateway
+			 *
+			 * @param SV_WC_Payment_Gateway $gateway
 			 */
 			do_action( 'wc_payment_gateway_' . $gateway->get_id() . '_system_status_start', $gateway );
 		?>

--- a/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
+++ b/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
@@ -61,7 +61,8 @@ class SV_WC_Payment_Gateway_API_Response_Message_Helper {
 	 * info.
 	 *
 	 * @since 2.2.0
-	 * @param array $message_ids array of string $message_id's which identify the message(s) to return
+	 *
+	 * @param string[] $message_ids array of string $message_id's which identify the message(s) to return
 	 * @return string a user message, combining all $message_ids
 	 */
 	public function get_user_messages( $message_ids ) {
@@ -145,7 +146,7 @@ class SV_WC_Payment_Gateway_API_Response_Message_Helper {
 		 * @since 2.2.0
 		 * @param string $message message to show to user
 		 * @param string $message_id machine code for the message, e.g. card_expired
-		 * @param \SV_WC_Payment_Gateway_API_Response_Message_Helper $this instance
+		 * @param SV_WC_Payment_Gateway_API_Response_Message_Helper $this instance
 		 */
 		return apply_filters( 'wc_payment_gateway_transaction_response_user_message', $message, $message_id, $this );
 	}

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
@@ -43,33 +43,37 @@ interface SV_WC_Payment_Gateway_API_Authorization_Response extends SV_WC_Payment
 	 * indicate that the charge will be paid by the card issuer.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return string credit card authorization code
 	 */
 	public function get_authorization_code();
 
 
 	/**
-	 * Returns the result of the AVS check
+	 * Returns the result of the AVS check.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return string result of the AVS check, if any
 	 */
 	public function get_avs_result();
 
 
 	/**
-	 * Returns the result of the CSC check
+	 * Returns the result of the CSC check.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return string result of CSC check
 	 */
 	public function get_csc_result();
 
 
 	/**
-	 * Returns true if the CSC check was successful
+	 * Returns true if the CSC check was successful.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return boolean true if the CSC check was successful
 	 */
 	public function csc_match();

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
@@ -35,9 +35,10 @@ interface SV_WC_Payment_Gateway_API_Create_Payment_Token_Response extends SV_WC_
 
 
 	/**
-	 * Returns the payment token
+	 * Returns the payment token.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return SV_WC_Payment_Gateway_Payment_Token payment token
 	 */
 	public function get_payment_token();

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
@@ -35,9 +35,10 @@ if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_W
 
 
 		/**
-		 * Returns the customer ID
+		 * Returns the customer ID.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @return string customer ID returned by the gateway
 		 */
 		public function get_customer_id();

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
@@ -35,10 +35,11 @@ interface SV_WC_Payment_Gateway_API_Get_Tokenized_Payment_Methods_Response exten
 
 
 	/**
-	 * Returns any payment tokens
+	 * Returns any payment tokens.
 	 *
 	 * @since 1.0.0
-	 * @return array array of SV_WC_Payment_Gateway_Payment_Token payment tokens, keyed by the token ID
+	 *
+	 * @return SV_WC_Payment_Gateway_Payment_Token[] array of SV_WC_Payment_Gateway_Payment_Token payment tokens, keyed by the token ID
 	 */
 	public function get_payment_tokens();
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
@@ -39,29 +39,33 @@ interface SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response ex
 
 
 	/**
-	 * Returns the card type, if available, i.e., 'visa', 'mastercard', etc
+	 * Returns the card type, if available, i.e., 'visa', 'mastercard', etc.
+	 *
+	 * @see SV_WC_Payment_Gateway_Helper::payment_type_to_name()
 	 *
 	 * @since 2.2.0
-	 * @see SV_WC_Payment_Gateway_Helper::payment_type_to_name()
-	 * @return string card type or null if not available
+	 *
+	 * @return string|null card type or null if not available
 	 */
 	public function get_card_type();
 
 
 	/**
-	 * Returns the card expiration month with leading zero, if available
+	 * Returns the card expiration month with leading zero, if available.
 	 *
 	 * @since 2.2.0
-	 * @return string card expiration month or null if not available
+	 *
+	 * @return string|null card expiration month or null if not available
 	 */
 	public function get_exp_month();
 
 
 	/**
-	 * Returns the card expiration year with four digits, if available
+	 * Returns the card expiration year with four digits, if available.
 	 *
 	 * @since 2.2.0
-	 * @return string card expiration year or null if not available
+	 *
+	 * @return string|null card expiration year or null if not available
 	 */
 	public function get_exp_year();
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
@@ -40,19 +40,21 @@ interface SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response extends
 
 
 	/**
-	 * Returns the account type, one of 'checking' or 'savings', if available
+	 * Returns the account type, one of 'checking' or 'savings', if available.
 	 *
 	 * @since 2.2.0
+	 *
 	 * @return string account type, one of 'checking' or 'savings'
 	 */
 	public function get_account_type();
 
 
 	/**
-	 * Returns the check number used, if available
+	 * Returns the check number used, if available.
 	 *
 	 * @since 2.2.0
-	 * @return int check number, or null
+	 *
+	 * @return int|null check number, or null
 	 */
 	public function get_check_number();
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
@@ -39,39 +39,43 @@ interface SV_WC_Payment_Gateway_API_Payment_Notification_Response extends SV_WC_
 
 
 	/**
-	 * Returns the order id associated with this response
+	 * Returns the order id associated with this response.
 	 *
 	 * @since 2.1.0
-	 * @return int the order id associated with this response, or null if it could not be determined
-	 * @throws Exception if there was a serious error finding the order id
+	 *
+	 * @return int|null the order id associated with this response, or null if it could not be determined
+	 * @throws \Exception if there was a serious error finding the order id
 	 */
 	public function get_order_id();
 
 
 	/**
-	 * Returns true if the transaction was cancelled, false otherwise
+	 * Returns true if the transaction was cancelled, false otherwise.
 	 *
 	 * @since 2.1.0
+	 *
 	 * @return bool true if cancelled, false otherwise
 	 */
 	public function transaction_cancelled();
 
 
 	/**
-	 * Returns the card PAN or checking account number, if available
+	 * Returns the card PAN or checking account number, if available.
 	 *
 	 * @since 2.2.0
-	 * @return string PAN or account number or null if not available
+	 *
+	 * @return string|null PAN or account number or null if not available
 	 */
 	public function get_account_number();
 
 
 	/**
-	 * Determine if this is an IPN response.
+	 * Determines if this is an IPN response.
 	 *
 	 * Intentionally commented out to prevent fatal errors in older plugins
 	 *
 	 * @since 4.3.0
+	 *
 	 * @return bool
 	 */
 	public function is_ipn();

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
@@ -118,7 +118,7 @@ interface SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response exten
 	/**
 	 * Determines whether the overall payment tokenization was successful.
 	 *
-	 * Gatewways can check that the payment method was tokenized, and if a new
+	 * Gateways can check that the payment method was tokenized, and if a new
 	 * customer was created, that was successful.
 	 *
 	 * @since 5.0.0
@@ -153,7 +153,7 @@ interface SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response exten
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return array
+	 * @return array|SV_WC_Payment_Gateway_Payment_Token[]
 	 */
 	public function get_edited_payment_tokens();
 
@@ -163,7 +163,7 @@ interface SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response exten
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return array
+	 * @return array|SV_WC_Payment_Gateway_Payment_Token[]
 	 */
 	public function get_deleted_payment_tokens();
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
@@ -35,9 +35,10 @@ interface SV_WC_Payment_Gateway_API_Response extends SV_WC_API_Response {
 
 
 	/**
-	 * Checks if the transaction was successful
+	 * Checks if the transaction was successful.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return bool true if approved, false otherwise
 	 */
 	public function transaction_approved();
@@ -49,6 +50,7 @@ interface SV_WC_Payment_Gateway_API_Response extends SV_WC_API_Response {
 	 * did not pass a fraud check and should be reviewed.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return bool true if the transaction was held, false otherwise
 	 */
 	public function transaction_held();
@@ -59,6 +61,7 @@ interface SV_WC_Payment_Gateway_API_Response extends SV_WC_API_Response {
 	 * associated with this transaction.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return string status message
 	 */
 	public function get_status_message();
@@ -69,6 +72,7 @@ interface SV_WC_Payment_Gateway_API_Response extends SV_WC_API_Response {
 	 * associated with this transaction.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return string status code
 	 */
 	public function get_status_code();
@@ -79,6 +83,7 @@ interface SV_WC_Payment_Gateway_API_Response extends SV_WC_API_Response {
 	 * associated with this transaction.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @return string transaction id
 	 */
 	public function get_transaction_id();
@@ -100,8 +105,10 @@ interface SV_WC_Payment_Gateway_API_Response extends SV_WC_API_Response {
 	 * issue on their own, but not enough to help nefarious folks fishing for
 	 * info.
 	 *
-	 * @since 2.2.0
 	 * @see SV_WC_Payment_Gateway_API_Response_Message_Helper
+	 *
+	 * @since 2.2.0
+	 *
 	 * @return string user message, if there is one
 	 */
 	public function get_user_message();

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
@@ -82,7 +82,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_API_Request extends SV_WC_API_JSON_Request
 		 *     @var string $domainName         the verified domain name
 		 *     @var string $displayName        the merchant display name
 		 * }
-		 * @param \SV_WC_Payment_Gateway_Apple_Pay_API_Request the request object
+		 * @param SV_WC_Payment_Gateway_Apple_Pay_API_Request the request object
 		 */
 		$this->data = apply_filters( 'sv_wc_apple_pay_api_merchant_data', $data, $this );
 	}

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
@@ -67,7 +67,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_API_Response extends SV_WC_API_JSON_Respon
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return array
+	 * @return string|array
 	 */
 	public function get_merchant_session() {
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
@@ -69,9 +69,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 	 * @param string $merchant_id the merchant ID to validate
 	 * @param string $domain_name the verified domain name
 	 * @param string $display_name the merchant display name
-	 * @return \SV_WC_Payment_Gateway_Apple_Pay_API_Response the response object
-	 *
-	 * @throws \SV_WC_API_Exception
+	 * @return SV_WC_Payment_Gateway_Apple_Pay_API_Response the response object
+	 * @throws SV_WC_API_Exception
 	 */
 	public function validate_merchant( $url, $merchant_id, $domain_name, $display_name ) {
 
@@ -90,10 +89,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param \SV_WC_API_Request
-	 * @return \SV_WC_API_Response
-	 *
-	 * @throws \SV_WC_API_Exception
+	 * @param SV_WC_API_Request|object
+	 * @return SV_WC_API_Response|object
+	 * @throws SV_WC_API_Exception
 	 */
 	protected function perform_request( $request ) {
 
@@ -133,7 +131,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 	 *
 	 * @return bool
 	 *
-	 * @throws \SV_WC_API_Exception
+	 * @throws SV_WC_API_Exception
 	 */
 	protected function do_post_parse_response_validation() {
 
@@ -156,7 +154,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 	 * @since 4.7.0
 	 *
 	 * @param array $type Optional. The desired request type
-	 * @return \SV_WC_Payment_Gateway_Apple_Pay_API_Request the request object
+	 * @return SV_WC_Payment_Gateway_Apple_Pay_API_Request the request object
 	 */
 	protected function get_new_request( $type = array() ) {
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
@@ -41,7 +41,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Payment_Response extends SV_WC_API_JSON_Re
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return object
+	 * @return array
 	 */
 	public function get_payment_data() {
 
@@ -145,7 +145,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Payment_Response extends SV_WC_API_JSON_Re
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param object $contact the address to prepare
+	 * @param \stdClass|object $contact the address to prepare
 	 * @return array
 	 */
 	protected function prepare_address( $contact ) {

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -36,7 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_WC_Pa
 class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 
 
-	/** @var \SV_WC_Payment_Gateway_Apple_Pay the Apple Pay handler instance */
+	/** @var SV_WC_Payment_Gateway_Apple_Pay the Apple Pay handler instance */
 	protected $handler;
 
 
@@ -44,6 +44,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 	 * Construct the class.
 	 *
 	 * @since 4.7.0
+	 *
+	 * @param SV_WC_Payment_Gateway_Apple_Pay $handler main Apple Pay handler instance
 	 */
 	public function __construct( $handler ) {
 
@@ -218,8 +220,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 	 * @internal
 	 *
 	 * @since 4.7.0
-	 *
-	 * @return array
 	 */
 	public function add_settings() {
 		global $current_section;
@@ -240,7 +240,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 	 * @global string $current_section The current settings section.
 	 */
 	public function save_settings() {
-
 		global $current_section;
 
 		// Output the general settings

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -36,7 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_WC_Pa
 class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 
 
-	/** @var \SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance */
+	/** @var SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance */
 	protected $handler;
 
 
@@ -45,7 +45,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param \SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance
+	 * @param SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Apple_Pay $handler ) {
 
@@ -248,7 +248,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Apple_Pay
+	 * @return SV_WC_Payment_Gateway_Apple_Pay
 	 */
 	protected function get_handler() {
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -36,13 +36,13 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_WC_Pa
 class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 
-	/** @var \SV_WC_Payment_Gateway_Plugin $plugin the gateway plugin instance */
+	/** @var SV_WC_Payment_Gateway_Plugin $plugin the gateway plugin instance */
 	protected $plugin;
 
-	/** @var \SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance */
+	/** @var SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance */
 	protected $handler;
 
-	/** @var \SV_WC_Payment_Gateway $gateway the gateway instance */
+	/** @var SV_WC_Payment_Gateway $gateway the gateway instance */
 	protected $gateway;
 
 
@@ -51,8 +51,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param \SV_WC_Payment_Gateway_Plugin $plugin the gateway plugin instance
-	 * @param \SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance
+	 * @param SV_WC_Payment_Gateway_Plugin $plugin the gateway plugin instance
+	 * @param SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler instance
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Plugin $plugin, SV_WC_Payment_Gateway_Apple_Pay $handler ) {
 
@@ -319,7 +319,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway
+	 * @return SV_WC_Payment_Gateway
 	 */
 	protected function get_gateway() {
 
@@ -332,7 +332,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Plugin
+	 * @return SV_WC_Payment_Gateway_Plugin
 	 */
 	protected function get_plugin() {
 
@@ -344,7 +344,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Apple_Pay
+	 * @return SV_WC_Payment_Gateway_Apple_Pay
 	 */
 	protected function get_handler() {
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -42,8 +42,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 	 * @since 4.7.0
 	 *
 	 * @param \WC_Cart $cart cart object
-	 *
-	 * @throws \SV_WC_Payment_Gateway_Exception
+	 * @return \WC_Order|void
+	 * @throws SV_WC_Payment_Gateway_Exception
+	 * @throws \Exception
 	 */
 	public static function create_order( \WC_Cart $cart ) {
 
@@ -154,8 +155,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 	 *
 	 * @param array $order_data the order data
 	 * @return \WC_Order
-	 *
-	 * @throws \SV_WC_Payment_Gateway_Exception
+	 * @throws SV_WC_Payment_Gateway_Exception
 	 */
 	public static function get_order_object( $order_data ) {
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -95,7 +95,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * @since 4.7.0
 	 *
 	 * @return array
-	 * @throws \SV_WC_Payment_Gateway_Exception
+	 * @throws \Exception
 	 */
 	public function process_payment() {
 
@@ -170,7 +170,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * @since 4.7.0
 	 *
 	 * @param int $user_id WordPress user ID
-	 * @param \SV_WC_Payment_Gateway_Apple_Pay_Payment_Response $payment_response payment response object
+	 * @param SV_WC_Payment_Gateway_Apple_Pay_Payment_Response $payment_response payment response object
 	 */
 	protected function update_customer_addresses( $user_id, SV_WC_Payment_Gateway_Apple_Pay_Payment_Response $payment_response ) {
 
@@ -218,13 +218,12 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * Gets a single product payment request.
 	 *
 	 * @since 4.7.0
-	 * @see \SV_WC_Payment_Gateway_Apple_Pay::build_payment_request()
+	 * @see SV_WC_Payment_Gateway_Apple_Pay::build_payment_request()
 	 *
 	 * @param \WC_Product $product product object
 	 * @param bool $in_cart whether to generate a cart for this request
 	 * @return array
-	 *
-	 * @throws \SV_WC_Payment_Gateway_Exception
+	 * @throws SV_WC_Payment_Gateway_Exception
 	 */
 	public function get_product_payment_request( \WC_Product $product, $in_cart = false ) {
 
@@ -286,12 +285,11 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * Gets a payment request based on WooCommerce cart data.
 	 *
 	 * @since 4.7.0
-	 * @see \SV_WC_Payment_Gateway_Apple_Pay::build_payment_request()
+	 * @see SV_WC_Payment_Gateway_Apple_Pay::build_payment_request()
 	 *
 	 * @param \WC_Cart $cart cart object
 	 * @return array
-	 *
-	 * @throws \SV_WC_Payment_Gateway_Exception
+	 * @throws SV_WC_Payment_Gateway_Exception
 	 */
 	public function get_cart_payment_request( \WC_Cart $cart ) {
 
@@ -340,8 +338,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * @since 4.7.0
 	 *
 	 * @return array
-	 *
-	 * @throws \SV_WC_Payment_Gateway_Exception
+	 * @throws SV_WC_Payment_Gateway_Exception
 	 */
 	public function recalculate_totals() {
 
@@ -526,6 +523,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 *     @type float $fees     fees total
 	 *     @type float $taxes    tax total
 	 * }
+	 * @return array
 	 */
 	public function build_payment_request_lines( $totals ) {
 
@@ -625,7 +623,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Apple_Pay_Payment_Response|false
+	 * @return false|SV_WC_Payment_Gateway_Apple_Pay_Payment_Response|false
 	 */
 	public function get_stored_payment_response() {
 
@@ -643,6 +641,8 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * Stores payment request data for later use.
 	 *
 	 * @since 4.7.0
+	 *
+	 * @param mixed|array $data
 	 */
 	public function store_payment_request( $data ) {
 
@@ -654,6 +654,8 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * Stores payment response data for later use.
 	 *
 	 * @since 4.7.0
+	 *
+	 * @param mixed|array $data
 	 */
 	public function store_payment_response( $data ) {
 
@@ -736,7 +738,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Apple_Pay_API
+	 * @return SV_WC_Payment_Gateway_Apple_Pay_API
 	 */
 	public function get_api() {
 
@@ -968,7 +970,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 		 * @since 4.7.0
 		 *
 		 * @param array $networks the supported networks
-		 * @param \SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler
+		 * @param SV_WC_Payment_Gateway_Apple_Pay $handler the Apple Pay handler
 		 */
 		return apply_filters( 'sv_wc_apple_pay_supported_networks', array_values( $networks ), $this );
 	}
@@ -1002,7 +1004,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway|null
+	 * @return SV_WC_Payment_Gateway|null
 	 */
 	public function get_processing_gateway() {
 
@@ -1032,7 +1034,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Plugin
+	 * @return SV_WC_Payment_Gateway_Plugin
 	 */
 	public function get_plugin() {
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -124,7 +124,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		 *
 		 * @since 4.3.0
 		 * @param bool $is_valid true for validation to pass
-		 * @param \SV_WC_Payment_Gateway_Direct $this direct gateway class instance
+		 * @param SV_WC_Payment_Gateway_Direct $this direct gateway class instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_validate_credit_card_fields', $is_valid, $this );
 	}
@@ -322,19 +322,22 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		 *
 		 * @since 4.3.0
 		 * @param bool $is_valid true for validation to pass
-		 * @param \SV_WC_Payment_Gateway_Direct $this direct gateway class instance
+		 * @param SV_WC_Payment_Gateway_Direct $this direct gateway class instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_validate_echeck_fields', $is_valid, $this );
 	}
 
 
 	/**
-	 * Handles payment processing
+	 * Handles payment processing.
+	 *
+	 * @see WC_Payment_Gateway::process_payment()
 	 *
 	 * @since 1.0.0
-	 * @see WC_Payment_Gateway::process_payment()
+	 *
 	 * @param int|string $order_id
 	 * @return array associative array with members 'result' and 'redirect'
+	 * @throws \Exception
 	 */
 	public function process_payment( $order_id ) {
 
@@ -629,18 +632,18 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		 *
 		 * @since 1.0.0
 		 * @param \WC_Order $order order object
-		 * @param \SV_WC_Payment_Gateway_Direct $this instance
+		 * @param SV_WC_Payment_Gateway_Direct $this instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_get_order', $order, $this );
 	}
 
 
 	/**
-	 * Performs a check transaction for the given order and returns the
-	 * result
+	 * Performs a check transaction for the given order and returns the result.
 	 *
 	 * @since 1.0.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @return SV_WC_Payment_Gateway_API_Response the response
 	 * @throws SV_WC_Plugin_Exception network timeouts, etc
 	 */
@@ -675,10 +678,11 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 			 * is approved.
 			 *
 			 * @since 4.1.0
+			 *
 			 * @param string $message order note
 			 * @param \WC_Order $order order object
-			 * @param \SV_WC_Payment_Gateway_API_Response $response transaction response
-			 * @param \SV_WC_Payment_Gateway_Direct $this instance
+			 * @param SV_WC_Payment_Gateway_API_Response $response transaction response
+			 * @param SV_WC_Payment_Gateway_Direct $this instance
 			 */
 			$message = apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_check_transaction_approved_order_note', $message, $order, $response, $this );
 
@@ -692,11 +696,11 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Performs a credit card transaction for the given order and returns the
-	 * result
+	 * Performs a credit card transaction for the given order and returns the result.
 	 *
 	 * @since 1.0.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response optional credit card transaction response
 	 * @return SV_WC_Payment_Gateway_API_Response the response
 	 * @throws SV_WC_Plugin_Exception network timeouts, etc
@@ -759,10 +763,11 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 			 * is approved.
 			 *
 			 * @since 4.1.0
+			 *
 			 * @param string $message order note
 			 * @param \WC_Order $order order object
-			 * @param \SV_WC_Payment_Gateway_API_Response $response transaction response
-			 * @param \SV_WC_Payment_Gateway_Direct $this instance
+			 * @param SV_WC_Payment_Gateway_API_Response $response transaction response
+			 * @param SV_WC_Payment_Gateway_Direct $this instance
 			 */
 			$message = apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_credit_card_transaction_approved_order_note', $message, $order, $response, $this );
 
@@ -955,7 +960,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 			 *
 			 * @param string $token_id new token ID
 			 * @param int $user_id user ID
-			 * @param \SV_WC_Payment_Gateway_API_Response $response API response object
+			 * @param SV_WC_Payment_Gateway_API_Response $response API response object
 			 */
 			do_action( 'wc_payment_gateway_' . $this->get_id() . '_payment_method_added', $token->get_id(), $order->get_user_id(), $response );
 
@@ -989,9 +994,9 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		 *   @type string $message notice message to render
 		 *   @type bool $success true to redirect to my account, false to stay on page
 		 * }
-		 * @param \SV_WC_Payment_Gateway_API_Create_Payment_Token_Response $response instance
+		 * @param SV_WC_Payment_Gateway_API_Create_Payment_Token_Response $response instance
 		 * @param \WC_Order $order order instance
-		 * @param \SV_WC_Payment_Gateway_Direct $this direct gateway instance
+		 * @param SV_WC_Payment_Gateway_Direct $this direct gateway instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_add_payment_method_transaction_result', $result, $response, $order, $this );
 	}
@@ -1116,7 +1121,8 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * + transaction environment
 	 *
 	 * @since 4.0.0
-	 * @param \SV_WC_Payment_Gateway_API_Create_Payment_Token_Response $response
+	 *
+	 * @param SV_WC_Payment_Gateway_API_Create_Payment_Token_Response $response
 	 */
 	protected function add_add_payment_method_transaction_data( $response ) {
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -208,16 +208,17 @@ class SV_WC_Payment_Gateway_Helper {
 
 
 	/**
-	 * Get the known card types and their variations.
+	 * Gets the known card types and their variations.
 	 *
 	 * Returns the card types in the format:
 	 *
 	 * 'mastercard' {
-	 *     'name'      => 'MasterCard',
-	 *     'varations' => array( 'mc' ),
+	 *     'name'       => 'MasterCard',
+	 *     'variations' => array( 'mc' ),
 	 * }
 	 *
 	 * @since 4.5.0
+	 *
 	 * @return array
 	 */
 	public static function get_card_types() {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -83,14 +83,15 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Process the payment by redirecting customer to the WooCommerce pay page
-	 * or the gatway hosted pay page
+	 * Processes the payment by redirecting customer to the WooCommerce pay page or the gateway hosted pay page.
+	 *
+	 * @see \WC_Payment_Gateway::process_payment()
 	 *
 	 * @since 1.0.0
-	 * @see WC_Payment_Gateway::process_payment()
+	 *
 	 * @param int $order_id the order to process
 	 * @return array with keys 'result' and 'redirect'
-	 * @throws \SV_WC_Payment_Gateway_Exception if payment processing must be halted, and a message displayed to the customer
+	 * @throws SV_WC_Payment_Gateway_Exception if payment processing must be halted, and a message displayed to the customer
 	 */
 	public function process_payment( $order_id ) {
 
@@ -217,9 +218,11 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * that collect some or all payment information on-site, and POST the
 	 * entered information to a remote server for processing
 	 *
-	 * @since 2.2.0
 	 * @see SV_WC_Payment_Gateway_Hosted::use_auto_form_post()
-	 * @param WC_Order $order the order object
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param \WC_Order $order the order object
 	 * @param array $request_params associative array of request parameters
 	 */
 	public function render_pay_page_form( $order, $request_params ) {
@@ -345,7 +348,8 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * Returns the gateway hosted pay page parameters, if any
 	 *
 	 * @since 2.1.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @return array associative array of name-value parameters
 	 */
 	protected function get_hosted_pay_page_params( $order ) {
@@ -361,8 +365,9 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * This method may be called more than once during a single request.
 	 *
 	 * @since 2.1.0
+	 *
 	 * @see SV_WC_Payment_Gateway_Hosted::get_hosted_pay_page_params()
-	 * @param WC_Order $order optional order object, defaults to null
+	 * @param \WC_Order $order optional order object, defaults to null
 	 * @return string hosted pay page url, or false if it could not be determined
 	 */
 	abstract public function get_hosted_pay_page_url( $order = null );
@@ -372,6 +377,8 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * Handle a payment notification request.
 	 *
 	 * @since 4.3.0
+	 *
+	 * @throws \Exception
 	 */
 	public function handle_transaction_response_request() {
 
@@ -423,6 +430,8 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 *
 	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response response object
 	 * @return \WC_Order
+	 * @throws SV_WC_Payment_Gateway_Exception
+	 * @throws \Exception
 	 */
 	protected function get_order_from_response( $response ) {
 
@@ -488,8 +497,8 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 *
 	 * @since 4.3.0
 	 * @param \WC_Order $order the order object
-	 * @param \SV_WC_Payment_Gateway_API_Payment_Notification_Response the response object
-	 * @throws \SV_WC_Payment_Gateway_Exception
+	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response the response object
+	 * @throws SV_WC_Payment_Gateway_Exception
 	 */
 	protected function validate_transaction_response( $order, $response ) {
 
@@ -513,7 +522,8 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * @since 2.1.0
 	 *
 	 * @param \WC_Order $order the order
-	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response transaction response
+	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response transaction response
+	 * @throws \Exception
 	 */
 	protected function process_transaction_response( $order, $response ) {
 
@@ -524,7 +534,7 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 				$order = $this->process_tokenization_response( $order, $response );
 			}
 
-			// always add transasaction data to the order for approved and held transactions
+			// always add transaction data to the order for approved and held transactions
 			$this->add_transaction_data( $order, $response );
 
 			// let gateways easily add their own data
@@ -564,6 +574,7 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * @param \WC_Order $order order object
 	 * @param SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response $response response object
 	 * @return \WC_Order order object
+	 * @throws \Exception
 	 */
 	protected function process_tokenization_response( \WC_Order $order, $response ) {
 
@@ -665,7 +676,7 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * @since 2.1.0
 	 *
 	 * @param \WC_Order $order the order object
-	 * @param \WC_Paytrail_API_Payment_Response $response the response object
+	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
 	 */
 	protected function do_transaction_approved( \WC_Order $order, $response ) {
 
@@ -689,7 +700,7 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 * @since 4.3.0
 	 *
 	 * @param \WC_Order $order the order object
-	 * @param \SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
+	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
 	 */
 	protected function do_transaction_held( \WC_Order $order, $response ) {
 
@@ -707,12 +718,12 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Handle a cancelled transaction response.
+	 * Handles a cancelled transaction response.
 	 *
 	 * @since 4.3.0
 	 *
 	 * @param \WC_Order $order the order object
-	 * @param \SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
+	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
 	 */
 	protected function do_transaction_cancelled( \WC_Order $order, $response ) {
 
@@ -730,12 +741,12 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Handle a failed transaction response.
+	 * Handles a failed transaction response.
 	 *
 	 * @since 4.3.0
 	 *
 	 * @param \WC_Order $order the order object
-	 * @param \SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
+	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
 	 */
 	protected function do_transaction_failed( \WC_Order $order, $response ) {
 
@@ -753,13 +764,14 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Handle an invalid transaction response.
+	 * Handles an invalid transaction response.
 	 *
 	 * i.e. the order has already been paid or was not found
 	 *
 	 * @since 4.3.0
+	 *
 	 * @param \WC_Order $order Optional. The order object
-	 * @param \SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
+	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
 	 */
 	protected function do_invalid_transaction_response( $order = null, $response ) {
 
@@ -829,12 +841,11 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Log pay page form submission request
+	 * Logs pay page form submission request.
 	 *
 	 * @since 2.1.0
-	 * @param array $request the request data associative array, which should
-	 *        include members 'method', 'uri', 'body'
-	 * @param object $response optional response object
+	 *
+	 * @param array $request the request data associative array, which should include members 'method', 'uri', 'body'
 	 */
 	public function log_hosted_pay_page_request( $request ) {
 
@@ -850,10 +861,11 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Log IPN/redirect-back transaction response request to the log file
+	 * Logs IPN/redirect-back transaction response request to the log file.
 	 *
 	 * @since 2.1.0
-	 * @param array $response the request data
+	 *
+	 * @param array|string $response the request data
 	 * @param string $message optional message string with a %s to hold the
 	 *        response data.  Defaults to 'Request %s'
 	 * $response

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -42,13 +42,13 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	/** @var SV_WC_Payment_Gateway_Plugin */
 	protected $plugin;
 
-	/** @var array of SV_WC_Payment_Gateway_Token objects */
+	/** @var SV_WC_Payment_Gateway_Payment_Token[] array of token objects */
 	protected $tokens;
 
-	/** @var array of credit card SV_WC_Payment_Gateway_Token objects */
+	/** @var SV_WC_Payment_Gateway_Payment_Token[] array of token objects */
 	protected $credit_card_tokens;
 
-	/** @var array of eCheck SV_WC_Payment_Gateway_Token objects */
+	/** @var SV_WC_Payment_Gateway_Payment_Token[] array of token objects */
 	protected $echeck_tokens;
 
 	/** @var bool true if there are tokens */
@@ -187,7 +187,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			 * Fired before the My Payment Methods table HTML is rendered.
 			 *
 			 * @since 4.0.0
-			 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+			 *
+			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 			 */
 			do_action( 'wc_' . $this->get_plugin()->get_id() . '_before_my_payment_method_table', $this );
 
@@ -199,7 +200,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			 * Fired after the My Payment Methods table HTML is rendered.
 			 *
 			 * @since 4.0.0
-			 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+			 *
+			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 			 */
 			do_action( 'wc_' . $this->get_plugin()->get_id() . '_after_my_payment_method_table', $this );
 
@@ -277,8 +279,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * present.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $message no methods text
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		/* translators: Payment method as in a specific credit card, eCheck or bank account */
 		$html = '<p>' . apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_no_payment_methods_text', esc_html__( 'You do not have any saved payment methods.', 'woocommerce-plugin-framework' ), $this ) . '</p>';
@@ -290,8 +293,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * present.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html no methods HTML
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_no_payment_methods_html', $html, $this );
 	}
@@ -314,8 +318,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * Allow actors to modify the my payment methods table heading text.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $message table heading text
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		/* translators: Payment method as in a specific credit card, eCheck or bank account */
 		$title = apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_title', esc_html__( 'My Payment Methods', 'woocommerce-plugin-framework' ), $this );
@@ -337,8 +342,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * Allow actors to modify the table title HTML.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html table title HTML
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_title_html', $html, $this );
 	}
@@ -366,8 +372,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * Allow actors to modify the table HTML.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html table HTML
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_html', $html, $this );
 	}
@@ -395,8 +402,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * Allow actors to modify the table head HTML.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html table head HTML
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_head_html', $html, $this );
 	}
@@ -429,7 +437,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 *     @type string $expiry
 		 *     @type string $actions
 		 * }
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $headers, $this );
 	}
@@ -478,17 +486,20 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * Allow actors to modify the table body HTML.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html table body HTML
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_body_html', $html, $this );
 	}
 
 
 	/**
-	 * Return the table body row HTML, each row represents a single payment method
+	 * Returns the table body row HTML, each row represents a single payment method.
 	 *
 	 * @since 4.0.0
+	 *
+	 * @param SV_WC_Payment_Gateway_Payment_Token[] $tokens token objects
 	 * @return string table tbody > tr HTML
 	 */
 	protected function get_table_body_row_html( $tokens ) {
@@ -532,9 +543,10 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * Allow actors to modify the table row HTML.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html table row HTML
-		 * @param array $tokens simple array of SV_WC_Payment_Gateway_Payment_Token objects
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_Payment_Token[] $tokens simple array of token objects
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_row_html', $html, $tokens, $this );
 	}
@@ -544,7 +556,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 * Return the payment method data for a given token
 	 *
 	 * @since 4.0.0
-	 * @param \SV_WC_Payment_Gateway_Payment_Token the token object
+	 *
+	 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
 	 * @return array payment method data suitable for HTML output
 	 */
 	protected function get_table_body_row_data( $token ) {
@@ -567,13 +580,14 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * Allow actors to modify the table body row data.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param array $methods {
 		 *     @type string $title payment method title
 		 *     @type string $expiry payment method expiry
 		 *     @type string $actions actions for payment method
 		 * }
 		 * @param array $token simple array of SV_WC_Payment_Gateway_Payment_Token objects
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data', $method, $token, $this );
 	}
@@ -833,8 +847,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 *     @type string $class action button class
 		 *     @type string $name action button name
 		 * }
-		 * @param \SV_WC_Payment_Gateway_Payment_Token $token
-		 * @param \SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 * @param SV_WC_Payment_Gateway_Payment_Token $token
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
 		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_method_actions', $actions, $token, $this );
 	}
@@ -1039,9 +1053,11 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 * using filters
 	 *
 	 * @since 4.0.0
-	 * @return \SV_WC_Payment_Gateway_Plugin
+	 *
+	 * @return SV_WC_Payment_Gateway_Plugin
 	 */
 	public function get_plugin() {
+
 		return $this->plugin;
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -49,10 +49,11 @@ class SV_WC_Payment_Gateway_Payment_Form {
 
 
 	/**
-	 * Setup Class
+	 * Sets up class.
 	 *
-	 * @param \SV_WC_Payment_Gateway|\SV_WC_Payment_Gateway_Direct $gateway gateway for form
 	 * @since 4.0.0
+	 *
+	 * @param SV_WC_Payment_Gateway|SV_WC_Payment_Gateway_Direct $gateway gateway for form
 	 */
 	public function __construct( $gateway ) {
 
@@ -67,9 +68,10 @@ class SV_WC_Payment_Gateway_Payment_Form {
 
 
 	/**
-	 * Add hooks for rendering the payment form
+	 * Adds hooks for rendering the payment form.
 	 *
 	 * @see SV_WC_Payment_Gateway_Payment_Form::render()
+	 *
 	 * @since 4.0.0
 	 */
 	protected function add_hooks() {
@@ -137,12 +139,14 @@ class SV_WC_Payment_Gateway_Payment_Form {
 
 
 	/**
-	 * Return the gateway for this form
+	 * Returns the gateway for this form.
 	 *
 	 * @since 4.0.0
-	 * @return \SV_WC_Payment_Gateway|\SV_WC_Payment_Gateway_Direct
+	 *
+	 * @return SV_WC_Payment_Gateway|SV_WC_Payment_Gateway_Direct
 	 */
 	public function get_gateway() {
+
 		return $this->gateway;
 	}
 
@@ -184,8 +188,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters whether tokenization is allowed for the payment form.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param bool $tokenization_allowed
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_tokenization_allowed', $tokenization_allowed, $this );
 	}
@@ -216,8 +221,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters whether tokenization is forced for the payment form.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param bool $tokenization_forced
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_tokenization_forced', $tokenization_forced, $this );
 	}
@@ -268,8 +274,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * for a non-standard payment type (like PayPal Express)
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param array $fields in the format supported by woocommerce_form_fields()
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_default_payment_form_fields', $fields, $this );
 	}
@@ -355,8 +362,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the default field data for credit card gateways.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param array $fields in the format supported by woocommerce_form_fields()
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_default_credit_card_fields', $fields, $this );
 	}
@@ -439,8 +447,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the default field data for eCheck gateways.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param array $fields in the format supported by woocommerce_form_fields()
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_default_echeck_fields', $fields, $this );
 	}
@@ -472,8 +481,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the HTML rendered for payment form description.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_description', $description, $this );
 	}
@@ -497,8 +507,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the HTML rendered for the same eCheck image.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_sample_check_html', $html, $this );
 	}
@@ -530,11 +541,12 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		/**
 		 * Payment Gateway Payment Form Saved Payment Methods HTML.
 		 *
-		 * Filters the HTML rendered for the entired saved payment methods section.
+		 * Filters the HTML rendered for the entire saved payment methods section.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_saved_payment_methods_html', $html, $this );
 	}
@@ -571,8 +583,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the HTML rendered for the "Manage Payment Methods" button.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_manage_payment_methods_button_html', $html, $this );
 	}
@@ -610,8 +623,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the HTML rendered for a saved payment method, like "Amex ending in 6666".
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_payment_method_html', $html, $token, $this );
 	}
@@ -669,9 +683,10 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the text/HTML rendered for a saved payment method, like "Amex ending in 6666".
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $title
-		 * @param \SV_WC_Payment_Gateway_Payment_Token $token
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Token $token
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_payment_method_title', $title, $token, $this );
 	}
@@ -706,7 +721,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 *
 		 * @since 4.0.0
 		 * @param string $html
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_new_payment_method_input_html', $html, $this );
 	}
@@ -737,12 +752,12 @@ class SV_WC_Payment_Gateway_Payment_Form {
 				/**
 				 * Payment Form Default Tokenize Payment Method Checkbox to Checked Filter.
 				 *
-				 * Allow actors to default the tokenize payment method checkbox state to
-				 * checked.
+				 * Allow actors to default the tokenize payment method checkbox state to checked.
 				 *
 				 * @since 4.2.0
+				 *
 				 * @param bool $checked default false, set to true to change the checkbox state to checked
-				 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+				 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 				 */
 				$checked = apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_default_tokenize_payment_method_checkbox_to_checked', false, $this );
 
@@ -755,6 +770,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 				 * text rendered on the payment form on the checkout page.
 				 *
 				 * @since 4.0.0
+				 *
 				 * @param string $checkbox_text checkbox text
 				 */
 				/* translators: account as in customer's account on the eCommerce site */
@@ -769,8 +785,9 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * Filters the HTML rendered for the "save payment method" checkbox.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $html
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		return apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_save_payment_method_checkbox_html', $html, $this );
 	}
@@ -797,7 +814,8 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * @hooked SV_WC_Payment_Gateway_Payment_Form::render_fieldset_start() - 30 (outputs opening fieldset tag and starting payment fields div)
 		 *
 		 * @since 4.0.0
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 *
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		do_action( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_start', $this );
 
@@ -810,7 +828,8 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * @hooked SV_WC_Payment_Gateway_Payment_Form::render_payment_fields() - 0 (outputs payment fields like account number, expiry, etc)
 		 *
 		 * @since 4.0.0
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 *
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		do_action( 'wc_' . $this->get_gateway()->get_id() . '_payment_form', $this );
 
@@ -824,7 +843,8 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 * @hooked SV_WC_Payment_Gateway_Payment_Form::render_js() - 5 (outputs JS for instantiating payment form JS class)
 		 *
 		 * @since 4.0.0
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 *
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		do_action( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_end', $this );
 	}
@@ -973,7 +993,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		 *   @type string $type gateway payment type (e.g. 'credit-card')
 		 *   @type bool $csc_required true if CSC field display is required
 		 * }
-		 * @param \SV_WC_Payment_Gateway_Payment_Form $this payment form instance
+		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
 		 */
 		$args = apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_js_args', $args, $this );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -626,7 +626,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * Returns true if on the pay page and this is the currently selected gateway
 	 *
 	 * @since 1.0.0
-	 * @return mixed true if on pay page and is currently selected gateways, false if on pay page and not the selected gateway, null otherwise
+	 *
+	 * @return null|bool true if on pay page and is currently selected gateways, false if on pay page and not the selected gateway, null otherwise
 	 */
 	public function is_pay_page_gateway() {
 
@@ -728,10 +729,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Get the payment form class instance
+	 * Gets the payment form class instance.
 	 *
 	 * @since 4.1.2
-	 * @return \SV_WC_Payment_Gateway_Payment_Form
+	 *
+	 * @return SV_WC_Payment_Gateway_Payment_Form
 	 */
 	public function get_payment_form_instance() {
 
@@ -881,7 +883,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * initialized.
 		 *
 		 * @since 4.1.0
-		 * @param \SV_WC_Payment_Gateway_Direct $this instance
+		 *
+		 * @param SV_WC_Payment_Gateway_Direct $this instance
 		 */
 		do_action( 'wc_payment_gateway_' . $this->get_id() . '_init_integrations', $this );
 	}
@@ -905,7 +908,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * @since 5.0.0
 	 *
 	 * @param string $id the integration ID, e.g. subscriptions
-	 * @return \SV_WC_Payment_Gateway_Integration|null
+	 * @return SV_WC_Payment_Gateway_Integration|null
 	 */
 	public function get_integration( $id ) {
 
@@ -920,7 +923,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Integration_Subscriptions
+	 * @return SV_WC_Payment_Gateway_Integration_Subscriptions
 	 */
 	protected function build_subscriptions_integration() {
 
@@ -933,7 +936,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Integration_Subscriptions|null
+	 * @return SV_WC_Payment_Gateway_Integration_Subscriptions|null
 	 */
 	public function get_subscriptions_integration() {
 
@@ -948,7 +951,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Integration_Pre_Orders
+	 * @return SV_WC_Payment_Gateway_Integration_Pre_Orders
 	 */
 	protected function build_pre_orders_integration() {
 
@@ -961,7 +964,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @return \SV_WC_Payment_Gateway_Integration_Pre_Orders|null
+	 * @return SV_WC_Payment_Gateway_Integration_Pre_Orders|null
 	 */
 	public function get_pre_orders_integration() {
 
@@ -1072,7 +1075,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * @since 4.7.0
 	 *
 	 * @param \WC_Order the order object
-	 * @param \SV_WC_Payment_Gateway_Apple_Pay_Payment_Response authorized payment response
+	 * @param SV_WC_Payment_Gateway_Apple_Pay_Payment_Response authorized payment response
 	 * @return \WC_Order
 	 */
 	public function get_order_for_apple_pay( \WC_Order $order, SV_WC_Payment_Gateway_Apple_Pay_Payment_Response $response ) {
@@ -1361,10 +1364,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Display settings page with some additional javascript for hiding conditional fields
+	 * Displays settings page with some additional javascript for hiding conditional fields.
+	 *
+	 * @see \WC_Settings_API::admin_options()
 	 *
 	 * @since 1.0.0
-	 * @see WC_Settings_API::admin_options()
 	 */
 	public function admin_options() {
 
@@ -1683,14 +1687,15 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		$order = $this->get_order_with_unique_transaction_ref( $order );
 
 		/**
-		 * Filter the base order for a payment transaction
+		 * Filters the base order for a payment transaction.
 		 *
 		 * Actors can use this filter to adjust or add additional information to
 		 * the order object that gateways use for processing transactions.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param \WC_Order $order order object
-		 * @param \SV_WC_Payment_Gateway $this payment gateway instance
+		 * @param SV_WC_Payment_Gateway $this payment gateway instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_get_order_base', $order, $this );
 	}
@@ -1705,6 +1710,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @param \WC_Order $order order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response response object
+	 * @throws \Exception
 	 */
 	protected function complete_payment( \WC_Order $order, SV_WC_Payment_Gateway_API_Response $response ) {
 
@@ -1836,13 +1842,14 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Process refund
+	 * Processes a refund.
 	 *
 	 * @since 3.1.0
+	 *
 	 * @param int $order_id order being refunded
 	 * @param float $amount refund amount
 	 * @param string $reason user-entered reason text for refund
-	 * @return bool|WP_Error true on success, or a WP_Error object on failure/error
+	 * @return bool|\WP_Error true on success, or a WP_Error object on failure/error
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
 
@@ -1929,10 +1936,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * refund-specific data
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order|int $order order being processed
+	 *
+	 * @param \WC_Order|int $order order being processed
 	 * @param float $amount refund amount
 	 * @param string $reason optional refund reason text
-	 * @return WC_Order object with refund information attached
+	 * @return \WC_Order|\WP_Error object with refund information attached
 	 */
 	protected function get_order_for_refund( $order, $amount, $reason ) {
 
@@ -1956,21 +1964,23 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * Allow actors to modify the order object used for refund transactions.
 		 *
 		 * @since 3.1.0
-		 * @param \WC_Order $order order object
-		 * @param \SV_WC_Payment_Gateway $this instance
+		 *
+		 * @param \WC_Order|\WP_Error $order order object
+		 * @param SV_WC_Payment_Gateway $this instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_get_order_for_refund', $order, $this );
 	}
 
 
 	/**
-	 * Adds the standard refund transaction data to the order
+	 * Adds the standard refund transaction data to the order.
 	 *
 	 * Note that refunds can be performed multiple times for a single order so
 	 * transaction IDs keys are not unique
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response transaction response
 	 */
 	protected function add_refund_data( \WC_Order $order, $response ) {
@@ -1986,10 +1996,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Adds any gateway-specific data to the order after a refund is performed
+	 * Adds any gateway-specific data to the order after a refund is performed.
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response the transaction response
 	 */
 	protected function add_payment_gateway_refund_data( \WC_Order $order, $response ) {
@@ -1998,10 +2009,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Adds an order note with the amount and (optional) refund transaction ID
+	 * Adds an order note with the amount and (optional) refund transaction ID.
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order order object
+	 *
+	 * @param \WC_Order $order order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response transaction response
 	 */
 	protected function add_refund_order_note( \WC_Order $order, $response ) {
@@ -2023,12 +2035,13 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Build the WP_Error object for a failed refund
+	 * Builds the WP_Error object for a failed refund.
 	 *
 	 * @since 3.1.0
+	 *
 	 * @param int|string $error_code error code
 	 * @param string $error_message error message
-	 * @return WP_Error suitable for returning from the process_refund() method
+	 * @return \WP_Error suitable for returning from the process_refund() method
 	 */
 	protected function get_refund_failed_wp_error( $error_code, $error_message ) {
 
@@ -2058,7 +2071,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * amount has been refunded.
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order order object
+	 *
+	 * @param \WC_Order $order order object
 	 */
 	public function mark_order_as_refunded( $order ) {
 
@@ -2095,8 +2109,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * charge that has not yet settled (e.g. Authorize.net AIM/CIM)
 	 *
 	 * @since 4.0.0
+	 *
 	 * @param \WC_Order $order order
-	 * @param \SV_WC_Payment_Gateway_API_Response $response refund response
+	 * @param SV_WC_Payment_Gateway_API_Response $response refund response
 	 * @return boolean true if a void should be performed for the given order/response
 	 */
 	protected function maybe_void_instead_of_refund( $order, $response ) {
@@ -2106,11 +2121,12 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Process a void
+	 * Processes a void order.
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order order object (with refund class member already added)
-	 * @return bool|WP_Error true on success, or a WP_Error object on failure/error
+	 *
+	 * @param \WC_Order $order order object (with refund class member already added)
+	 * @return bool|\WP_Error true on success, or a WP_Error object on failure/error
 	 */
 	protected function process_void( \WC_Order $order ) {
 
@@ -2157,10 +2173,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Adds the standard void transaction data to the order
+	 * Adds the standard void transaction data to the order.
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response transaction response
 	 */
 	protected function add_void_data( \WC_Order $order, $response ) {
@@ -2176,10 +2193,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Adds any gateway-specific data to the order after a void is performed
+	 * Adds any gateway-specific data to the order after a void is performed.
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response the transaction response
 	 */
 	protected function add_payment_gateway_void_data( \WC_Order $order, $response ) {
@@ -2188,12 +2206,13 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Build the WP_Error object for a failed void
+	 * Builds the WP_Error object for a failed void.
 	 *
 	 * @since 3.1.0
+	 *
 	 * @param int|string $error_code error code
 	 * @param string $error_message error message
-	 * @return WP_Error suitable for returning from the process_refund() method
+	 * @return \WP_Error suitable for returning from the process_refund() method
 	 */
 	protected function get_void_failed_wp_error( $error_code, $error_message ) {
 
@@ -2219,11 +2238,14 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Mark an order as voided. Because WC has no status for "void", we use
-	 * refunded.
+	 * Marks an order as voided.
+	 *
+	 * Because WC has no status for "void", we use refunded.
 	 *
 	 * @since 3.1.0
-	 * @param WC_Order $order order object
+	 *
+	 * @param \WC_Order $order order object
+	 * @param SV_WC_Payment_Gateway_API_Response $response object
 	 */
 	public function mark_order_as_voided( $order, $response ) {
 
@@ -2280,11 +2302,12 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Returns the $order object with a unique transaction ref member added
+	 * Returns the $order object with a unique transaction ref member added.
 	 *
 	 * @since 2.2.0
-	 * @param WC_Order $order the order object
-	 * @return WC_Order order object with member named unique_transaction_ref
+	 *
+	 * @param \WC_Order $order the order object
+	 * @return \WC_Order order object with member named unique_transaction_ref
 	 */
 	protected function get_order_with_unique_transaction_ref( $order ) {
 
@@ -2310,12 +2333,13 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Called after an unsuccessful transaction attempt
+	 * Called after an unsuccessful transaction attempt.
 	 *
 	 * @since 1.0.0
-	 * @param WC_Order $order the order
+	 *
+	 * @param \WC_Order $order the order
 	 * @param SV_WC_Payment_Gateway_API_Response $response the transaction response
-	 * @return boolean false
+	 * @return false
 	 */
 	protected function do_transaction_failed_result( \WC_Order $order, SV_WC_Payment_Gateway_API_Response $response ) {
 
@@ -2345,10 +2369,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Adds the standard transaction data to the order
+	 * Adds the standard transaction data to the order.
 	 *
 	 * @since 1.0.0
-	 * @param WC_Order $order the order object
+	 *
+	 * @param \WC_Order $order the order object
 	 * @param SV_WC_Payment_Gateway_API_Response|null $response optional transaction response
 	 */
 	public function add_transaction_data( $order, $response = null ) {
@@ -2437,20 +2462,22 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * transactional data to an order given the transaction response object.
 		 *
 		 * @since 4.1.0
+		 *
 		 * @param \WC_Order $order order object
-		 * @param \SV_WC_Payment_Gateway_API_Response|null $response transaction response
-		 * @param \SV_WC_Payment_Gateway $this instance
+		 * @param SV_WC_Payment_Gateway_API_Response|null $response transaction response
+		 * @param SV_WC_Payment_Gateway $this instance
 		 */
 		do_action( 'wc_payment_gateway_' . $this->get_id() . '_add_transaction_data', $order, $response, $this );
 	}
 
 
 	/**
-	 * Adds any gateway-specific transaction data to the order
+	 * Adds any gateway-specific transaction data to the order.
 	 *
 	 * @since 1.0.0
-	 * @param WC_Order $order the order object
-	 * @param \SV_WC_Payment_Gateway_API_Customer_Response $response the transaction response
+	 *
+	 * @param \WC_Order $order the order object
+	 * @param SV_WC_Payment_Gateway_API_Customer_Response $response the transaction response
 	 */
 	public function add_payment_gateway_transaction_data( $order, $response ) {
 		// Optional method
@@ -2462,8 +2489,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * response
 	 *
 	 * @since 4.0.0
+	 *
 	 * @param \WC_Order $order order
-	 * @param \SV_WC_Payment_Gateway_API_Customer_Response $response
+	 * @param SV_WC_Payment_Gateway_API_Customer_Response $response
 	 */
 	protected function add_customer_data( $order, $response = null ) {
 
@@ -2498,6 +2526,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * @param \WC_Order $order order object
 	 * @param SV_WC_Payment_Gateway_API_Response $response response object
 	 * @return string
+	 * @throws \Exception
 	 */
 	public function get_credit_card_transaction_approved_message( \WC_Order $order, $response ) {
 
@@ -2553,10 +2582,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * is approved.
 		 *
 		 * @since 4.1.0
+		 *
 		 * @param string $message order note
 		 * @param \WC_Order $order order object
-		 * @param \SV_WC_Payment_Gateway_API_Response $response transaction response
-		 * @param \SV_WC_Payment_Gateway_Direct $this instance
+		 * @param SV_WC_Payment_Gateway_API_Response $response transaction response
+		 * @param SV_WC_Payment_Gateway_Direct $this instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_credit_card_transaction_approved_order_note', $message, $order, $response, $this );
 	}
@@ -2597,20 +2627,21 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * is approved.
 		 *
 		 * @since 4.1.0
+		 *
 		 * @param string $message order note
 		 * @param \WC_Order $order order object
-		 * @param \SV_WC_Payment_Gateway_API_Response $response transaction response
-		 * @param \SV_WC_Payment_Gateway_Direct $this instance
+		 * @param SV_WC_Payment_Gateway_API_Response $response transaction response
+		 * @param SV_WC_Payment_Gateway_Direct $this instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_check_transaction_approved_order_note', $message, $order, $response, $this );
 	}
 
 
 	/**
-	 * Mark the given order as 'on-hold', set an order note and display a message
-	 * to the customer
+	 * Marks the given order as 'on-hold', set an order note and display a message to the customer.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @param \WC_Order $order the order
 	 * @param string $message a message to display within the order note
 	 * @param SV_WC_Payment_Gateway_API_Response $response optional, the transaction response object
@@ -2677,8 +2708,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * additionally include more detailed information.
 	 *
 	 * @since 4.0.0
+	 *
 	 * @param string $text order received text
-	 * @param WC_Order|null $order order object
+	 * @param \WC_Order|null $order order object
 	 * @return string
 	 */
 	public function maybe_render_held_order_received_text( $text, $order ) {
@@ -2695,10 +2727,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Mark the given order as failed and set the order note
+	 * Marks the given order as failed and set the order note.
 	 *
 	 * @since 1.0.0
-	 * @param WC_Order $order the order
+	 *
+	 * @param \WC_Order $order the order
 	 * @param string $error_message a message to display inside the "Payment Failed" order note
 	 * @param SV_WC_Payment_Gateway_API_Response optional $response the transaction response object
 	 */
@@ -2729,11 +2762,12 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Mark the given order as cancelled and set the order note
+	 * Marks the given order as cancelled and set the order note.
 	 *
 	 * @since 2.1.0
-	 * @param WC_Order $order the order
-	 * @param string $error_message a message to display inside the "Payment Cancelled" order note
+	 *
+	 * @param \WC_Order $order the order
+	 * @param string $message a message to display inside the "Payment Cancelled" order note
 	 * @param SV_WC_Payment_Gateway_API_Response optional $response the transaction response object
 	 */
 	public function mark_order_as_cancelled( $order, $message, $response = null ) {
@@ -2862,7 +2896,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * support a customer id
 	 *
 	 * @since 1.0.0
-	 * @param WC_Order $order order object
+	 *
+	 * @param \WC_Order $order order object
 	 * @return string payment gateway guest customer id
 	 */
 	public function get_guest_customer_id( \WC_Order $order ) {
@@ -3054,8 +3089,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * Determines if a credit card transaction should result in a charge.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @param \WC_Order $order Optional. The order being charged
-	 * @throws Exception
 	 * @return bool
 	 */
 	public function perform_credit_card_charge( \WC_Order $order = null ) {
@@ -3072,9 +3107,10 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * Filters whether a credit card transaction should result in a charge.
 		 *
 		 * @since 4.5.0
+		 *
 		 * @param bool $perform whether the transaction should result in a charge
 		 * @param \WC_Order|null $order the order being charged
-		 * @param \SV_WC_Payment_Gateway $gateway the gateway object
+		 * @param SV_WC_Payment_Gateway $gateway the gateway object
 		 */
 		return apply_filters( 'wc_' . $this->get_id() . '_perform_credit_card_charge', $perform, $order, $this );
 	}
@@ -3084,8 +3120,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * Determines if a credit card transaction should result in an authorization.
 	 *
 	 * @since 1.0.0
+	 *
 	 * @param \WC_Order $order Optional. The order being authorized
-	 * @throws Exception
 	 * @return bool
 	 */
 	public function perform_credit_card_authorization( \WC_Order $order = null ) {
@@ -3100,7 +3136,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * @since 4.5.0
 		 * @param bool $perform whether the transaction should result in an authorization
 		 * @param \WC_Order|null $order the order being authorized
-		 * @param \SV_WC_Payment_Gateway $gateway the gateway object
+		 * @param SV_WC_Payment_Gateway $gateway the gateway object
 		 */
 		return apply_filters( 'wc_' . $this->get_id() . '_perform_credit_card_authorization', $perform, $order, $this );
 	}
@@ -3515,11 +3551,12 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * Adds order meta data.
 	 *
 	 * @since 2.2.0
+	 *
 	 * @param \WC_Order|int the order to add meta to
 	 * @param string $key meta key (already prefixed with gateway ID)
 	 * @param mixed $value meta value
 	 * @param bool $unique whether the meta value should be unique
-	 * @return bool|int
+	 * @return false|void
 	 */
 	public function add_order_meta( $order, $key, $value, $unique = false ) {
 
@@ -3563,10 +3600,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * Updates order meta data.
 	 *
 	 * @since 2.2.0
+	 *
 	 * @param \WC_Order|int the order to update meta for
 	 * @param string $key meta key
 	 * @param mixed $value meta value
-	 * @return bool|int
+	 * @return false|void
 	 */
 	public function update_order_meta( $order, $key, $value ) {
 
@@ -3648,9 +3686,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * Returns the parent plugin object
 	 *
 	 * @since 1.0.0
-	 * @return \SV_WC_Payment_Gateway_Plugin the parent plugin object
+	 *
+	 * @return SV_WC_Payment_Gateway_Plugin the parent plugin object
 	 */
 	public function get_plugin() {
+
 		return $this->plugin;
 	}
 
@@ -3761,7 +3801,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 				 * (including ourselves) to take action when support is declared.
 				 *
 				 * @since 1.0.0
-				 * @param \SV_WC_Payment_Gateway $this instance
+				 *
+				 * @param SV_WC_Payment_Gateway $this instance
 				 * @param string $name of supported feature being added
 				 */
 				do_action( 'wc_payment_gateway_' . $this->get_id() . '_supports_' . str_replace( '-', '_', $name ), $this, $name );
@@ -3794,7 +3835,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			 * (including ourselves) to take action when support is removed.
 			 *
 			 * @since 4.1.0
-			 * @param \SV_WC_Payment_Gateway $this instance
+			 *
+			 * @param SV_WC_Payment_Gateway $this instance
 			 * @param string $name of supported feature being removed
 			 */
 			do_action( 'wc_payment_gateway_' . $this->get_id() . '_removed_support_' . str_replace( '-', '_', $name ), $this, $name );
@@ -3878,7 +3920,12 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Returns true if the current environment is $environment_id
+	 * Returns true if the current environment is $environment_id.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|mixed $environment_id
+	 * @return bool
 	 */
 	public function is_environment( $environment_id ) {
 		return $environment_id == $this->get_environment();

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -36,15 +36,16 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_3_0\\SV_WC_Pa
 abstract class SV_WC_Payment_Gateway_Integration {
 
 
-	/** @var \SV_WC_Payment_Gateway_Direct direct gateway instance */
+	/** @var SV_WC_Payment_Gateway direct gateway instance */
 	protected $gateway;
 
 
 	/**
-	 * Boostrap class
+	 * Bootstraps the class.
 	 *
 	 * @since 4.1.0
-	 * @param \SV_WC_Payment_Gateway_Direct $gateway direct gateway instance
+	 *
+	 * @param SV_WC_Payment_Gateway $gateway direct gateway instance
 	 */
 	public function __construct( SV_WC_Payment_Gateway $gateway ) {
 
@@ -56,7 +57,7 @@ abstract class SV_WC_Payment_Gateway_Integration {
 	 * Return the gateway for the integration
 	 *
 	 * @since 4.1.0
-	 * @return \SV_WC_Payment_Gateway_Direct
+	 * @return SV_WC_Payment_Gateway
 	 */
 	public function get_gateway() {
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -41,7 +41,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 	 *
 	 * @since 4.1.0
 	 *
-	 * @param \SV_WC_Payment_Gateway $gateway gateway object
+	 * @param SV_WC_Payment_Gateway|SV_WC_Payment_Gateway_Direct $gateway gateway object
 	 */
 	public function __construct( SV_WC_Payment_Gateway $gateway ) {
 
@@ -111,12 +111,16 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 
 	/**
-	 * Adds pre-orders data to the order object.  Filtered onto SV_WC_Payment_Gateway::get_order()
+	 * Adds pre-orders data to the order object.
+	 *
+	 * Filtered onto SV_WC_Payment_Gateway::get_order()
+	 *
+	 * @see SV_WC_Payment_Gateway::get_order()
 	 *
 	 * @since 4.1.0
-	 * @see SV_WC_Payment_Gateway::get_order()
-	 * @param WC_Order $order the order
-	 * @return WC_Order the orders
+	 *
+	 * @param \WC_Order $order the order
+	 * @return \WC_Order
 	 */
 	public function get_order( $order ) {
 
@@ -278,10 +282,12 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 
 	/**
-	 * Process a pre-order payment when the pre-order is released
+	 * Processes a pre-order payment when the pre-order is released.
 	 *
 	 * @since 4.1.0
+	 *
 	 * @param \WC_Order $order original order containing the pre-order
+	 * @throws SV_WC_Payment_Gateway_Exception
 	 */
 	public function process_release_payment( $order ) {
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -41,10 +41,11 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
-	 * Bootstrap class
+	 * Bootstraps the class.
 	 *
 	 * @since 4.1.0
-	 * @param \SV_WC_Payment_Gateway_Direct $gateway
+	 *
+	 * @param SV_WC_Payment_Gateway|SV_WC_Payment_Gateway_Direct $gateway
 	 */
 	public function __construct( SV_WC_Payment_Gateway $gateway ) {
 
@@ -334,7 +335,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 *
 	 * @param bool|array $result result from any others filtering this
 	 * @param int $order_id an order or subscription ID
-	 * @param \SV_WC_Payment_Gateway_Direct $gateway gateway object
+	 * @param SV_WC_Payment_Gateway_Direct $gateway gateway object
 	 * @return array $result change payment result
 	 */
 	public function process_change_payment( $result, $order_id, $gateway ) {
@@ -576,12 +577,13 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
-	 * Disable the "Delete" My Payment Methods method action button if there is an associated subscription.
+	 * Disables the "Delete" My Payment Methods method action button if there is an associated subscription.
 	 *
 	 * @since 4.3.0
+	 *
 	 * @param array $actions the token actions
-	 * @param \SV_WC_Payment_Gateway_Payment_Token the token object
-	 * @param \SV_WC_Payment_Gateway_My_Payment_Methods the my payment methods instance
+	 * @param SV_WC_Payment_Gateway_Payment_Token the token object
+	 * @param SV_WC_Payment_Gateway_My_Payment_Methods the my payment methods instance
 	 * @return array
 	 */
 	public function disable_my_payment_methods_table_method_delete( $actions, $token, $handler ) {
@@ -610,11 +612,12 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
-	 * Get the subscriptions tied to a user payment token.
+	 * Gets the subscriptions tied to a user payment token.
 	 *
 	 * @since 4.3.0
+	 *
 	 * @param int $user_id the user
-	 * @param \SV_WC_Payment_Gateway_Payment_Token the token object
+	 * @param SV_WC_Payment_Gateway_Payment_Token the token object
 	 * @return array the subscriptions or an empty array
 	 */
 	protected function get_payment_token_subscriptions( $user_id, $token ) {
@@ -672,8 +675,9 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * payments for a customer via the Edit Subscriptions screen in 2.0.x
 	 *
 	 * @since 4.1.0
+	 *
 	 * @param array $meta associative array of meta data required for automatic payments
-	 * @throws Exception if payment token or customer ID is missing or blank
+	 * @throws \Exception if payment token or customer ID is missing or blank
 	 */
 	public function admin_validate_payment_meta( $meta ) {
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -39,7 +39,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	/** @var string the gateway environment ID */
 	protected $environment_id;
 
-	/** @var array array of cached user id to array of SV_WC_Payment_Gateway_Payment_Token token objects */
+	/** @var array|SV_WC_Payment_Gateway_Payment_Token[] array of cached user id to array of SV_WC_Payment_Gateway_Payment_Token token objects */
 	protected $tokens;
 
 	/** @var SV_WC_Payment_Gateway gateway instance */
@@ -440,7 +440,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 * @param array $args optional arguments, can include
 	 *  	`customer_id` - if not provided, this will be looked up based on $user_id
 	 *  	`environment_id` - defaults to plugin current environment
-	 * @return array associative array of string token to SV_WC_Payment_Gateway_Payment_Token object
+	 * @return array|SV_WC_Payment_Gateway_Payment_Token[] associative array of string token to SV_WC_Payment_Gateway_Payment_Token object
 	 */
 	public function get_tokens( $user_id, $args = array() ) {
 

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -142,7 +142,7 @@ class REST_API {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @return SV_WC_Plugin
+	 * @return SV_WC_Plugin|SV_WC_Payment_Gateway_Plugin
 	 */
 	protected function get_plugin() {
 

--- a/woocommerce/utilities/class-sv-wp-async-request.php
+++ b/woocommerce/utilities/class-sv-wp-async-request.php
@@ -76,7 +76,7 @@ abstract class SV_WP_Async_Request {
 	 *
 	 * @since 4.4.0
 	 * @param array $data
-	 * @return \SV_WP_Async_Request
+	 * @return SV_WP_Async_Request
 	 */
 	public function set_data( $data ) {
 		$this->data = $data;
@@ -89,7 +89,7 @@ abstract class SV_WP_Async_Request {
 	 * Dispatch the async request
 	 *
 	 * @since 4.4.0
-	 * @return array|WP_Error
+	 * @return array|\WP_Error
 	 */
 	public function dispatch() {
 

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -129,12 +129,13 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 
 
 	/**
-	 * Maybe process job queue
+	 * Maybe processes job queue.
 	 *
-	 * Checks whether data exists within the job queue and that
-	 * the background process is not already running.
+	 * Checks whether data exists within the job queue and that the background process is not already running.
 	 *
 	 * @since 4.4.0
+	 *
+	 * @throws \Exception upon error
 	 */
 	public function maybe_handle() {
 
@@ -250,7 +251,7 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 * Unlock the process so that other instances can spawn.
 	 *
 	 * @since 4.4.0
-	 * @return \SV_WP_Background_Job_Handler
+	 * @return SV_WP_Background_Job_Handler
 	 */
 	protected function unlock_process() {
 
@@ -366,8 +367,8 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param mixed $attrs Job attributes.
-	 * @return object|null
+	 * @param array|mixed $attrs Job attributes.
+	 * @return \stdClass|object|null
 	 */
 	public function create_job( $attrs ) {
 		global $wpdb;
@@ -410,11 +411,11 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		}
 
 		/**
-		 * Run when a job is created
+		 * Runs when a job is created.
 		 *
 		 * @since 4.4.0
 		 *
-		 * @param object $job The created job
+		 * @param \stdClass|object $job the created job
 		 */
 		do_action( "{$this->identifier}_job_created", $job );
 
@@ -429,7 +430,7 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *
 	 * @param string $id Optional. Job ID. Will return first job in queue if not
 	 *                   provided. Will not return completed or failed jobs from queue.
-	 * @return object|null The found job object or null
+	 * @return \stdClass|object|null The found job object or null
 	 */
 	public function get_job( $id = null ) {
 		global $wpdb;
@@ -472,18 +473,18 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		}
 
 		/**
-		 * Filter job as returned from the database
+		 * Filters the job as returned from the database.
 		 *
 		 * @since 4.4.0
 		 *
-		 * @param object $job
+		 * @param \stdClass|object $job
 		 */
 		return apply_filters( "{$this->identifier}_returned_job", $job );
 	}
 
 
 	/**
-	 * Get jobs
+	 * Gets jobs.
 	 *
 	 * @since 4.4.2
 	 *
@@ -494,7 +495,7 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *     @type string $order ASC or DESC. Defaults to DESC
 	 *     @type string $orderby Field to order by. Defaults to option_id
 	 * }
-	 * @return array|null Found jobs or null if none found
+	 * @return \stdClass[]|object[]|null Found jobs or null if none found
 	 */
 	public function get_jobs( $args = array() ) {
 		global $wpdb;
@@ -562,11 +563,13 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 
 
 	/**
-	 * Handle
+	 * Handles jobs.
 	 *
 	 * Process jobs while remaining within server memory and time limit constraints.
 	 *
 	 * @since 4.4.0
+	 *
+	 * @throws \Exception
 	 */
 	protected function handle() {
 
@@ -614,10 +617,10 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param object $job
+	 * @param \stdClass|object $job
 	 * @param int $items_per_batch number of items to process in a single request. Defaults to unlimited.
 	 * @throws \Exception when job data is incorrect
-	 * @return object $job
+	 * @return \stdClass $job
 	 */
 	public function process_job( $job, $items_per_batch = null ) {
 
@@ -697,8 +700,8 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param object|string $job Job instance or ID
-	 * @return object|false on failure
+	 * @param \stdClass|object|string $job Job instance or ID
+	 * @return \stdClass|object|false on failure
 	 */
 	public function update_job( $job ) {
 
@@ -715,10 +718,11 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		$this->update_job_option( $job );
 
 		/**
-		 * Run when a job is updated
+		 * Runs when a job is updated.
 		 *
 		 * @since 4.4.0
-		 * @param object $job The updated job
+		 *
+		 * @param \stdClass|object $job the updated job
 		 */
 		do_action( "{$this->identifier}_job_updated", $job );
 
@@ -727,12 +731,12 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 
 
 	/**
-	 * Handle job completion
+	 * Handles job completion.
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param object|string $job Job instance or ID
-	 * @return object|false on failure
+	 * @param \stdClass|object|string $job Job instance or ID
+	 * @return \stdClass|object|false on failure
 	 */
 	public function complete_job( $job ) {
 
@@ -750,10 +754,11 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		$this->update_job_option( $job );
 
 		/**
-		 * Run when a job is completed
+		 * Runs when a job is completed.
 		 *
 		 * @since 4.4.0
-		 * @param object $job The completed job
+		 *
+		 * @param \stdClass|object $job the completed job
 		 */
 		do_action( "{$this->identifier}_job_complete", $job );
 
@@ -770,9 +775,9 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param object|string $job Job instance or ID
+	 * @param \stdClass|object|string $job Job instance or ID
 	 * @param string $reason Optional. Reason for failure.
-	 * @return object|false on failure
+	 * @return \stdClass|false on failure
 	 */
 	public function fail_job( $job, $reason = '' ) {
 
@@ -794,11 +799,11 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		$this->update_job_option( $job );
 
 		/**
-		 * Run when a job is failed
+		 * Runs when a job is failed.
 		 *
 		 * @since 4.4.0
 		 *
-		 * @param object $job The failed job
+		 * @param \stdClass|object $job the failed job
 		 */
 		do_action( "{$this->identifier}_job_failed", $job );
 
@@ -811,7 +816,7 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *
 	 * @since 4.4.2
 	 *
-	 * @param object|string $job Job instance or ID
+	 * @param \stdClass|object|string $job Job instance or ID
 	 * @return false on failure
 	 */
 	public function delete_job( $job ) {
@@ -828,11 +833,11 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		$wpdb->delete( $wpdb->options, array( 'option_name' => "{$this->identifier}_job_{$job->id}" ) );
 
 		/**
-		* Run after a job is deleted
+		* Runs after a job is deleted.
 		*
 		* @since 4.4.2
 		*
-		* @param object $job The job that was deleted from database
+		* @param \stdClass|object $job the job that was deleted from database
 		*/
 		do_action( "{$this->identifier}_job_deleted", $job );
 	}
@@ -852,12 +857,13 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		$this->clear_scheduled_event();
 	}
 
+
 	/**
 	 * Schedule cron healthcheck
 	 *
 	 * @since 4.4.0
 	 * @param array $schedules
-	 * @return mixed
+	 * @return array
 	 */
 	public function schedule_cron_healthcheck( $schedules ) {
 
@@ -946,7 +952,7 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 * @since 4.4.2
 	 *
 	 * @param mixed $item Job data item to iterate over
-	 * @param object $job Job instance
+	 * @param \stdClass|object $job Job instance
 	 * @return mixed
 	 */
 	abstract protected function process_item( $item, $job );
@@ -956,7 +962,8 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 * Handles PHP shutdown, say after a fatal error.
 	 *
 	 * @since 4.5.0
-	 * @param object $job the job being processed
+	 *
+	 * @param \stdClass|object $job the job being processed
 	 */
 	public function handle_shutdown( $job ) {
 
@@ -977,7 +984,7 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 	 *
 	 * @since 4.6.3
 	 *
-	 * @param object $job the job instance to update in database
+	 * @param \stdClass|object $job the job instance to update in database
 	 * @return int|bool number of rows updated or false on failure, see wpdb::update()
 	 */
 	private function update_job_option( $job ) {

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -160,6 +160,8 @@ class SV_WP_Job_Batch_Handler {
 	 * @internal
 	 *
 	 * @since 4.8.0
+	 *
+	 * @throws \Exception upon error.
 	 */
 	public function ajax_process_batch() {
 
@@ -213,13 +215,12 @@ class SV_WP_Job_Batch_Handler {
 	 * Handles a job after processing one of its batches.
 	 *
 	 * Allows plugins to add extra job properties and handle certain statuses.
+	 * Implementations may throw a SV_WC_Plugin_Exception.
 	 *
 	 * @since 4.8.0
 	 *
-	 * @param object $job job object
-	 * @return object $job job object
-	 *
-	 * @throws SV_WC_Plugin_Exception
+	 * @param \stdClass|object $job job object
+	 * @return \stdClass|object $job job object
 	 */
 	protected function process_job_status( $job ) {
 
@@ -230,15 +231,16 @@ class SV_WP_Job_Batch_Handler {
 
 
 	/**
-	 * Process a batch of items for the given job.
+	 * Processes a batch of items for the given job.
 	 *
 	 * A batch consists of the number of items defined by self::get_items_per_batch()
-	 * or the number we're able to process before exeeding time or memory limits.
+	 * or the number we're able to process before exceeding time or memory limits.
 	 *
 	 * @since 4.8.0
 	 *
 	 * @param string $job_id job to process
-	 * @return object $job job after processing the batch
+	 * @return \stdClass|object $job job after processing the batch
+	 * @throws \Exception
 	 * @throws SV_WC_Plugin_Exception
 	 */
 	public function process_batch( $job_id ) {
@@ -293,7 +295,7 @@ class SV_WP_Job_Batch_Handler {
 	 *
 	 * @since 4.8.0
 	 *
-	 * @return SV_WP_Plugin
+	 * @return SV_WC_Plugin
 	 */
 	protected function get_plugin() {
 

--- a/woocommerce/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce/woocommerce-framework-plugin-loader-sample.php
@@ -57,7 +57,7 @@ class SV_WC_Framework_Plugin_Loader {
 	const MINIMUM_WC_VERSION = '2.6';
 
 	/** SkyVerge plugin framework version used by this plugin */
-	const FRAMEWORK_VERSION = '5.2.2';
+	const FRAMEWORK_VERSION = '5.3.0'; // TODO: framework version
 
 	/** the plugin name, for displaying notices */
 	const PLUGIN_NAME = 'WooCommerce Framework Plugin'; // TODO: plugin name

--- a/woocommerce/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce/woocommerce-framework-plugin-loader-sample.php
@@ -63,7 +63,7 @@ class SV_WC_Framework_Plugin_Loader {
 	const PLUGIN_NAME = 'WooCommerce Framework Plugin'; // TODO: plugin name
 
 
-	/** @var SV_WC_Plugin_Loader single instance of this class */
+	/** @var SV_WC_Framework_Plugin_Loader single instance of this class // TODO: replace with loader class name */
 	protected static $instance;
 
 	/** @var array the admin notices to add */
@@ -307,6 +307,10 @@ class SV_WC_Framework_Plugin_Loader {
 	 * Adds an admin notice to be displayed.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @param string $slug the notice slug
+	 * @param string $class the notice class
+	 * @param string $message the message body text
 	 */
 	public function add_admin_notice( $slug, $class, $message ) {
 


### PR DESCRIPTION
This PR only revises some PHPDoc tags for exceptions being thrown by FW methods and some return types. 

Some of the referenced types or exceptions include the outdated global namespace which the framework is no longer using; or the way around, occasionally does not include the global namespace for return types expected to be in that namespace such as WC core objects.

This PR does not make code changes, but I hope it improves the consistency of PHPdocs.