### PR TITLE
[ch12277] Add support to WooCommerce Admin Notes

### DIFF
--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -87,7 +87,7 @@ class Lifecycle {
 		}
 
 		// catch any milestones triggered by action
-		add_action( 'wc_' . $this->get_plugin()->get_id() . '_milestone_reached', array( $this, 'trigger_milestone' ), 10, 4 );
+		add_action( 'wc_' . $this->get_plugin()->get_id() . '_milestone_reached', [ $this, 'trigger_milestone' ], 10, 4 );
 	}
 
 
@@ -441,6 +441,7 @@ class Lifecycle {
 				[
 					'name'    => 'dismiss',
 					'label'   => __( 'Dismiss', 'woocommerce-plugin-framework' ),
+					'url'     => '#',
 				]
 			];
 		}

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -313,9 +313,11 @@ class Lifecycle {
 
 			if ( $message ) {
 
-				$this->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $id, array(
+				$this->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $id, [
 					'always_show_on_settings' => false,
-				) );
+					'is_snoozable'            => false,
+					'type'                    => 'info',
+				] );
 
 				// only display one notice at a time
 				break;

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -243,7 +243,7 @@ class SV_WC_Admin_Notice_Handler {
 			try {
 				/** @var \WC_Admin_Notes_Data_Store $data_store check if an identical note already exists in db */
 				$data_store = \WC_Data_Store::load( 'admin-note' );
-				$found_note = $data_store ? $data_store->get_notes_with_name( $note_id ) : null;
+				$found_note = $data_store ? $data_store->get_notes_with_name( $note ) : null;
 			} catch ( \Exception $e ) {
 				$found_note = null;
 			}
@@ -376,6 +376,7 @@ class SV_WC_Admin_Notice_Handler {
 		$display = false;
 
 		if ( self::should_use_admin_notes() ) {
+
 
 			$note    = $this->get_admin_note( $message_id );
 			$display = ! $note || ! $this->is_notice_dismissed( $note );

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -397,8 +397,16 @@ class SV_WC_Admin_Notice_Handler {
 	 * @return bool
 	 */
 	private static function should_use_admin_notes() {
+		global $current_screen;
 
-		return SV_WC_Plugin_Compatibility::is_wc_admin_available();
+		// keep displaying notices on the WordPress plugins page
+		if ( $current_screen && 'plugins' === $current_screen->id ) {
+			$use_admin_notes = false;
+		} else {
+			$use_admin_notes = SV_WC_Plugin_Compatibility::is_wc_admin_available();
+		}
+
+		return $use_admin_notes;
 	}
 
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -277,7 +277,7 @@ class SV_WC_Admin_Notice_Handler {
 			$is_dismissible = ! isset( $args['dismissible'] ) || true === $args['dismissible'];
 
 			if ( $is_dismissible ) {
-				$note->add_action( 'dismiss', __( 'Dismiss', 'woocommerce-plugin-framework' ), '#' );
+				$note->add_action( 'dismiss', __( 'Dismiss', 'woocommerce-plugin-framework' ) );
 			}
 
 		} elseif ( ! empty( $args['actions'] ) && is_array( $args['actions'] ) ) {
@@ -287,7 +287,7 @@ class SV_WC_Admin_Notice_Handler {
 				$action = wp_parse_args( $action, [
 					'name'    => '',
 					'label'   => '',
-					'url'     => '#',
+					'url'     => '',
 					'status'  => $note::E_WC_ADMIN_NOTE_ACTIONED,
 					'primary' => false,
 				] );

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -200,12 +200,14 @@ class SV_WC_Admin_Notice_Handler {
 	 */
 	public function add_admin_note( $content, $name = '', array $data = [] ) {
 
-		$note = new \WC_Admin_Note( wp_parse_args( self::normalize_notice_arguments( $data ), [
+		$data = wp_parse_args( self::normalize_notice_arguments( $data ), [
 			'name'    => empty( trim( $name ) ) ? uniqid( $this->get_plugin()->get_id_dasherized(), false ) : $name,
 			'title'   => $this->get_plugin()->get_plugin_name(),
 			'content' => $content,
 			'source'  => $this->get_plugin()->get_id_dasherized(),
-		] ) );
+		] );
+
+		$note = new \WC_Admin_Note( $data );
 
 		// maybe set an action to dismiss the note
 		if ( ! isset( $data['actions'] ) && $note::E_WC_ADMIN_NOTE_UNACTIONED === $note->get_status() && empty( $note->get_actions() )  ) {

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -74,6 +74,7 @@ class SV_WC_Admin_Notice_Handler {
 		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', [ $this, 'handle_dismiss_notice' ] );
 
 		// deletes an action that has been dismissed via dismiss action button
+		add_action( 'woocommerce_admin_note_action',         [ $this, 'delete_admin_note'] );
 		add_action( 'woocommerce_admin_note_action_dismiss', [ $this, 'delete_admin_note' ] );
 	}
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -240,7 +240,7 @@ class SV_WC_Admin_Notice_Handler {
 					'name'    => '',
 					'label'   => '',
 					'url'     => '',
-					'status'  => $note::E_WC_ADMIN_NOTE_UNACTIONED,
+					'status'  => $note::E_WC_ADMIN_NOTE_ACTIONED,
 					'primary' => false,
 				] );
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -467,21 +467,16 @@ class SV_WC_Admin_Notice_Handler {
 	/**
 	 * Determines whether admin note should be used instead of admin notices.
 	 *
+	 * This method will check if WooCommerce Admin is available and the current page can display admin notes.
+	 *
 	 * @since 5.4.1-dev.1
 	 *
 	 * @return bool
 	 */
 	private static function should_use_admin_notes() {
-		global $current_screen;
 
-		// keep displaying notices on the WordPress plugins page
-		if ( $current_screen && 'plugins' === $current_screen->id ) {
-			$use_admin_notes = false;
-		} else {
-			$use_admin_notes = SV_WC_Plugin_Compatibility::is_wc_admin_available();
-		}
-
-		return $use_admin_notes;
+		return SV_WC_Plugin_Compatibility::is_wc_admin_available()
+			&& \WC_Admin_Page_Controller::get_instance()->is_connected_page();
 	}
 
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -200,12 +200,12 @@ class SV_WC_Admin_Notice_Handler {
 	 */
 	public function add_admin_note( $content, $name = '', array $data = [] ) {
 
-		$note = new \WC_Admin_Note( self::normalize_notice_arguments( wp_parse_args( $data, [
+		$note = new \WC_Admin_Note( wp_parse_args( self::normalize_notice_arguments( $data ), [
 			'name'    => empty( trim( $name ) ) ? uniqid( $this->get_plugin()->get_id_dasherized(), false ) : $name,
 			'title'   => $this->get_plugin()->get_plugin_name(),
 			'content' => $content,
 			'source'  => $this->get_plugin()->get_id_dasherized(),
-		] ) ) );
+		] ) );
 
 		// maybe set an action to dismiss the note
 		if ( ! isset( $data['actions'] ) && $note::E_WC_ADMIN_NOTE_UNACTIONED === $note->get_status() && empty( $note->get_actions() )  ) {

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -29,11 +29,9 @@ defined( 'ABSPATH' ) or exit;
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_1\\SV_WC_Admin_Notice_Handler' ) ) :
 
 /**
- * SkyVerge Admin Notice Handler Class
+ * SkyVerge Admin Notice Handler Class.
  *
- * The purpose of this class is to provide a facility for displaying
- * conditional (often dismissible) admin notices during a single page
- * request
+ * The purpose of this class is to provide a facility for displaying conditional (often dismissible) admin notices during a single page request.
  *
  * @since 3.0.0
  */
@@ -44,7 +42,7 @@ class SV_WC_Admin_Notice_Handler {
 	private $plugin;
 
 	/** @var array associative array of id to notice text */
-	private $admin_notices = array();
+	private $admin_notices = [];
 
 	/** @var boolean static member to enforce a single rendering of the admin notice placeholder element */
 	static private $admin_notice_placeholder_rendered = false;
@@ -54,92 +52,218 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Initialize and setup the Admin Notice Handler
+	 * Initializes and sets up the admin notice Handler.
 	 *
 	 * @since 3.0.0
+	 *
+	 * @param SV_WC_Plugin $plugin main class
 	 */
 	public function __construct( $plugin ) {
 
-		$this->plugin      = $plugin;
+		$this->plugin = $plugin;
 
 		// render any admin notices, delayed notices, and
-		add_action( 'admin_notices', array( $this, 'render_admin_notices'         ), 15 );
-		add_action( 'admin_footer',  array( $this, 'render_delayed_admin_notices' ), 15 );
-		add_action( 'admin_footer',  array( $this, 'render_admin_notice_js'       ), 20 );
+		add_action( 'admin_notices', [ $this, 'render_admin_notices'         ], 15 );
+		add_action( 'admin_footer',  [ $this, 'render_delayed_admin_notices' ], 15 );
+		add_action( 'admin_footer',  [ $this, 'render_admin_notice_js'       ], 20 );
 
 		// AJAX handler to dismiss any warning/error notices
-		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', array( $this, 'handle_dismiss_notice' ) );
+		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', [ $this, 'handle_dismiss_notice' ] );
 	}
 
 
 	/**
-	 * Adds the given $message as a dismissible notice identified by $message_id,
-	 * unless the notice has been dismissed, or we're on the plugin settings page
+	 * Normalizes admin notices arguments.
+	 *
+	 * @see \WC_Admin_Note::__construct() for available properties when using WooCommerce Admin
+	 *
+	 * @since 5.4.1-dev.1
+	 *
+	 * @param array $args associative array of arguments
+	 * @return array
+	 */
+	private static function normalize_notice_arguments( $args ) {
+
+		if ( SV_WC_Plugin_Compatibility::is_wc_admin_available() ) {
+
+			$args = wp_parse_args( $args, [
+				'locale'       => get_locale(),
+				'is_snoozable' => isset( $args['dismissible'] ) ? $args['dismissible'] : true,
+				'type'         => self::normalize_notice_type( $args ),
+			] );
+
+			if ( empty( $args['icon'] ) ) {
+				switch ( $args['type'] ) {
+					case 'error' :
+					case 'warning' :
+					case 'notice' :
+					case 'update' :
+						$args['icon'] = 'notice';
+					break;
+					case 'info' :
+					default :
+						$args['icon'] = 'info';
+					break;
+				}
+			}
+
+			if ( empty( $args['date_created'] ) ) {
+				try {
+					$datetime             = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+					$args['date_created'] = $datetime->format( 'c' );
+				} catch ( \Exception $e ) {
+					$args['date_created'] = date( 'Y-m-d H:i:s', current_time( 'timestamp' ) );
+				}
+			}
+
+		} else {
+
+			$args = wp_parse_args( $args, [
+				'always_show_on_settings' => true,
+				'dismissible'             => isset( $args['is_snoozable'] ) ? $args['is_snoozable'] : true,
+				'notice_class'            => self::normalize_notice_type( $args ),
+				'is_visible'              => true,
+			] );
+		}
+
+		return $args;
+	}
+
+
+	/**
+	 * Normalizes a notice class or type, according to whether WooCommerce Admin is present.
+	 *
+	 * @since 5.4.1-dev.1
+	 *
+	 * @param array $notice_args associative array of arguments
+	 * @return string
+	 */
+	private static function normalize_notice_type( $notice_args ) {
+
+		if ( ! empty( $notice_args['type'] ) ) {
+			$notice_type = $notice_args['type'];
+		} elseif ( ! empty( $notice_args['notice_class'] ) ) {
+			$notice_type = $notice_args['notice_class'];
+		} else {
+			$notice_type = 'updated';
+		}
+
+		$default_type   = 'updated';
+		$accepted_types = [
+			'error',
+			'info',
+			'notice',
+			'notice-info',
+			'notice-warning',
+			'updated',
+		];
+
+		if ( SV_WC_Plugin_Compatibility::is_wc_admin_available() ) {
+			$note           = new \WC_Admin_Note();
+			$accepted_types = $note::get_allowed_types();
+			$default_type   = $note::E_WC_ADMIN_NOTE_INFORMATIONAL;
+		}
+
+		return in_array( $notice_type, $accepted_types, true ) ? $notice_type : $default_type;
+	}
+
+
+	/**
+	 * Adds a message to be displayed as a WooCommerce Admin Note.
+	 *
+	 * @see \WC_Admin_Note::__construct() for available arguments
+	 *
+	 * @since 5.4.1-dev.1
+	 *
+	 * @param string $name note slug identifier
+	 * @param string $content note content
+	 * @param array $data additional arguments
+	 * @return int the added note ID
+	 */
+	public function add_admin_note( $name, $content, $data ) {
+
+		$note = new \WC_Admin_Note( self::normalize_notice_arguments( wp_parse_args( $data, [
+			'name'    => $name,
+			'title'   => $this->get_plugin()->get_plugin_name(),
+			'content' => $content,
+			'source'  => $this->get_plugin()->get_id_dasherized(),
+		] ) ) );
+
+		return $note->save();
+	}
+
+
+	/**
+	 * Adds a message to be displayed as an admin notice.
+	 *
+	 * If WooCommerce Admin is used, the notice will be passed as an admin note instead.
+	 * @see \WC_Admin_Note::__construct() for available parameters
+	 * @see SV_WC_Admin_Notice_Handler::add_admin_note()
 	 *
 	 * @since 3.0.0
+	 *
 	 * @param string $message the notice message to display
 	 * @param string $message_id the message id
-	 * @param array $params {
-	 *     Optional parameters.
-	 *
-	 *     @type bool $dismissible             If the notice should be dismissible
-	 *     @type bool $always_show_on_settings If the notice should be forced to display on the
-	 *                                         plugin settings page, regardless of `$dismissible`.
-	 *     @type string $notice_class          Additional classes for the notice.
-	 * }
+	 * @param array $args optional arguments
 	 */
-	public function add_admin_notice( $message, $message_id, $params = array() ) {
+	public function add_admin_notice( $message, $message_id, $args = [] ) {
 
-		$params = wp_parse_args( $params, array(
-			'dismissible'             => true,
-			'always_show_on_settings' => true,
-			'notice_class'            => 'updated',
-		) );
+		$args = self::normalize_notice_arguments( $args );
 
-		if ( $this->should_display_notice( $message_id, $params ) ) {
-			$this->admin_notices[ $message_id ] = array(
+		if ( SV_WC_Plugin_Compatibility::is_wc_admin_available() ) {
+
+			try {
+				/** @var \WC_Admin_Notes_Data_Store $data_store check if an identical note already exists in db */
+				$data_store = \WC_Data_Store::load( 'admin-note' );
+				$found_note = $data_store ? $data_store->get_notes_with_name( $message_id ) : null;
+			} catch ( \Exception $e ) {
+				$found_note = null;
+			}
+
+			if ( empty( $found_note ) ) {
+				$this->add_admin_note( $message_id, $message, $args );
+			}
+
+		} elseif ( $this->should_display_notice( $message_id, $args ) ) {
+
+			$this->admin_notices[ $message_id ] = [
 				'message'  => $message,
 				'rendered' => false,
-				'params'   => $params,
-			);
+				'params'   => $args,
+			];
 		}
 	}
 
 
 	/**
-	 * Returns true if the identified notice hasn't been cleared, or we're on
-	 * the plugin settings page (where notices are always displayed)
+	 * Determines whether an admin notice should be displayed.
+	 *
+	 * This is normally the case when one of the following conditions is true:
+	 * - the identified notice hasn't been cleared
+	 * - the plugin settings page (where notices are always displayed)
 	 *
 	 * @since 3.0.0
-	 * @param string $message_id the message id
-	 * @param array $params {
-	 *     Optional parameters.
 	 *
-	 *     @type bool $dismissible             If the notice should be dismissible
-	 *     @type bool $always_show_on_settings If the notice should be forced to display on the
-	 *                                         plugin settings page, regardless of `$dismissible`.
-	 * }
+	 * @param string $message_id the message id
+	 * @param array $args optional arguments
 	 * @return bool
 	 */
-	public function should_display_notice( $message_id, $params = array() ) {
+	public function should_display_notice( $message_id, $args = [] ) {
 
 		// bail out if user is not a shop manager
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return false;
 		}
 
-		$params = wp_parse_args( $params, array(
-			'dismissible'             => true,
-			'always_show_on_settings' => true,
-		) );
+		$args = self::normalize_notice_arguments( $args );
 
 		// if the notice is always shown on the settings page, and we're on the settings page
-		if ( $params['always_show_on_settings'] && $this->get_plugin()->is_plugin_settings() ) {
+		if ( $args['always_show_on_settings'] && $this->get_plugin()->is_plugin_settings() ) {
 			return true;
 		}
 
 		// non-dismissible, always display
-		if ( ! $params['dismissible'] ) {
+		if ( ! $args['dismissible'] ) {
 			return true;
 		}
 
@@ -149,10 +273,11 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Render any admin notices, as well as the admin notice placeholder
+	 * Renders any admin notices, as well as the admin notice placeholder.
 	 *
 	 * @since 3.0.0
-	 * @param boolean $is_visible true if the notices should be immediately visible, false otherwise
+	 *
+	 * @param bool
 	 */
 	public function render_admin_notices( $is_visible = true ) {
 
@@ -162,82 +287,75 @@ class SV_WC_Admin_Notice_Handler {
 		}
 
 		foreach ( $this->admin_notices as $message_id => $message_data ) {
+
 			if ( ! $message_data['rendered'] ) {
+
 				$message_data['params']['is_visible'] = $is_visible;
+
 				$this->render_admin_notice( $message_data['message'], $message_id, $message_data['params'] );
+
 				$this->admin_notices[ $message_id ]['rendered'] = true;
 			}
 		}
 
 		if ( $is_visible && ! self::$admin_notice_placeholder_rendered ) {
+
 			// placeholder for moving delayed notices up into place
 			echo '<div class="js-wc-' . esc_attr( $this->get_plugin()->get_id_dasherized() ) . '-admin-notice-placeholder"></div>';
+
 			self::$admin_notice_placeholder_rendered = true;
 		}
-
 	}
 
 
 	/**
-	 * Render any delayed admin notices, which have not yet already been rendered
+	 * Renders any delayed admin notices, which have not yet already been rendered.
 	 *
 	 * @since 3.0.0
 	 */
 	public function render_delayed_admin_notices() {
+
 		$this->render_admin_notices( false );
 	}
 
 
 	/**
-	 * Render a single admin notice
+	 * Renders a single admin notice.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @param string $message the notice message to display
 	 * @param string $message_id the message id
-	 * @param array $params {
-	 *     Optional parameters.
-	 *
-	 *     @type bool $dismissible             If the notice should be dismissible
-	 *     @type bool $is_visible              If the notice should be immediately visible
-	 *     @type bool $always_show_on_settings If the notice should be forced to display on the
-	 *                                         plugin settings page, regardless of `$dismissible`.
-	 *     @type string $notice_class          Additional classes for the notice.
-	 * }
+	 * @param array $args optional arguments
 	 */
-	public function render_admin_notice( $message, $message_id, $params = array() ) {
+	public function render_admin_notice( $message, $message_id, $args = [] ) {
 
-		$params = wp_parse_args( $params, array(
-			'dismissible'             => true,
-			'is_visible'              => true,
-			'always_show_on_settings' => true,
-			'notice_class'            => 'updated',
-		) );
-
-		$classes = array(
+		$args    = self::normalize_notice_arguments( $args );
+		$classes = [
 			'notice',
 			'js-wc-plugin-framework-admin-notice',
-			$params['notice_class'],
-		);
+			$args['notice_class'],
+		];
 
 		// maybe make this notice dismissible
 		// uses a WP core class which handles the markup and styling
-		if ( $params['dismissible'] && ( ! $params['always_show_on_settings'] || ! $this->get_plugin()->is_plugin_settings() ) ) {
+		if ( $args['dismissible'] && ( ! $args['always_show_on_settings'] || ! $this->get_plugin()->is_plugin_settings() ) ) {
 			$classes[] = 'is-dismissible';
 		}
 
-		echo sprintf(
+		printf(
 			'<div class="%1$s" data-plugin-id="%2$s" data-message-id="%3$s" %4$s><p>%5$s</p></div>',
 			esc_attr( implode( ' ', $classes ) ),
 			esc_attr( $this->get_plugin()->get_id() ),
 			esc_attr( $message_id ),
-			( ! $params['is_visible'] ) ? 'style="display:none;"' : '',
+			( ! $args['is_visible'] ) ? 'style="display:none;"' : '',
 			wp_kses_post( $message )
 		);
 	}
 
 
 	/**
-	 * Render the javascript to handle the notice "dismiss" functionality
+	 * Renders the JavaScript to handle the notice "dismiss" functionality.
 	 *
 	 * @since 3.0.0
 	 */
@@ -253,8 +371,8 @@ class SV_WC_Admin_Notice_Handler {
 		self::$admin_notice_js_rendered = true;
 
 		ob_start();
-		?>
 
+		?>
 		// Log dismissed notices
 		$( '.js-wc-plugin-framework-admin-notice' ).on( 'click.wp-dismiss-notice', '.notice-dismiss', function( e ) {
 
@@ -297,22 +415,22 @@ class SV_WC_Admin_Notice_Handler {
 		// move any delayed notices up into position .show();
 		$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ).show();
 		<?php
-		$javascript = ob_get_clean();
 
-		wc_enqueue_js( $javascript );
+		wc_enqueue_js( ob_get_clean() );
 	}
 
 
 	/**
-	 * Marks the identified admin notice as dismissed for the given user
+	 * Marks the identified admin notice as dismissed for the given user.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @param string $message_id the message identifier
 	 * @param int $user_id optional user identifier, defaults to current user
 	 */
 	public function dismiss_notice( $message_id, $user_id = null ) {
 
-		if ( is_null( $user_id ) ) {
+		if ( null === $user_id ) {
 			$user_id = get_current_user_id();
 		}
 
@@ -323,28 +441,28 @@ class SV_WC_Admin_Notice_Handler {
 		update_user_meta( $user_id, '_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismissed_messages', $dismissed_notices );
 
 		/**
-		 * Admin Notice Dismissed Action.
-		 *
 		 * Fired when a user dismisses an admin notice.
 		 *
 		 * @since 3.0.0
+		 *
 		 * @param string $message_id notice identifier
-		 * @param string|int $user_id
+		 * @param int $user_id user identifier
 		 */
 		do_action( 'wc_' . $this->get_plugin()->get_id(). '_dismiss_notice', $message_id, $user_id );
 	}
 
 
 	/**
-	 * Marks the identified admin notice as not dismissed for the identified user
+	 * Marks the identified admin notice as not dismissed for the identified user.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @param string $message_id the message identifier
 	 * @param int $user_id optional user identifier, defaults to current user
 	 */
 	public function undismiss_notice( $message_id, $user_id = null ) {
 
-		if ( is_null( $user_id ) ) {
+		if ( null === $user_id ) {
 			$user_id = get_current_user_id();
 		}
 
@@ -357,13 +475,13 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Returns true if the identified admin notice has been dismissed for the
-	 * given user
+	 * Determines whether a notice was dismissed by a matching user.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @param string $message_id the message identifier
 	 * @param int $user_id optional user identifier, defaults to current user
-	 * @return boolean true if the message has been dismissed by the admin user
+	 * @return bool
 	 */
 	public function is_notice_dismissed( $message_id, $user_id = null ) {
 
@@ -374,26 +492,22 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Returns the full set of dismissed notices for the user identified by
-	 * $user_id, for this plugin
+	 * Gets dismissed notices for a given user, for the current plugin.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @param int $user_id optional user identifier, defaults to current user
-	 * @return array of message id to dismissed status (true or false)
+	 * @return array of notice identifiers with dismissed status (true or false)
 	 */
 	public function get_dismissed_notices( $user_id = null ) {
 
-		if ( is_null( $user_id ) ) {
+		if ( null === $user_id ) {
 			$user_id = get_current_user_id();
 		}
 
 		$dismissed_notices = get_user_meta( $user_id, '_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismissed_messages', true );
 
-		if ( empty( $dismissed_notices ) ) {
-			return array();
-		} else {
-			return $dismissed_notices;
-		}
+		return empty( $dismissed_notices ) || ! is_array( $dismissed_notices ) ? [] : $dismissed_notices;
 	}
 
 
@@ -401,14 +515,13 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Dismiss the identified notice
+	 * Dismisses the identified notice.
 	 *
 	 * @since 3.0.0
 	 */
 	public function handle_dismiss_notice() {
 
 		$this->dismiss_notice( $_REQUEST['messageid'] );
-
 	}
 
 
@@ -416,14 +529,17 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Get the plugin
+	 * Gets the plugin main instance.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @return SV_WC_Plugin returns the plugin instance
 	 */
 	protected function get_plugin() {
+
 		return $this->plugin;
 	}
+
 
 }
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -349,19 +349,36 @@ class SV_WC_Admin_Notice_Handler {
 	 * @since 5.4.1-dev.1
 	 *
 	 * @param int|string|\WC_Admin_Note $note admin note by ID or name
+	 * @param string $action current action (optional argument set in hook)
 	 * @return bool success
 	 */
-	public function delete_admin_note( $note ) {
+	public function delete_admin_note( $note, $action = '' ) {
 
 		if ( get_option( self::$admin_note_lock ) ) {
-			return $this->delete_admin_note( $note );
+			return $this->delete_admin_note( $note, $action );
 		}
 
 		$note   = $this->get_admin_note( $note );
 		$delete = false;
 
 		if ( $note && $this->get_plugin()->get_id_dasherized() === $note->get_source() ) {
-			$delete = $note->delete( true );
+
+			switch( current_action() ) {
+				case 'woocommerce_admin_note_action':
+					$has_dismiss_action = true;
+				break;
+				case 'woocommerce_admin_note_action_dismiss' :
+					$has_dismiss_action = true;
+					$action             = 'dismiss';
+				break;
+				default :
+					$has_dismiss_action = false;
+				break;
+			}
+
+			if ( ! $has_dismiss_action || ( $has_dismiss_action && 'dismiss' === $action ) ) {
+				$delete = $note->delete( true );
+			}
 		}
 
 		return $delete;

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -290,6 +290,10 @@ class SV_WC_Admin_Notice_Handler {
 			if ( is_array( $found_note ) ) {
 				$found_note = current( $found_note );
 			}
+
+			if ( is_numeric( $found_note ) ) {
+				$found_note = new \WC_Admin_Note( $found_note );
+			}
 		}
 
 		return $found_note instanceof \WC_Admin_Note ? $found_note : null;

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -72,6 +72,9 @@ class SV_WC_Admin_Notice_Handler {
 
 		// AJAX handler to dismiss any warning/error notices
 		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', [ $this, 'handle_dismiss_notice' ] );
+
+		// deletes an action that has been dismissed via dismiss action button
+		add_action( 'woocommerce_admin_note_action_dismiss', [ $this, 'delete_admin_note' ] );
 	}
 
 
@@ -340,7 +343,7 @@ class SV_WC_Admin_Notice_Handler {
 
 
 	/**
-	 * Deletes an admin note.
+	 * Deletes an admin note left by the current plugin.
 	 *
 	 * @since 5.4.1-dev.1
 	 *
@@ -353,9 +356,14 @@ class SV_WC_Admin_Notice_Handler {
 			return $this->delete_admin_note( $note );
 		}
 
-		$note = $this->get_admin_note( $note );
+		$note   = $this->get_admin_note( $note );
+		$delete = false;
 
-		return $note ? $note->delete() : false;
+		if ( $note && $this->get_plugin()->get_id_dasherized() === $note->get_source() ) {
+			$delete = $note->delete( true );
+		}
+
+		return $delete;
 	}
 
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -474,9 +474,23 @@ class SV_WC_Admin_Notice_Handler {
 	 * @return bool
 	 */
 	private static function should_use_admin_notes() {
+		global $current_screen;
 
-		return SV_WC_Plugin_Compatibility::is_wc_admin_available()
-			&& \WC_Admin_Page_Controller::get_instance()->is_connected_page();
+		if ( $current_screen && 'plugins' === $current_screen->id ) {
+
+			$use_admin_notes = false;
+
+		} else {
+
+			$use_admin_notes = SV_WC_Plugin_Compatibility::is_wc_admin_available();
+
+			if ( $use_admin_notes && function_exists( 'get_current_screen' ) ) {
+
+				$use_admin_notes = \WC_Admin_Page_Controller::get_instance()->is_connected_page();
+			}
+		}
+
+		return $use_admin_notes;
 	}
 
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -111,7 +111,7 @@ class SV_WC_Admin_Notice_Handler {
 
 			if ( empty( $args['date_created'] ) ) {
 				try {
-					$datetime             = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+					$datetime             = new \DateTime( date( 'Y-m-d H:i:s', current_time( 'timestamp', true ) ), new \DateTimeZone( 'UTC' ) );
 					$args['date_created'] = $datetime->format( 'c' );
 				} catch ( \Exception $e ) {
 					$args['date_created'] = date( 'Y-m-d H:i:s', current_time( 'timestamp' ) );

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -434,7 +434,7 @@ class SV_WC_Admin_Notice_Handler {
 		if ( self::should_use_admin_notes() ) {
 
 			$note    = $this->get_admin_note( $message_id );
-			$display = ! $note || ! $this->is_notice_dismissed( $note );
+			$display = ! $note || ! $this->is_notice_dismissed( $note->get_id() );
 
 		} elseif ( current_user_can( 'manage_woocommerce' ) ) {
 
@@ -744,7 +744,7 @@ class SV_WC_Admin_Notice_Handler {
 
 			foreach ( $notes as $note ) {
 				if ( ! array_key_exists( $note->get_name(), $notes ) ) {
-					$items[ $note->get_name() ] = $this->is_notice_dismissed( $note );
+					$items[ $note->get_name() ] = $this->is_notice_dismissed( $note->get_id() );
 				}
 			}
 		}

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -273,23 +273,6 @@ class SV_WC_Plugin_Compatibility {
 	}
 
 
-	/**
-	 * Connects a page to WooCommerce Admin, if available.
-	 *
-	 * @since 5.4.1-dev.1
-	 *
-	 * @see \WC_Admin_Page_Controller::connect_page() for $options
-	 *
-	 * @param array $options associative array of arguments
-	 */
-	public static function connect_wc_admin_page( $options ) {
-
-		if ( function_exists( 'get_current_screen' ) && self::is_wc_admin_available() ) {
-			\WC_Admin_Page_Controller::get_instance()->connect_page( $options );
-		}
-	}
-
-
 	/** WordPress core ******************************************************/
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -273,6 +273,23 @@ class SV_WC_Plugin_Compatibility {
 	}
 
 
+	/**
+	 * Connects a page to WooCommerce Admin, if available.
+	 *
+	 * @since 5.4.1-dev.1
+	 *
+	 * @see \WC_Admin_Page_Controller::connect_page() for $options
+	 *
+	 * @param array $options associative array of arguments
+	 */
+	public static function _wc_admin_page( $options ) {
+
+		if ( self::is_wc_admin_available() ) {
+			\WC_Admin_Page_Controller::get_instance()->connect_page( $options );
+		}
+	}
+
+
 	/** WordPress core ******************************************************/
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -268,7 +268,8 @@ class SV_WC_Plugin_Compatibility {
 	public static function is_wc_admin_available() {
 
 		// TODO in the future when the feature plugin is going to be merged into WooCommerce core, consider adding an alternative WooCommerce version check {FN:2019-07-24}
-		return class_exists( 'WC_Admin_Install' ) && class_exists( 'WC_Admin_Note' );
+		return class_exists( 'WC_Admin_Page_Controller', false )
+			&& class_exists( 'WC_Admin_Note', false );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -284,7 +284,7 @@ class SV_WC_Plugin_Compatibility {
 	 */
 	public static function connect_wc_admin_page( $options ) {
 
-		if ( self::is_wc_admin_available() ) {
+		if ( function_exists( 'get_current_screen' ) && self::is_wc_admin_available() ) {
 			\WC_Admin_Page_Controller::get_instance()->connect_page( $options );
 		}
 	}

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -258,6 +258,20 @@ class SV_WC_Plugin_Compatibility {
 	}
 
 
+	/**
+	 * Determines whether the next generation WooCommerce Admin is available.
+	 *
+	 * @since 5.4.1-dev.1
+	 *
+	 * @return bool
+	 */
+	public static function is_wc_admin_available() {
+
+		// TODO in the future when the feature plugin is going to be merged into WooCommerce core, consider adding an alternative WooCommerce version check {FN:2019-07-24}
+		return class_exists( 'WC_Admin_Install' ) && class_exists( 'WC_Admin_Note' );
+	}
+
+
 	/** WordPress core ******************************************************/
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -282,7 +282,7 @@ class SV_WC_Plugin_Compatibility {
 	 *
 	 * @param array $options associative array of arguments
 	 */
-	public static function _wc_admin_page( $options ) {
+	public static function connect_wc_admin_page( $options ) {
 
 		if ( self::is_wc_admin_available() ) {
 			\WC_Admin_Page_Controller::get_instance()->connect_page( $options );


### PR DESCRIPTION
## Add support for WooCommerce Admin Notes

Replace/integrate our WordPress notices handler to display notices, warnings and messages to merchants in admin with admin notes provided by the next generation WooCommerce Admin interface.

#### CH Story: [C12277](https://app.clubhouse.io/skyverge/story/12277/add-wc-admin-support-to-the-admin-notice-handler)

### Premise 

If a merchant has [WooCommerce Admin](https://wordpress.org/plugins/woocommerce-admin/) feature plugin installed, or later on when this plugin gets merged into WooCommerce core, there's a new place where important messages exclusive to WooCommerce are displayed, without getting mixed up with other traditional WordPress admin notices from other plugins.

In WooCommerce Admin, such admin messages are normalized as Admin Notes. These are abstracted into `WC_Admin_Note` objects which is yet another WooCommerce object collection built on top of the `WC_Data_Store` model (stored in a dedicated `wpdb` table) and made accessible to a React UI via WC REST API. Such notes, being db objects, carry a lot more information and logic than WordPress notices could (in fact, WordPress notices aren't standardized into any store: it's just a common CSS/HTML structure that could be attached to a known action hook). 

Since there will be a grace time where both installations without WooCommerce Admin and with WooCommerce Admin will be supported by our plugins, we need to account for both behaviors and continue display traditional WordPress notices where WooCommerce Admin isn't available. 

As such, we can leverage our current admin notice handler to register and display a traditional WordPress notice OR create (once, as it's saved in db) a WooCommerce Admin Note, which WooCommerce Admin will take care of outputting and handling.

### Implementation

This PR implements some conditional logic to achieve this, therefore existing plugins calling `SV_WC_Admin_Notice_Handler::add_admin_notice()` will already support admin notes if WooCommerce Admin is present.

The handler takes care of normalizing some arguments that are expected by admin notes, which differ from the arguments normally accepted by `add_admin_notice()`.  `add_admin_notice()` is made able to handle both legacy and new arguments. Our plugins can use either set of arguments and the handler will convert them for appropriate use according to WooCommerce Admin presence. 

Newer usages of `add_admin_notice()` are encouraged to use the new set of arguments, as the admin notes allow for additional fine tuning. The accepted arguments are the same as the `WC_Admin_Note` object constructor, which I'm reproducing below. Whenever I added an inline comment, there is a default value the handler will take care of; when the comment is not present, the default value is handled by WooCommerce Admin:

```php
// by calling this existing method we can already set an admin note, with or without these new additional arguments
SV_WC_Admin_Notice_Handler::add_admin_notice( $message_id, $message_content, [
	'name'          => '-', // slug, will default to $message_id
	'type'          => self::E_WC_ADMIN_NOTE_INFORMATIONAL, // milestones will be info, other notes will try to match the current notice_class attribute
	'locale'        => 'en_US', // we should have WC admin deal with it for now
	'title'         => '-', // will default to plugin name
	'content'       => '-', // will default on $message_content
	'icon'          => 'info', // will default to matching 'type'
	'content_data'  => new stdClass(),
	'status'        => self::E_WC_ADMIN_NOTE_UNACTIONED, // this means the note wasn't dismissed, by default
	'source'        => 'woocommerce', // this will match the plugin name, e.g. 'woocommerce-memberships'
	'date_created'  => '0000-00-00 00:00:00', // this will default to current time
	'date_reminder' => '', // this is handled by WC Admin in case the user snoozes the note
	'is_snoozable'  => false, // defaults to false if the note can be dismissed, true otherwise
	'actions'       => [], // if this key is not passed at all, and the note is dismissible, a "Dismiss" action will be set
] );
```

This is all that should be needed to start using notes. The admin notice handler class in this PR also comes new public methods (also used internally) to do basic CRUD operations with notes exclusively.

Existing methods have been updated to detect whether to look for notes or notices and return result consistent with existing return types, as well accepted method args.

### Types

Note types replace the `notice_class` which our admin notices have been using to color code the type of notice (warning, error, etc.).

Also Admin Notes use color coding, however, the `type` parameter will also determine where the note will appear. See following table:

|Type   |Suggested usage                     |Position   |Color
|-------|------------------------------------|-----------|-----
|info   |General info, milestones            |Inbox      |gray
|update |Plugin updates, important info      |Foreground |blue
|warning|General notice, non critical errors |Inbox      |orange/yellow
|error  |Errors demanding attention          |Foreground |red

Admin notes can appear in a foreground position, close to where WordPress notices use to show. Except they're stacked and a merchant has to cycle through them (most recent on top). Alternatively, minor messages (info, notice) may appear in an "inbox" sidebar in background, which the merchant can access to by clicking. Notes appearing  in inbox will make use of the `icon` attribute (see [Gridicons](https://github.com/Automattic/gridicons)).

### Status

Admin notes can have a status. Generally supported statuses are three: `unactioned`, `actioned`, `snoozed`. Most notes will start as `unactioned`: the user (or the plugin) has not taken any action (or the plugin hasn't dismissed the note by logic). Some notes can also be snoozed if a `is_snoozable` parameter is `true`. This generally applies to notes that appear in foreground: `snoozable` notes can be snoozed for different lengths of time. 

### Actions

Admin notes can display buttons triggering actions. Normally these actions are simply URLs that the button will follow (but nothing forbids to attach some advanced behavior here). A note can have any number of actions, or none. If none, the note needs to be dismissed via PHP code or REST API. 

### Snoozing a note

If `is_snoozable` was set to `true` an admin note shown in foreground can be snoozed by the merchant. WooCommerce Admin takes care of that (unsnoozing is done via Action Scheduler). If a note is snoozed it is temporarily dismissed from view and its status is moved to `snoozed`.

We should probably use this for nags that cannot (or shouldn't) be dismissed via action button. For example, deprecation notices. 

### Dismissing and deleting notes

Actioned notes (notes where the user has clicked an action button which triggers an `actioned` status in the note) are dismissed from view, however are retained in database. WooCommerce Admin does not look like having an automated mechanism for clearing old dismissed notes by this time and it's up to a plugin to delete its notes from db.

There is an action `woocommerce_admin_note_action` or more specific `woocommerce_admin_note_action_{$action_name}` that could be useful to hook to to automatically delete notes that have been "actioned" by an action button. It is not clear what is the recommended way to delete these notes permanently to avoid clutter in db. There is an [open issue](https://github.com/woocommerce/woocommerce-admin/issues/2505) on the WooCommerce Admin repository to introduce a proper dismissal default action, so this seems to be an open topic.

Finally, actions attached to a note is treated as meta data which gets its own table. Even if actions share the same name, new actions are created for the same note, even if they share the name of actions of other notes. When a note is deleted, its associated actions are deleted from db as well.

### Content data

Notes can also carry objects in one of their properties. This is additional, optional, data that could be used for further manipulation when an action is taken, or to carry data that is not a string and cannot be output in the content body. This type of content could be very useful for support purposes, among other usages, because, for example, the data attached to the note triggered by an error that prompted the note creation could be sent as part of a support request and processed by our support bot.

### Display

Notes are displayed anywhere WooCommerce Admin can output its views. Normally, these are all core WooCommerce admin pages (e.g. products, orders, settings...) and the newly introduced Analytics pages.

Third parties and extensions need to declare support to WooCommerce Admin to have content displayed on them, using the `wc_admin_connect_page()` function and maybe further adjusting the `wc_admin_connect_page_options` filter. The passed argument for each should contain the following data:

```php
/**
 * Connects a page to WooCommerce Admin.
 *
 * Use the `js_page` option to determine if registering.
 *
 * @param array $options {
 *   Array describing the page.
 *
 *   @type string       id           Id to reference the page.
 *   @type string|array title        Page title. Used in menus and breadcrumbs.
 *   @type string|null  parent       Parent ID. Null for new top level page.
 *   @type string       screen_id    The screen ID that represents the connected page. (Not required for registering).
 *   @type string       path         Path for this page. E.g. admin.php?page=wc-settings&tab=checkout
 *   @type string       capability   Capability needed to access the page.
 *   @type string       icon         Icon. Dashicons helper class, base64-encoded SVG, or 'none'.
 *   @type int          position     Menu item position.
 *   @type boolean      js_page      If this is a JS-powered page.
 * }
 */
wc_admin_connect_page( $options );
```

## Caveats

Some things to keep in mind when dealing with notes vs notices:

* Notices can be dismissed per user; notes are shown to all shop managers and their status changes for all
* Notices can be shown non any screen with minimal tweaking; notes will only be shown on screens that have been connected to WC Admin. Once connected it's harder not to show them on certain screens but keep them in others.
* WooCommerce Admin is still receiving a lot of updates and therefore it may be a bit premature to add support to WooCommerce Admin Notes into Framework before they are even merged into a WooCommerce beta.

## To do

### Connect pages to WooCommerce Admin

To fully support admin notes, our extensions need also to support to WooCommerce admin, otherwise its screens/cards/menu bar won't show on non-connected screens. 

To do so  one can use `wc_admin_connect_page()`. To detect whether a page has been connected, there's the function `wc_admin_is_connected_page()`. The problem with the latter is that within its logic, WooCommerce Admin makes use of `get_current_screen()` which is not always available when our plugins/framework need to check whether the admin notes system is available. 

So we would have to revise/check when our plugins add their notices, to be conditionally turned in notes, and see if this function is available and the timing to connect to WooCommerce Admin is right. Or possibly, we could add more Framework methods, connected our pages very early and then check internally if those are going to be connected, so our `SV_WC_Admin_Notice_Handler::should_use_admin_notes()` returns true for them.

### Messages handler

This PR doesn't deal yet with WordPress messages, but notes are both notices and messages. To display the latter in WooCommerce Admin pages, they also need to be adapted into notes.

## QA

- [ ] To test an implementation, a plugin needs to point its composer file to use this dev branch of the Framework rather than a release branch
- [ ] Try having such plugin setting admin notices: they should be displayed as admin  notes