### PR TITLE
[ch12281] Add unsupported WC core admin notices 

### DIFF
--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -54,21 +54,23 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Initialize and setup the Admin Notice Handler
+	 * Initializes and sets up the admin notices handler.
 	 *
 	 * @since 3.0.0
+	 *
+	 * @param SV_WC_Plugin main instance
 	 */
 	public function __construct( $plugin ) {
 
-		$this->plugin      = $plugin;
+		$this->plugin = $plugin;
 
 		// render any admin notices, delayed notices, and
-		add_action( 'admin_notices', array( $this, 'render_admin_notices'         ), 15 );
-		add_action( 'admin_footer',  array( $this, 'render_delayed_admin_notices' ), 15 );
-		add_action( 'admin_footer',  array( $this, 'render_admin_notice_js'       ), 20 );
+		add_action( 'admin_notices', [ $this, 'render_admin_notices'         ], 15 );
+		add_action( 'admin_footer',  [ $this, 'render_delayed_admin_notices' ], 15 );
+		add_action( 'admin_footer',  [ $this, 'render_admin_notice_js'       ], 20 );
 
 		// AJAX handler to dismiss any warning/error notices
-		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', array( $this, 'handle_dismiss_notice' ) );
+		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', [ $this, 'handle_dismiss_notice' ] );
 	}
 
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -54,23 +54,21 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Initializes and sets up the admin notices handler.
+	 * Initialize and setup the Admin Notice Handler
 	 *
 	 * @since 3.0.0
-	 *
-	 * @param SV_WC_Plugin main instance
 	 */
 	public function __construct( $plugin ) {
 
-		$this->plugin = $plugin;
+		$this->plugin      = $plugin;
 
 		// render any admin notices, delayed notices, and
-		add_action( 'admin_notices', [ $this, 'render_admin_notices'         ], 15 );
-		add_action( 'admin_footer',  [ $this, 'render_delayed_admin_notices' ], 15 );
-		add_action( 'admin_footer',  [ $this, 'render_admin_notice_js'       ], 20 );
+		add_action( 'admin_notices', array( $this, 'render_admin_notices'         ), 15 );
+		add_action( 'admin_footer',  array( $this, 'render_delayed_admin_notices' ), 15 );
+		add_action( 'admin_footer',  array( $this, 'render_admin_notice_js'       ), 20 );
 
 		// AJAX handler to dismiss any warning/error notices
-		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', [ $this, 'handle_dismiss_notice' ] );
+		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', array( $this, 'handle_dismiss_notice' ) );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -191,8 +191,14 @@ class SV_WC_Plugin_Compatibility {
 
 					// reverse array as WordPress supplies oldest version first, newest last
 					foreach ( array_keys( array_reverse( $plugin_info['versions'] ) ) as $wc_version ) {
-						// skip trunk, release candidates, betas and other non-final versions
-						if ( 'trunk' !== $wc_version && false === strpos( $wc_version, '-' ) ) {
+
+						// skip trunk, release candidates, betas and other non-final or irregular versions
+						if (
+							   is_string( $wc_version )
+							&& '' !== $wc_version
+							&& is_numeric( $wc_version[0] )
+							&& false === strpos( $wc_version, '-' )
+						) {
 							$latest_wc_versions[] = $wc_version;
 						}
 					}

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -102,8 +102,8 @@ abstract class SV_WC_Plugin {
 	 * @param array $args {
 	 *     optional plugin arguments
 	 *
+	 *     @type int|float $latest_wc_versions the last supported versions of WooCommerce, as a major.minor float relative to the latest available version
 	 *     @type string $text_domain the plugin textdomain, used to set up translations
-	 *     @type int|float $woocommerce the last supported version of WooCommerce, relative to the latest available
 	 *     @type array  $dependencies {
 	 *         PHP extension, function, and settings dependencies
 	 *

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -551,53 +551,21 @@ abstract class SV_WC_Plugin {
 		$supported_wc_version = substr( $supported_wc_version, 0, strpos( $supported_wc_version, '.', strpos( $supported_wc_version, '.' ) + 1 ) );
 		$compared_wc_version  = $current_wc_version && $supported_wc_version ? version_compare( $current_wc_version, $supported_wc_version ) : null;
 
-		// TODO remove the first conditional below after WC 3.8 has been published {FN 2019-07-31}
-
-		// installed version is at least 2 versions older, but the latest WooCommerce version available is still 3.6 or 3.7, for now just issue a warning about future support deprecation policy change
-		if ( 1 !== $compared_wc_version && ( false !== strpos( $latest_wc_version, '3.6' ) || false !== strpos( $latest_wc_version, '3.7' ) ) ) {
-
-			$this->get_admin_notice_handler()->add_admin_notice(
-				sprintf(
-					/* translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version number, %3$s - opening <a> HTML link tag, %4$s - closing </a> HTML link tag */
-					__( 'Heads up! In the future, %1$s will remove support for WooCommerce that is 3 minor versions older than the latest available version. Please %3$supdate WooCommerce%4$s.', 'woocommerce-plugin-framework' ),
-					$this->get_plugin_name(),
-					$supported_wc_version,
-					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">', '</a>'
-				),
-				$this->get_id_dasherized() . '-wc-version-support-policy-change',
-				[ 'notice_class' => 'notice-warning' ]
-			);
-
-		// installed version is exactly as the last supported version (default: 2 minor versions behind)
-		} elseif ( 0 === $compared_wc_version ) {
-
-			$this->get_admin_notice_handler()->add_admin_notice(
-				sprintf(
-					/* translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version number, %3$s - opening <a> HTML link tag, %4$s - closing </a> HTML link tag */
-					__( 'Heads up! %1$s will remove support for WooCommerce %2$s in a future version. Please %3$supdate WooCommerce%4$s.', 'woocommerce-plugin-framework' ),
-					$this->get_plugin_name(),
-					$supported_wc_version,
-					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">', '</a>'
-				),
-				$this->get_id_dasherized() . '-deprecated-wc-version-as-of-' . str_replace( '.', '-', $supported_wc_version ),
-				[ 'notice_class' => 'notice-warning' ]
-			);
-
-		// installed version is older than the last supported version (default: 2 minor versions behind)
-		} elseif ( -1 === $compared_wc_version ) {
+		// installed version is at more than 2 minor versions ($min_wc_semver value) behind the last published version
+		if ( -1 === $compared_wc_version ) {
 
 			$this->get_admin_notice_handler()->dismiss_notice( $this->get_id_dasherized() . '-deprecated-wc-version-as-of-' . str_replace( '.', '-', $supported_wc_version ) );
 
 			$this->get_admin_notice_handler()->add_admin_notice(
 				sprintf(
 					/* translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version number, %3$s - opening <a> HTML link tag, %4$s - closing </a> HTML link tag */
-					__( 'Heads up! %1$s no longer supports WooCommerce %2$s. Please %3$supdate WooCommerce%4$s.', 'woocommerce-plugin-framework' ),
+					__( 'Heads up! %1$s will remove support for WooCommerce %2$s in a future upcoming version. Please %3$supdate WooCommerce%4$s.', 'woocommerce-plugin-framework' ),
 					$this->get_plugin_name(),
-					$current_wc_version,
+					$supported_wc_version,
 					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">', '</a>'
 				),
-				$this->get_id_dasherized() . '-unsupported-wc-version-as-of-' . str_replace( '.', '-', $supported_wc_version ),
-				[ 'notice_class' => 'notice-error' ]
+				$this->get_id_dasherized() . '-deprecated-wc-version-as-of-' . str_replace( '.', '-', $supported_wc_version ),
+				[ 'notice_class' => 'notice-warning' ]
 			);
 		}
 	}

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -553,8 +553,8 @@ abstract class SV_WC_Plugin {
 
 		// TODO remove the first conditional below after WC 3.8 has been published {FN 2019-07-31}
 
-		// installed version is at least 2 versions older, but the latest WooCommerce version available is still 3.7, for now just issue a warning about future support deprecation policy change
-		if ( 1 !== $compared_wc_version && false !== strpos( $latest_wc_version, '3.7' ) ) {
+		// installed version is at least 2 versions older, but the latest WooCommerce version available is still 3.6 or 3.7, for now just issue a warning about future support deprecation policy change
+		if ( 1 !== $compared_wc_version && ( false !== strpos( $latest_wc_version, '3.6' ) || false !== strpos( $latest_wc_version, '3.7' ) ) ) {
 
 			$this->get_admin_notice_handler()->add_admin_notice(
 				sprintf(

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -510,6 +510,11 @@ abstract class SV_WC_Plugin {
 			return;
 		}
 
+		// bail to prevent further overhead if the current user has already dismissed unsupported WooCommerce notices
+		if ( $this->get_admin_notice_handler()->is_notice_dismissed( $this->get_id() . '-unsupported-wc-version' ) ) {
+			return;
+		}
+
 		// grab semver parts
 		$supported_wc_version = current( $latest_wc_versions );
 		$latest_semver        = explode( '.', $supported_wc_version );

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -561,7 +561,7 @@ abstract class SV_WC_Plugin {
 					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">', '</a>'
 				),
 				$this->get_id() . '-deprecated-wc-version-' . str_replace( '.', '_', $current_wc_version ),
-				[ 'notice_class' => 'warning' ]
+				[ 'notice_class' => 'notice-warning' ]
 			);
 
 		// installed version is older than the last supported version (default: 2 minor versions behind)

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -559,7 +559,7 @@ abstract class SV_WC_Plugin {
 			$this->get_admin_notice_handler()->add_admin_notice(
 				sprintf(
 					/* translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version number, %3$s - opening <a> HTML link tag, %4$s - closing </a> HTML link tag */
-					__( 'Heads up! %1$s will remove support for WooCommerce %2$s in a future upcoming version. Please %3$supdate WooCommerce%4$s.', 'woocommerce-plugin-framework' ),
+					__( 'Heads up! %1$s will soon discontinue support for WooCommerce %2$s. Please %3$supdate WooCommerce%4$s to take advantage of the latest updates and features.', 'woocommerce-plugin-framework' ),
 					$this->get_plugin_name(),
 					$supported_wc_version,
 					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">', '</a>'

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -68,6 +68,9 @@ abstract class SV_WC_Plugin {
 	/** @var string the plugin text domain */
 	private $text_domain;
 
+	/** @var int|float minimum supported WooCommerce versions before the latest (units for major releases, decimals for minor) */
+	private $latest_wc_versions;
+
 	/** @var SV_WC_Plugin_Dependencies dependency handler instance */
 	private $dependency_handler;
 
@@ -100,6 +103,7 @@ abstract class SV_WC_Plugin {
 	 *     optional plugin arguments
 	 *
 	 *     @type string $text_domain the plugin textdomain, used to set up translations
+	 *     @type int|float $woocommerce the last supported version of WooCommerce, relative to the latest available
 	 *     @type array  $dependencies {
 	 *         PHP extension, function, and settings dependencies
 	 *
@@ -109,18 +113,20 @@ abstract class SV_WC_Plugin {
 	 *     }
 	 * }
 	 */
-	public function __construct( $id, $version, $args = array() ) {
+	public function __construct( $id, $version, $args = [] ) {
 
 		// required params
 		$this->id      = $id;
 		$this->version = $version;
 
-		$args = wp_parse_args( $args, array(
-			'text_domain'  => '',
-			'dependencies' => array(),
-		) );
+		$args = wp_parse_args( $args, [
+			'latest_wc_versions' => 0.2, // by default, 2 minor versions behind the latest published are supported
+			'text_domain'        => '',
+			'dependencies'       => [],
+		] );
 
-		$this->text_domain = $args['text_domain'];
+		$this->latest_wc_versions = abs( $args['latest_wc_versions'] );
+		$this->text_domain        = $args['text_domain'];
 
 		// includes that are required to be available at all times
 		$this->includes();
@@ -483,15 +489,92 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Checks if required PHP extensions are loaded and adds an admin notice
-	 * for any missing extensions.  Also plugin settings can be checked
-	 * as well.
+	 * Adds admin notices upon initialization.
+	 *
+	 * This may also produce notices if running an unsupported version of WooCommerce.
 	 *
 	 * @since 3.0.0
 	 */
 	public function add_admin_notices() {
 
+		if ( empty( $this->latest_wc_versions ) || ! is_numeric( $this->latest_wc_versions ) || (float) $this->latest_wc_versions <= 0 ) {
+			return;
+		}
 
+		$latest_wc_versions = SV_WC_Plugin_Compatibility::get_latest_wc_versions();
+		$current_wc_version = SV_WC_Plugin_Compatibility::get_wc_version();
+
+		if ( empty( $latest_wc_versions ) || empty( $current_wc_version ) ) {
+			return;
+		}
+
+		$supported_wc_version = current( $latest_wc_versions );
+		$latest_semver        = explode( '.', $supported_wc_version );
+		$supported_semver     = explode( '.', (string) $this->latest_wc_versions );
+		$supported_major      = max( 0,  (int) $latest_semver[0] - (int) $supported_semver[0] );
+		$supported_minor      = isset( $supported_semver[1] ) ? (int) $supported_semver[1] : 0;
+		$previous_minor       = null;
+
+		// loop known WooCommerce versions from the most recent until we get the oldest supported one
+		foreach ( $latest_wc_versions as $older_wc_version ) {
+
+			$supported_wc_version = $older_wc_version;
+
+			$older_semver = explode( '.', $older_wc_version );
+			$older_major  = (int) $older_semver[0];
+			$older_minor  = isset( $older_semver[1] ) ? (int) $older_semver[1] : 0;
+
+			// if major is ignored, skip; if the minor hasn't changed (patch must be), skip
+			if ( $older_major > $supported_major || $older_minor === $previous_minor ) {
+				continue;
+			}
+
+			// we reached the maximum number of supported minor versions
+			if ( $supported_minor <= 0 ) {
+				break;
+			}
+
+			// store the previous minor while we loop patch versions, which we ignore
+			$previous_minor = $older_minor;
+
+			$supported_minor--;
+		}
+
+		// for correct comparison, we strip the patch version from the determined versions and compare only major, minor versions
+		$current_wc_version   = substr( $current_wc_version, 0, strpos( $current_wc_version, '.', strpos( $current_wc_version, '.' ) + 1 ) );
+		$supported_wc_version = substr( $supported_wc_version, 0, strpos( $supported_wc_version, '.', strpos( $supported_wc_version, '.' ) + 1 ) );
+		$compared_wc_version  = $current_wc_version && $supported_wc_version ? version_compare( $current_wc_version, $supported_wc_version ) : null;
+
+		// installed version is exactly as the last supported version (default: 2 minor versions behind)
+		if ( 0 === $compared_wc_version ) {
+
+			$this->get_admin_notice_handler()->add_admin_notice(
+				sprintf(
+					/* translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version number, %3$s - opening <a> HTML link tag, %4$s - closing </a> HTML link tag */
+					__( 'Heads up! %1$s will remove support for WooCommerce %2$s in a future version. Please %3$supdate WooCommerce%4$s.', 'woocommerce-plugin-framework' ),
+					$this->get_plugin_name(),
+					$supported_wc_version,
+					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">', '</a>'
+				),
+				$this->get_id() . '-unsupported-wc-version',
+				[ 'notice_class' => 'warning' ]
+			);
+
+		// installed version is older than the last supported version (default: 2 minor versions behind)
+		} elseif ( -1 === $compared_wc_version ) {
+
+			$this->get_admin_notice_handler()->add_admin_notice(
+				sprintf(
+					/* translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version number, %3$s - opening <a> HTML link tag, %4$s - closing </a> HTML link tag */
+					__( 'Heads up! %1$s no longer supports WooCommerce %2$s. Please %3$supdate WooCommerce%4$s.', 'woocommerce-plugin-framework' ),
+					$this->get_plugin_name(),
+					$current_wc_version,
+					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">', '</a>'
+				),
+				$this->get_id() . '-unsupported-wc-version',
+				[ 'notice_class' => 'error' ]
+			);
+		}
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -497,6 +497,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function add_admin_notices() {
 
+		// bail if there's no defined versions to compare
 		if ( empty( $this->latest_wc_versions ) || ! is_numeric( $this->latest_wc_versions ) || (float) $this->latest_wc_versions <= 0 ) {
 			return;
 		}
@@ -504,10 +505,12 @@ abstract class SV_WC_Plugin {
 		$latest_wc_versions = SV_WC_Plugin_Compatibility::get_latest_wc_versions();
 		$current_wc_version = SV_WC_Plugin_Compatibility::get_wc_version();
 
+		// bail if the latest WooCommerce version or the current WooCommerce versions can't be determined
 		if ( empty( $latest_wc_versions ) || empty( $current_wc_version ) ) {
 			return;
 		}
 
+		// grab semver parts
 		$supported_wc_version = current( $latest_wc_versions );
 		$latest_semver        = explode( '.', $supported_wc_version );
 		$supported_semver     = explode( '.', (string) $this->latest_wc_versions );
@@ -518,6 +521,7 @@ abstract class SV_WC_Plugin {
 		// loop known WooCommerce versions from the most recent until we get the oldest supported one
 		foreach ( $latest_wc_versions as $older_wc_version ) {
 
+			// as we loop through versions, the latest one before we break the loop will be the minimum supported one
 			$supported_wc_version = $older_wc_version;
 
 			$older_semver = explode( '.', $older_wc_version );
@@ -540,7 +544,7 @@ abstract class SV_WC_Plugin {
 			$supported_minor--;
 		}
 
-		// for correct comparison, we strip the patch version from the determined versions and compare only major, minor versions
+		// for strict comparison, we strip the patch version from the determined versions and compare only major, minor versions, ignoring patches
 		$current_wc_version   = substr( $current_wc_version, 0, strpos( $current_wc_version, '.', strpos( $current_wc_version, '.' ) + 1 ) );
 		$supported_wc_version = substr( $supported_wc_version, 0, strpos( $supported_wc_version, '.', strpos( $supported_wc_version, '.' ) + 1 ) );
 		$compared_wc_version  = $current_wc_version && $supported_wc_version ? version_compare( $current_wc_version, $supported_wc_version ) : null;


### PR DESCRIPTION
Adds notices if the merchant is running a WooCommerce version 2 minor releases _behind_ the latest available version on WordPress.org.


#### CH Story: [ch12277](https://app.clubhouse.io/skyverge/story/12281/add-admin-notices-for-unsupported-wc-core-versions)

### Details

Individual plugins can override this criteria by passing a `latest_wc_versions` argument inside the `$args` param passed to `SV_WC_Plugin` constructor.

This argument can be 0 or empty, or can be a float. When float, for example the default `0.2` it means the framework will treat this as an inverse partial semver and assume x.y versions behind the latest. In this case (default) value, 2 minor versions behind latest are supported. If a plugin wants to offer longer support up to three versions this could be `0.3`. 

Since the Framework is an open source project that may be used by third parties I thought it would be most considerate to offer this kind of flexibility. This may be helpful for ourselves (should we have a different handling or no handling for specific plugins) but also for third parties with a different support policy (for example `1.0` will offer support up to a major version behind).

To know which is the true last version of WooCommerce, the framework will issue a request to WordPress.org via WordPress.org API. This will fetch all information about the `woocommerce` plugin including its versions. `trunk`, release candidates, betas, etc. will be removed from the versions array. The last element in the array is the last available version. From this version, the framework loops back until it cycles the specified parameter (default `0.2`). Since semver isn't linear, it does so in a way that doesn't assume in advance what "2 versions behind" means, given this could be 4.0.0, and two minor versions behind could mean 3.8.9 and 3.8.8 OR 3.9.2 and 3.9.1 as well. 

To avoid querying the WordPress.Org API too often, the latest WooCommerce versions are stored in a weekly transient that can be shared by all frameworked plugins.

Finally, if the installed version is 1-2 (or specified) versions behind, it will display a notice reminding the merchant about the imminent support drop. If the version is even older, it will issue a warning notice telling the merchant the current WooCommerce version is no longer supported by the plugin that issued the notice. Once the merchant updates, the notice is no longer shown.

## QA

- [ ] To test an implementation, have a look at this [Memberships PR](https://github.com/skyverge/woocommerce-memberships/pull/727#issue-300206508). To trigger the notice you can simply edit the `WC_VERSION` constant from the active WooCommerce plugin. 
- [ ] If the constant is moved within 2 minor versions behind, a yellow notice should appear.
- [ ] If the constant is moved further behind, a red warning notice should appear.
- [ ] Either notice should prompt the user to update WooCommerce, linking to the WordPress update page.