### PR TITLE
[ch10558] Alert customer when key configuration is missing

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -3,6 +3,7 @@
 2019.nn.nn - version 5.4.2-dev.1
  * Tweak - Add replacement helper methods to get the current screen in WordPress and check the screen ID
  * Misc - Change SV_WC_Payment_Gateway::is_configured() from protected to public
+ * Misc - Add admin notice when a gateway is enabled but is not configured and is unable to take payments
 
 2019.08.06 - version 5.4.1
  * Misc - Add a configurable admin notice for plugins running deprecated WooCommerce versions

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -568,6 +568,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 		// add notices about enabled debug logging
 		$this->add_debug_setting_notices();
+
+		// add notices about gateways not being configured
+		$this->add_gateway_not_configured_notices();
 	}
 
 
@@ -718,6 +721,25 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 				) );
 
 				break;
+			}
+		}
+	}
+
+
+	/**
+	 * Adds notices about gateways not being configured.
+	 *
+	 * @since 5.4.2-dev.1
+	 */
+	protected function add_gateway_not_configured_notices() {
+
+		foreach ( $this->get_gateways() as $gateway ) {
+
+			if ( $gateway->is_enabled() && ! $gateway->is_configured() && ! $gateway->inherit_settings() ) {
+
+				$this->get_admin_notice_handler()->add_admin_notice( $gateway->get_not_configured_error_message(), $gateway->get_id() . '-not-configured', [
+					'notice_class' => 'error',
+				] );
 			}
 		}
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4152,6 +4152,26 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	}
 
 
+	/**
+	 * Returns the error message for display if the gateway is not configured.
+	 *
+	 * @since 5.4.2-dev.1
+	 *
+	 * @return string
+	 */
+	public function get_not_configured_error_message() {
+
+		return sprintf(
+			/* translators: %1$s - gateway name, %2$s - <a> tag, %3$s - </a> tag, %4$s - <a> tag */
+			__( 'Heads up! %1$s is not fully configured and cannot accept payments. Please %2$sreview the documentation%3$s and configure the %4$sgateway settings%3$s.', 'woocommerce-plugin-framework' ),
+			$this->get_method_title(),
+			'<a href="' . $this->get_plugin()->get_documentation_url() . '" target="_blank">',
+			'</a>',
+			'<a href="' . $this->get_plugin()->get_settings_url( $this->get_id() ) . '">'
+		);
+	}
+
+
 	/** Deprecated Methods ********************************************************************************************/
 
 


### PR DESCRIPTION
# Summary

Adds an admin notice when a gateway is enabled, but not configured properly and can't accept payments.

### Story: [CH 10558](https://app.clubhouse.io/skyverge/story/10558/alert-the-customer-when-key-configuration-is-missing)
### Release: #340

## QA

- [ ] Enable a gateway without configuring it - see the notice
- [ ] Configure the gateway and save the settings - notice is gone
- [ ] Override `$gateway->get_not_configured_error_message()` for a gateway and see that the notice is changed to that overridden message

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description