### PR TITLE
Protect against notices when get_current_screen() returns null

### DIFF
--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -144,10 +144,9 @@ abstract class Setup_Wizard {
 	 * @since 5.2.2
 	 */
 	public function add_admin_notices() {
+		global $current_screen;
 
-		$current_screen = get_current_screen();
-
-		if ( ( $current_screen && 'plugins' === $current_screen->id ) || $this->get_plugin()->is_plugin_settings() ) {
+		if ( ( isset( $current_screen->id ) && 'plugins' === $current_screen->id ) || $this->get_plugin()->is_plugin_settings() ) {
 
 			if ( $this->is_complete() && $this->get_documentation_notice_message() ) {
 				$notice_id = "wc_{$this->id}_docs";

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -821,8 +821,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 * @since 4.1.0
 	 */
 	public function subscriptions_add_renewal_support_status_inline_style() {
+		global $current_screen;
 
-		if ( SV_WC_Plugin_Compatibility::normalize_wc_screen_id() === get_current_screen()->id ) {
+		if ( isset( $current_screen->id ) && SV_WC_Plugin_Compatibility::normalize_wc_screen_id() === $current_screen->id ) {
 			wp_add_inline_style( 'woocommerce_admin_styles', '.sv-wc-payment-gateway-renewal-status-inactive{font-size:1.4em;display:block;text-indent:-9999px;position:relative;height:1em;width:1em;cursor:pointer}.sv-wc-payment-gateway-renewal-status-inactive:before{line-height:1;margin:0;position:absolute;width:100%;height:100%;content:"\e016";color:#ffba00;font-family:WooCommerce;speak:none;font-weight:400;font-variant:normal;text-transform:none;-webkit-font-smoothing:antialiased;text-indent:0;top:0;left:0;text-align:center}' );
 		}
 	}


### PR DESCRIPTION
### [CH 14390](https://app.clubhouse.io/skyverge/story/14390)

# Summary

`get_current_screen()` sometimes returns null, and our two usages of it in the framework can throw notices in those rare instances, one of which is visible in the [Social Login setup wizard](http://cloud.skyver.ge/a895da336fe6).

even though `get_current_screen()` checks the global variable `$current_screen`, I chose to check the same global rather than continue to use `get_current_screen()` because it's much simpler and more concise to just call `isset( $current_screen->id )` rather than `is_callable( 'get_current_screen' ) && isset( get_current_screen()->id )`