### PR TITLE
[ch7127] Add standard subscription data to orders 

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.4.2-dev.1
+ * Tweak - Add a standard set of data to orders for subscription details
 
 2019.08.06 - version 5.4.1
  * Misc - Add a configurable admin notice for plugins running deprecated WooCommerce versions


### PR DESCRIPTION
## Summary

Adds subscriptions details to order payment data as set from gateway.

#### Story: [ch7127](https://app.clubhouse.io/skyverge/story/7127/add-a-standard-set-of-data-to-orders-for-subscription-details)

### Additional details

Sets a `WC_Order::payment->subscription` object of `stdClass()` with the following properties:

```
\stdClass $order->payment->subscription {
	 *  int $id the subscription's ID
	 *  bool $is_renewal whether the order is for a subscription renewal
	 *  bool $is_installment whether the subscription is for an installment
	 *  bool $is_first whether it is the first payment for an installment series
	 *  bool $is_last whether it is the last payment for an installment series
	 *}
```

The object is always set with all properties set to false and subscription ID set to 0 (default values).

Therefore actors can expect this object when Subscriptions is active, but they can easily verify by ID or whether the property `WC_Order::payment->recurring` is `true`.
