### PR TITLE
[ch14390] Replacement screen helper methods

### DIFF
--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -145,9 +145,7 @@ abstract class Setup_Wizard {
 	 */
 	public function add_admin_notices() {
 
-		$current_screen = get_current_screen();
-
-		if ( ( $current_screen && 'plugins' === $current_screen->id ) || $this->get_plugin()->is_plugin_settings() ) {
+		if ( Framework\SV_WC_Helper::is_current_screen( 'plugins' ) || $this->get_plugin()->is_plugin_settings() ) {
 
 			if ( $this->is_complete() && $this->get_documentation_notice_message() ) {
 				$notice_id = "wc_{$this->id}_docs";

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.4.2-dev.1
+ * Tweak - Add replacement helper methods to get the current screen in WordPress and check the screen ID
 
 2019.08.06 - version 5.4.1
  * Misc - Add a configurable admin notice for plugins running deprecated WooCommerce versions

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -963,7 +963,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_He
 		 *
 		 * @since 5.4.2-dev.1
 		 *
-		 * @return null
+		 * @return \WP_Screen|null
 		 */
 		public static function get_current_screen() {
 			global $current_screen;

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -957,6 +957,41 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_He
 
 
 		/**
+		 * Gets the WordPress current screen.
+		 *
+		 * @see get_current_screen() replacement which is always available, unlike the WordPress core function
+		 *
+		 * @since 5.4.2-dev.1
+		 *
+		 * @return null
+		 */
+		public static function get_current_screen() {
+			global $current_screen;
+
+			return $current_screen ?: null;
+		}
+
+
+		/**
+		 * Checks if the current screen matches a specified ID.
+		 *
+		 * This helps avoiding using the get_current_screen() function which is not always available,
+		 * or setting the substitute global $current_screen every time a check needs to be performed.
+		 *
+		 * @since 5.4.2-dev.1
+		 *
+		 * @param string $id id (or property) to compare
+		 * @param string $prop optional property to compare, defaults to screen id
+		 * @return bool
+		 */
+		public static function is_current_screen( $id, $prop = 'id' ) {
+			global $current_screen;
+
+			return isset( $current_screen->$prop ) && $id === $current_screen->$prop;
+		}
+
+
+		/**
 		 * Convert a 2-character country code into its 3-character equivalent, or
 		 * vice-versa, e.g.
 		 *

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -822,7 +822,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	public function subscriptions_add_renewal_support_status_inline_style() {
 
-		if ( SV_WC_Plugin_Compatibility::normalize_wc_screen_id() === get_current_screen()->id ) {
+		if ( SV_WC_Helper::is_current_screen( SV_WC_Plugin_Compatibility::normalize_wc_screen_id() ) ) {
 			wp_add_inline_style( 'woocommerce_admin_styles', '.sv-wc-payment-gateway-renewal-status-inactive{font-size:1.4em;display:block;text-indent:-9999px;position:relative;height:1em;width:1em;cursor:pointer}.sv-wc-payment-gateway-renewal-status-inactive:before{line-height:1;margin:0;position:absolute;width:100%;height:100%;content:"\e016";color:#ffba00;font-family:WooCommerce;speak:none;font-weight:400;font-variant:normal;text-transform:none;-webkit-font-smoothing:antialiased;text-indent:0;top:0;left:0;text-align:center}' );
 		}
 	}


### PR DESCRIPTION
## Summary

We had from time to time cases where `get_current_screen()` results in a PHP error for function not existing, since this function is not always made available in WordPress, even in admin context. 

The best practice would be using the global `$current_screen` and then checking if it's not null and access the `id` property of the `WP_Screen` class. 

So, we can have a couple of helper methods to handle these common checks for us.

#### Story: [ch14390](https://app.clubhouse.io/skyverge/story/14390/avoid-property-of-non-object-notice-on-get-current-screen-id-usage)

### Details

Adds:

* `SV_WC_Helper::get_current_screen()` replacement for `get_current_screen()` which will never cause a function not existing PHP error

* `SV_WC_Helper::is_current_screen( $id )` which will check if the current screen has a specified ID (can work with other properties to via secondary optional argument) - this simplifies bunch of common ops that require to declare `global $current_screen` check if is not null/has `id` prop and then compare with another variable.

### Resources

A bunch of cases we had concerning current screen function, missing checking if function exists, or if global is not null (but I'm sure there are/were more):

* https://app.clubhouse.io/skyverge/story/11754/fatal-error-when-using-get-current-screen
* https://app.clubhouse.io/skyverge/story/14280/calling-get-current-screen-causes-error-emails-to-be-sent
* https://app.clubhouse.io/skyverge/story/8674/throws-internal-server-error-with-woocommerce-3-6
