### PR TITLE
v5.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "skyverge/wc-plugin-framework",
     "description": "The official SkyVerge WooCommerce plugin framework",
-    "version": "5.4.2",
+    "version": "5.4.3-dev",
     "require-dev": {
         "lucatume/wp-browser": "^2.1"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "title": "WooCommerce Plugin Framework",
   "author": "SkyVerge Team",
   "homepage": "https://github.com/skyverge/wc-plugin-framework#readme",

--- a/tests/_archive/unit/Addresses/Address.php
+++ b/tests/_archive/unit/Addresses/Address.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit\Addresses;
 
 use SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for PluginFramework\Addresses\Address

--- a/tests/_archive/unit/Addresses/Customer_Address.php
+++ b/tests/_archive/unit/Addresses/Customer_Address.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit\Addresses;
 
 use SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for PluginFramework\Addresses\Address

--- a/tests/_archive/unit/helper.php
+++ b/tests/_archive/unit/helper.php
@@ -4,7 +4,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
 use \Patchwork as p;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Helper Class Unit Tests

--- a/tests/_archive/unit/payment-gateway-api-response-message-helper.php
+++ b/tests/_archive/unit/payment-gateway-api-response-message-helper.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_API_Response_Message_Helper

--- a/tests/_archive/unit/payment-gateway-helper.php
+++ b/tests/_archive/unit/payment-gateway-helper.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Helper

--- a/tests/_archive/unit/payment-gateway-payment-token.php
+++ b/tests/_archive/unit/payment-gateway-payment-token.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Payment_Token

--- a/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_API_Request

--- a/tests/_archive/unit/payment-gateway/apple-pay-api-response.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-api-response.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_API_Response

--- a/tests/_archive/unit/payment-gateway/apple-pay-payment-response.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-payment-response.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_Payment_Response

--- a/tests/_archive/unit/plugin.php
+++ b/tests/_archive/unit/plugin.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_2 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
 
 /**
  * Plugin Test

--- a/tests/_support/plugins/test-plugin/includes/Plugin.php
+++ b/tests/_support/plugins/test-plugin/includes/Plugin.php
@@ -1,7 +1,7 @@
 <?php
 namespace SkyVerge\WooCommerce\TestPlugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/integration/PluginTest.php
+++ b/tests/integration/PluginTest.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the base plugin class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Plugin
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin
  */
 class PluginTest extends \Codeception\TestCase\WPTestCase {
 
@@ -152,7 +152,7 @@ class PluginTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_get_dependency_handler() {
 
-		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Plugin_Dependencies', $this->get_plugin()->get_dependency_handler() );
+		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin_Dependencies', $this->get_plugin()->get_dependency_handler() );
 	}
 
 
@@ -161,7 +161,7 @@ class PluginTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_get_lifecycle_handler() {
 
-		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_4_2\Plugin\Lifecycle', $this->get_plugin()->get_lifecycle_handler() );
+		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_4_3\Plugin\Lifecycle', $this->get_plugin()->get_lifecycle_handler() );
 	}
 
 

--- a/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce-framework-plugin-loader-sample.php
@@ -58,7 +58,7 @@ class SV_WC_Framework_Plugin_Loader {
 	const MINIMUM_WC_VERSION = '3.0.9';
 
 	/** SkyVerge plugin framework version used by this plugin */
-	const FRAMEWORK_VERSION = '5.4.2'; // TODO: framework version
+	const FRAMEWORK_VERSION = '5.4.3'; // TODO: framework version
 
 	/** the plugin name, for displaying notices */
 	const PLUGIN_NAME = 'WooCommerce Framework Plugin'; // TODO: plugin name

--- a/woocommerce/Addresses/Address.php
+++ b/woocommerce/Addresses/Address.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Addresses;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Addresses;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Addresses\\Address' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Addresses\\Address' ) ) :
 
 /**
  * The base address data class.

--- a/woocommerce/Addresses/Customer_Address.php
+++ b/woocommerce/Addresses/Customer_Address.php
@@ -22,12 +22,12 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Addresses;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Addresses;
 use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Addresses\\Customer_Address' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Addresses\\Customer_Address' ) ) :
 
 /**
  * The customer address data class.

--- a/woocommerce/Addresses/Customer_Address.php
+++ b/woocommerce/Addresses/Customer_Address.php
@@ -23,7 +23,7 @@
  */
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Addresses;
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/Country_Helper.php
+++ b/woocommerce/Country_Helper.php
@@ -1,0 +1,659 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Country_Helper' ) ) :
+
+	/**
+	 * SkyVerge Country Helper Class
+	 *
+	 * The purpose of this class is to centralize country-related utility
+	 * functions that are commonly used in SkyVerge plugins
+	 *
+	 * @since 5.4.3-dev.1
+	 */
+	class Country_Helper {
+
+
+		/** @var array ISO 3166-alpha2 => ISO 3166-alpha3  */
+		static public $alpha3 = [
+			'AF' => 'AFG', 'AL' => 'ALB', 'DZ' => 'DZA', 'AD' => 'AND', 'AO' => 'AGO',
+			'AG' => 'ATG', 'AR' => 'ARG', 'AM' => 'ARM', 'AU' => 'AUS', 'AT' => 'AUT',
+			'AZ' => 'AZE', 'BS' => 'BHS', 'BH' => 'BHR', 'BD' => 'BGD', 'BB' => 'BRB',
+			'BY' => 'BLR', 'BE' => 'BEL', 'BZ' => 'BLZ', 'BJ' => 'BEN', 'BT' => 'BTN',
+			'BO' => 'BOL', 'BA' => 'BIH', 'BW' => 'BWA', 'BR' => 'BRA', 'BN' => 'BRN',
+			'BG' => 'BGR', 'BF' => 'BFA', 'BI' => 'BDI', 'KH' => 'KHM', 'CM' => 'CMR',
+			'CA' => 'CAN', 'CV' => 'CPV', 'CF' => 'CAF', 'TD' => 'TCD', 'CL' => 'CHL',
+			'CN' => 'CHN', 'CO' => 'COL', 'KM' => 'COM', 'CD' => 'COD', 'CG' => 'COG',
+			'CR' => 'CRI', 'CI' => 'CIV', 'HR' => 'HRV', 'CU' => 'CUB', 'CY' => 'CYP',
+			'CZ' => 'CZE', 'DK' => 'DNK', 'DJ' => 'DJI', 'DM' => 'DMA', 'DO' => 'DOM',
+			'EC' => 'ECU', 'EG' => 'EGY', 'SV' => 'SLV', 'GQ' => 'GNQ', 'ER' => 'ERI',
+			'EE' => 'EST', 'ET' => 'ETH', 'FJ' => 'FJI', 'FI' => 'FIN', 'FR' => 'FRA',
+			'GA' => 'GAB', 'GM' => 'GMB', 'GE' => 'GEO', 'DE' => 'DEU', 'GH' => 'GHA',
+			'GR' => 'GRC', 'GD' => 'GRD', 'GT' => 'GTM', 'GN' => 'GIN', 'GW' => 'GNB',
+			'GY' => 'GUY', 'HT' => 'HTI', 'HN' => 'HND', 'HU' => 'HUN', 'IS' => 'ISL',
+			'IN' => 'IND', 'ID' => 'IDN', 'IR' => 'IRN', 'IQ' => 'IRQ', 'IE' => 'IRL',
+			'IL' => 'ISR', 'IT' => 'ITA', 'JM' => 'JAM', 'JP' => 'JPN', 'JO' => 'JOR',
+			'KZ' => 'KAZ', 'KE' => 'KEN', 'KI' => 'KIR', 'KP' => 'PRK', 'KR' => 'KOR',
+			'KW' => 'KWT', 'KG' => 'KGZ', 'LA' => 'LAO', 'LV' => 'LVA', 'LB' => 'LBN',
+			'LS' => 'LSO', 'LR' => 'LBR', 'LY' => 'LBY', 'LI' => 'LIE', 'LT' => 'LTU',
+			'LU' => 'LUX', 'MK' => 'MKD', 'MG' => 'MDG', 'MW' => 'MWI', 'MY' => 'MYS',
+			'MV' => 'MDV', 'ML' => 'MLI', 'MT' => 'MLT', 'MH' => 'MHL', 'MR' => 'MRT',
+			'MU' => 'MUS', 'MX' => 'MEX', 'FM' => 'FSM', 'MD' => 'MDA', 'MC' => 'MCO',
+			'MN' => 'MNG', 'ME' => 'MNE', 'MA' => 'MAR', 'MZ' => 'MOZ', 'MM' => 'MMR',
+			'NA' => 'NAM', 'NR' => 'NRU', 'NP' => 'NPL', 'NL' => 'NLD', 'NZ' => 'NZL',
+			'NI' => 'NIC', 'NE' => 'NER', 'NG' => 'NGA', 'NO' => 'NOR', 'OM' => 'OMN',
+			'PK' => 'PAK', 'PW' => 'PLW', 'PA' => 'PAN', 'PG' => 'PNG', 'PY' => 'PRY',
+			'PE' => 'PER', 'PH' => 'PHL', 'PL' => 'POL', 'PT' => 'PRT', 'QA' => 'QAT',
+			'RO' => 'ROU', 'RU' => 'RUS', 'RW' => 'RWA', 'KN' => 'KNA', 'LC' => 'LCA',
+			'VC' => 'VCT', 'WS' => 'WSM', 'SM' => 'SMR', 'ST' => 'STP', 'SA' => 'SAU',
+			'SN' => 'SEN', 'RS' => 'SRB', 'SC' => 'SYC', 'SL' => 'SLE', 'SG' => 'SGP',
+			'SK' => 'SVK', 'SI' => 'SVN', 'SB' => 'SLB', 'SO' => 'SOM', 'ZA' => 'ZAF',
+			'ES' => 'ESP', 'LK' => 'LKA', 'SD' => 'SDN', 'SR' => 'SUR', 'SZ' => 'SWZ',
+			'SE' => 'SWE', 'CH' => 'CHE', 'SY' => 'SYR', 'TJ' => 'TJK', 'TZ' => 'TZA',
+			'TH' => 'THA', 'TL' => 'TLS', 'TG' => 'TGO', 'TO' => 'TON', 'TT' => 'TTO',
+			'TN' => 'TUN', 'TR' => 'TUR', 'TM' => 'TKM', 'TV' => 'TUV', 'UG' => 'UGA',
+			'UA' => 'UKR', 'AE' => 'ARE', 'GB' => 'GBR', 'US' => 'USA', 'UY' => 'URY',
+			'UZ' => 'UZB', 'VU' => 'VUT', 'VA' => 'VAT', 'VE' => 'VEN', 'VN' => 'VNM',
+			'YE' => 'YEM', 'ZM' => 'ZMB', 'ZW' => 'ZWE', 'TW' => 'TWN', 'CX' => 'CXR',
+			'CC' => 'CCK', 'HM' => 'HMD', 'NF' => 'NFK', 'NC' => 'NCL', 'PF' => 'PYF',
+			'YT' => 'MYT', 'GP' => 'GLP', 'PM' => 'SPM', 'WF' => 'WLF', 'TF' => 'ATF',
+			'BV' => 'BVT', 'CK' => 'COK', 'NU' => 'NIU', 'TK' => 'TKL', 'GG' => 'GGY',
+			'IM' => 'IMN', 'JE' => 'JEY', 'AI' => 'AIA', 'BM' => 'BMU', 'IO' => 'IOT',
+			'VG' => 'VGB', 'KY' => 'CYM', 'FK' => 'FLK', 'GI' => 'GIB', 'MS' => 'MSR',
+			'PN' => 'PCN', 'SH' => 'SHN', 'GS' => 'SGS', 'TC' => 'TCA', 'MP' => 'MNP',
+			'PR' => 'PRI', 'AS' => 'ASM', 'UM' => 'UMI', 'GU' => 'GUM', 'VI' => 'VIR',
+			'HK' => 'HKG', 'MO' => 'MAC', 'FO' => 'FRO', 'GL' => 'GRL', 'GF' => 'GUF',
+			'MQ' => 'MTQ', 'RE' => 'REU', 'AX' => 'ALA', 'AW' => 'ABW', 'AN' => 'ANT',
+			'SJ' => 'SJM', 'AC' => 'ASC', 'TA' => 'TAA', 'AQ' => 'ATA', 'CW' => 'CUW',
+		];
+
+		/** @var array ISO 3166-alpha2 => ISO 3166-numeric  */
+		static public $numeric = [
+			'AF' => '004', 'AX' => '248', 'AL' => '008', 'DZ' => '012', 'AS' => '016',
+			'AD' => '020', 'AO' => '024', 'AI' => '660', 'AQ' => '010', 'AG' => '028',
+			'AR' => '032', 'AM' => '051', 'AW' => '533', 'AU' => '036', 'AT' => '040',
+			'AZ' => '031', 'BS' => '044', 'BH' => '048', 'BD' => '050', 'BB' => '052',
+			'BY' => '112', 'BE' => '056', 'BZ' => '084', 'BJ' => '204', 'BM' => '060',
+			'BT' => '064', 'BO' => '068', 'BQ' => '535', 'BA' => '070', 'BW' => '072',
+			'BV' => '074', 'BR' => '076', 'IO' => '086', 'BN' => '096', 'BG' => '100',
+			'BF' => '854', 'BI' => '108', 'KH' => '116', 'CM' => '120', 'CA' => '124',
+			'CV' => '132', 'KY' => '136', 'CF' => '140', 'TD' => '148', 'CL' => '152',
+			'CN' => '156', 'CX' => '162', 'CC' => '166', 'CO' => '170', 'KM' => '174',
+			'CG' => '178', 'CD' => '180', 'CK' => '184', 'CR' => '188', 'CI' => '384',
+			'HR' => '191', 'CU' => '192', 'CW' => '531', 'CY' => '196', 'CZ' => '203',
+			'DK' => '208', 'DJ' => '262', 'DM' => '212', 'DO' => '214', 'EC' => '218',
+			'EG' => '818', 'SV' => '222', 'GQ' => '226', 'ER' => '232', 'EE' => '233',
+			'ET' => '231', 'FK' => '238', 'FO' => '234', 'FJ' => '242', 'FI' => '246',
+			'FR' => '250', 'GF' => '254', 'PF' => '258', 'TF' => '260', 'GA' => '266',
+			'GM' => '270', 'GE' => '268', 'DE' => '276', 'GH' => '288', 'GI' => '292',
+			'GR' => '300', 'GL' => '304', 'GD' => '308', 'GP' => '312', 'GU' => '316',
+			'GT' => '320', 'GG' => '831', 'GN' => '324', 'GW' => '624', 'GY' => '328',
+			'HT' => '332', 'HM' => '334', 'VA' => '336', 'HN' => '340', 'HK' => '344',
+			'HU' => '348', 'IS' => '352', 'IN' => '356', 'ID' => '360', 'IR' => '364',
+			'IQ' => '368', 'IE' => '372', 'IM' => '833', 'IL' => '376', 'IT' => '380',
+			'JM' => '388', 'JP' => '392', 'JE' => '832', 'JO' => '400', 'KZ' => '398',
+			'KE' => '404', 'KI' => '296', 'KP' => '408', 'KR' => '410', 'KW' => '414',
+			'KG' => '417', 'LA' => '418', 'LV' => '428', 'LB' => '422', 'LS' => '426',
+			'LR' => '430', 'LY' => '434', 'LI' => '438', 'LT' => '440', 'LU' => '442',
+			'MO' => '446', 'MK' => '807', 'MG' => '450', 'MW' => '454', 'MY' => '458',
+			'MV' => '462', 'ML' => '466', 'MT' => '470', 'MH' => '584', 'MQ' => '474',
+			'MR' => '478', 'MU' => '480', 'YT' => '175', 'MX' => '484', 'FM' => '583',
+			'MD' => '498', 'MC' => '492', 'MN' => '496', 'ME' => '499', 'MS' => '500',
+			'MA' => '504', 'MZ' => '508', 'MM' => '104', 'NA' => '516', 'NR' => '520',
+			'NP' => '524', 'NL' => '528', 'NC' => '540', 'NZ' => '554', 'NI' => '558',
+			'NE' => '562', 'NG' => '566', 'NU' => '570', 'NF' => '574', 'MP' => '580',
+			'NO' => '578', 'OM' => '512', 'PK' => '586', 'PW' => '585', 'PS' => '275',
+			'PA' => '591', 'PG' => '598', 'PY' => '600', 'PE' => '604', 'PH' => '608',
+			'PN' => '612', 'PL' => '616', 'PT' => '620', 'PR' => '630', 'QA' => '634',
+			'RE' => '638', 'RO' => '642', 'RU' => '643', 'RW' => '646', 'BL' => '652',
+			'SH' => '654', 'KN' => '659', 'LC' => '662', 'MF' => '663', 'PM' => '666',
+			'VC' => '670', 'WS' => '882', 'SM' => '674', 'ST' => '678', 'SA' => '682',
+			'SN' => '686', 'RS' => '688', 'SC' => '690', 'SL' => '694', 'SG' => '702',
+			'SX' => '534', 'SK' => '703', 'SI' => '705', 'SB' => '090', 'SO' => '706',
+			'ZA' => '710', 'GS' => '239', 'SS' => '728', 'ES' => '724', 'LK' => '144',
+			'SD' => '729', 'SR' => '740', 'SJ' => '744', 'SZ' => '748', 'SE' => '752',
+			'CH' => '756', 'SY' => '760', 'TW' => '158', 'TJ' => '762', 'TZ' => '834',
+			'TH' => '764', 'TL' => '626', 'TG' => '768', 'TK' => '772', 'TO' => '776',
+			'TT' => '780', 'TN' => '788', 'TR' => '792', 'TM' => '795', 'TC' => '796',
+			'TV' => '798', 'UG' => '800', 'UA' => '804', 'AE' => '784', 'GB' => '826',
+			'US' => '840', 'UM' => '581', 'UY' => '858', 'UZ' => '860', 'VU' => '548',
+			'VE' => '862', 'VN' => '704', 'VG' => '092', 'VI' => '850', 'WF' => '876',
+			'EH' => '732', 'YE' => '887', 'ZM' => '894', 'ZW' => '716',
+		];
+
+		/** @var array ISO 3166-alpha2 => phone calling code(s) */
+		static public $calling_codes = [
+			'BD' => '+880',
+			'BE' => '+32',
+			'BF' => '+226',
+			'BG' => '+359',
+			'BA' => '+387',
+			'BB' => '+1246',
+			'WF' => '+681',
+			'BL' => '+590',
+			'BM' => '+1441',
+			'BN' => '+673',
+			'BO' => '+591',
+			'BH' => '+973',
+			'BI' => '+257',
+			'BJ' => '+229',
+			'BT' => '+975',
+			'JM' => '+1876',
+			'BV' => '',
+			'BW' => '+267',
+			'WS' => '+685',
+			'BQ' => '+599',
+			'BR' => '+55',
+			'BS' => '+1242',
+			'JE' => '+441534',
+			'BY' => '+375',
+			'BZ' => '+501',
+			'RU' => '+7',
+			'RW' => '+250',
+			'RS' => '+381',
+			'TL' => '+670',
+			'RE' => '+262',
+			'TM' => '+993',
+			'TJ' => '+992',
+			'RO' => '+40',
+			'TK' => '+690',
+			'GW' => '+245',
+			'GU' => '+1671',
+			'GT' => '+502',
+			'GS' => '',
+			'GR' => '+30',
+			'GQ' => '+240',
+			'GP' => '+590',
+			'JP' => '+81',
+			'GY' => '+592',
+			'GG' => '+441481',
+			'GF' => '+594',
+			'GE' => '+995',
+			'GD' => '+1473',
+			'GB' => '+44',
+			'GA' => '+241',
+			'SV' => '+503',
+			'GN' => '+224',
+			'GM' => '+220',
+			'GL' => '+299',
+			'GI' => '+350',
+			'GH' => '+233',
+			'OM' => '+968',
+			'TN' => '+216',
+			'JO' => '+962',
+			'HR' => '+385',
+			'HT' => '+509',
+			'HU' => '+36',
+			'HK' => '+852',
+			'HN' => '+504',
+			'HM' => '',
+			'VE' => '+58',
+			'PR' => [
+				'+1787',
+				'+1939',
+			],
+			'PS' => '+970',
+			'PW' => '+680',
+			'PT' => '+351',
+			'SJ' => '+47',
+			'PY' => '+595',
+			'IQ' => '+964',
+			'PA' => '+507',
+			'PF' => '+689',
+			'PG' => '+675',
+			'PE' => '+51',
+			'PK' => '+92',
+			'PH' => '+63',
+			'PN' => '+870',
+			'PL' => '+48',
+			'PM' => '+508',
+			'ZM' => '+260',
+			'EH' => '+212',
+			'EE' => '+372',
+			'EG' => '+20',
+			'ZA' => '+27',
+			'EC' => '+593',
+			'IT' => '+39',
+			'VN' => '+84',
+			'SB' => '+677',
+			'ET' => '+251',
+			'SO' => '+252',
+			'ZW' => '+263',
+			'SA' => '+966',
+			'ES' => '+34',
+			'ER' => '+291',
+			'ME' => '+382',
+			'MD' => '+373',
+			'MG' => '+261',
+			'MF' => '+590',
+			'MA' => '+212',
+			'MC' => '+377',
+			'UZ' => '+998',
+			'MM' => '+95',
+			'ML' => '+223',
+			'MO' => '+853',
+			'MN' => '+976',
+			'MH' => '+692',
+			'MK' => '+389',
+			'MU' => '+230',
+			'MT' => '+356',
+			'MW' => '+265',
+			'MV' => '+960',
+			'MQ' => '+596',
+			'MP' => '+1670',
+			'MS' => '+1664',
+			'MR' => '+222',
+			'IM' => '+441624',
+			'UG' => '+256',
+			'TZ' => '+255',
+			'MY' => '+60',
+			'MX' => '+52',
+			'IL' => '+972',
+			'FR' => '+33',
+			'IO' => '+246',
+			'SH' => '+290',
+			'FI' => '+358',
+			'FJ' => '+679',
+			'FK' => '+500',
+			'FM' => '+691',
+			'FO' => '+298',
+			'NI' => '+505',
+			'NL' => '+31',
+			'NO' => '+47',
+			'NA' => '+264',
+			'VU' => '+678',
+			'NC' => '+687',
+			'NE' => '+227',
+			'NF' => '+672',
+			'NG' => '+234',
+			'NZ' => '+64',
+			'NP' => '+977',
+			'NR' => '+674',
+			'NU' => '+683',
+			'CK' => '+682',
+			'XK' => '',
+			'CI' => '+225',
+			'CH' => '+41',
+			'CO' => '+57',
+			'CN' => '+86',
+			'CM' => '+237',
+			'CL' => '+56',
+			'CC' => '+61',
+			'CA' => '+1',
+			'CG' => '+242',
+			'CF' => '+236',
+			'CD' => '+243',
+			'CZ' => '+420',
+			'CY' => '+357',
+			'CX' => '+61',
+			'CR' => '+506',
+			'CW' => '+599',
+			'CV' => '+238',
+			'CU' => '+53',
+			'SZ' => '+268',
+			'SY' => '+963',
+			'SX' => '+599',
+			'KG' => '+996',
+			'KE' => '+254',
+			'SS' => '+211',
+			'SR' => '+597',
+			'KI' => '+686',
+			'KH' => '+855',
+			'KN' => '+1869',
+			'KM' => '+269',
+			'ST' => '+239',
+			'SK' => '+421',
+			'KR' => '+82',
+			'SI' => '+386',
+			'KP' => '+850',
+			'KW' => '+965',
+			'SN' => '+221',
+			'SM' => '+378',
+			'SL' => '+232',
+			'SC' => '+248',
+			'KZ' => '+7',
+			'KY' => '+1345',
+			'SG' => '+65',
+			'SE' => '+46',
+			'SD' => '+249',
+			'DO' => [
+				'+1809',
+				'+1829',
+				'+1849',
+			],
+			'DM' => '+1767',
+			'DJ' => '+253',
+			'DK' => '+45',
+			'VG' => '+1284',
+			'DE' => '+49',
+			'YE' => '+967',
+			'DZ' => '+213',
+			'US' => '+1',
+			'UY' => '+598',
+			'YT' => '+262',
+			'UM' => '+1',
+			'LB' => '+961',
+			'LC' => '+1758',
+			'LA' => '+856',
+			'TV' => '+688',
+			'TW' => '+886',
+			'TT' => '+1868',
+			'TR' => '+90',
+			'LK' => '+94',
+			'LI' => '+423',
+			'LV' => '+371',
+			'TO' => '+676',
+			'LT' => '+370',
+			'LU' => '+352',
+			'LR' => '+231',
+			'LS' => '+266',
+			'TH' => '+66',
+			'TF' => '',
+			'TG' => '+228',
+			'TD' => '+235',
+			'TC' => '+1649',
+			'LY' => '+218',
+			'VA' => '+379',
+			'VC' => '+1784',
+			'AE' => '+971',
+			'AD' => '+376',
+			'AG' => '+1268',
+			'AF' => '+93',
+			'AI' => '+1264',
+			'VI' => '+1340',
+			'IS' => '+354',
+			'IR' => '+98',
+			'AM' => '+374',
+			'AL' => '+355',
+			'AO' => '+244',
+			'AQ' => '',
+			'AS' => '+1684',
+			'AR' => '+54',
+			'AU' => '+61',
+			'AT' => '+43',
+			'AW' => '+297',
+			'IN' => '+91',
+			'AX' => '+35818',
+			'AZ' => '+994',
+			'IE' => '+353',
+			'ID' => '+62',
+			'UA' => '+380',
+			'QA' => '+974',
+			'MZ' => '+258',
+		];
+
+
+		/** @var array flipped calling codes */
+		protected static $flipped_calling_codes;
+
+
+		/**
+		 * Convert a 2-character country code into its 3-character equivalent, or
+		 * vice-versa, e.g.
+		 *
+		 * 1) given USA, returns US
+		 * 2) given US, returns USA
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $code ISO-3166-alpha-2 or ISO-3166-alpha-3 country code
+		 * @return string country code
+		 */
+		public static function convert_alpha_country_code( $code ) {
+
+			$countries = 3 === strlen( $code ) ? array_flip( self::$alpha3 ) : self::$alpha3;
+
+			return isset( $countries[ $code ] ) ? $countries[ $code ] : $code;
+		}
+
+
+		/**
+		 * Converts an ISO 3166-alpha2 country code to an ISO 3166-alpha3 country code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $alpha2_code ISO 3166-alpha2 country code
+		 * @return string ISO 3166-alpha3 country code
+		 */
+		public static function alpha2_to_alpha3( $alpha2_code ) {
+
+			return isset( self::$alpha3[ $alpha2_code ] ) ? self::$alpha3[ $alpha2_code ] : '';
+		}
+
+
+		/**
+		 * Converts an ISO 3166-alpha2 country code to an ISO 3166-numeric country code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $alpha2_code ISO 3166-alpha2 country code
+		 * @return string ISO 3166-numeric country code
+		 */
+		public static function alpha2_to_numeric( $alpha2_code ) {
+
+			return isset( self::$numeric[ $alpha2_code ] ) ? self::$numeric[ $alpha2_code ] : '';
+		}
+
+
+		/**
+		 * Converts an ISO 3166-alpha2 country code to a calling code.
+		 *
+		 * This conversion is available in WC 3.6+ so we'll call out to that when available.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $alpha2_code ISO 3166-alpha2 country code
+		 * @return string calling code
+		 */
+		public static function alpha2_to_calling_code( $alpha2_code ) {
+
+			// check not only for the right version, but if the helper is loaded & available
+			if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.6.0' ) && WC() && isset( WC()->countries ) && is_callable( [ WC()->countries, 'get_country_calling_code' ] ) ) {
+
+				$calling_code = WC()->countries->get_country_calling_code( $alpha2_code );
+
+			} else {
+
+				$calling_code = isset( self::$calling_codes[ $alpha2_code ] ) ? self::$calling_codes[ $alpha2_code ] : '';
+
+				// we can't really know _which_ code is to be used, so use the first
+				$calling_code = is_array( $calling_code ) ? $calling_code[0] : $calling_code;
+			}
+
+			return $calling_code;
+		}
+
+
+		/**
+		 * Converts an ISO 3166-alpha3 country code to an ISO 3166-alpha2 country code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $alpha3_code ISO 3166-alpha3 country code
+		 * @return string ISO 3166-alpha2 country code
+		 */
+		public static function alpha3_to_alpha2( $alpha3_code ) {
+
+			$countries = array_flip( self::$alpha3 );
+
+			return isset( $countries[ $alpha3_code ] ) ? $countries[ $alpha3_code ] : '';
+		}
+
+
+		/**
+		 * Converts an ISO 3166-alpha3 country code to an ISO 3166-numeric country code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $alpha3_code ISO 3166-alpha3 country code
+		 * @return string ISO 3166-numeric country code
+		 */
+		public static function alpha3_to_numeric( $alpha3_code ) {
+			return self::alpha2_to_numeric( self::alpha3_to_alpha2( $alpha3_code ) );
+		}
+
+
+		/**
+		 * Converts an ISO 3166-alpha3 country code to a calling code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $alpha3_code ISO 3166-alpha3 country code
+		 * @return string calling code
+		 */
+		public static function alpha3_to_calling_code( $alpha3_code ) {
+			return self::alpha2_to_calling_code( self::alpha3_to_alpha2( $alpha3_code ) );
+		}
+
+
+		/**
+		 * Converts an ISO 3166-numeric country code to an ISO 3166-alpha2 code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $numeric ISO 3166-numeric country code
+		 * @return string ISO 3166-alpha2 country code
+		 */
+		public static function numeric_to_alpha2( $numeric ) {
+
+			$codes = array_flip( self::$numeric );
+
+			return isset( $codes[ $numeric ] ) ? $codes[ $numeric ] : '';
+		}
+
+
+		/**
+		 * Converts an ISO 3166-numeric country code to an ISO 3166-alpha3 code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $numeric ISO 3166-numeric country code
+		 * @return string ISO 3166-alpha3 country code
+		 */
+		public static function numeric_to_alpha3( $numeric ) {
+			return self::alpha2_to_alpha3( self::numeric_to_alpha2( $numeric ) );
+		}
+
+
+		/**
+		 * Converts an ISO 3166-numeric country code to a calling code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $numeric ISO 3166-numeric country code
+		 * @return string calling code
+		 */
+		public static function numeric_to_calling_code( $numeric ) {
+			return self::alpha2_to_calling_code( self::numeric_to_alpha2( $numeric ) );
+		}
+
+
+		/**
+		 * Converts a country calling code to an ISO 3166-alpha2 code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $calling_code country calling code (includes leading '+')
+		 * @return string ISO 3166-alpha2 code
+		 */
+		public static function calling_code_to_alpha2( $calling_code ) {
+
+			$flipped_calling_codes = self::get_flipped_calling_codes();
+
+			return isset( $flipped_calling_codes[ $calling_code ] ) ? $flipped_calling_codes[ $calling_code ] : '';
+		}
+
+
+		/**
+		 * Converts a country calling code to an ISO 3166-alpha3 code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $calling_code country calling code (includes leading '+')
+		 * @return string ISO 3166-alpha3 code
+		 */
+		public static function calling_code_to_alpha3( $calling_code ) {
+
+			return self::alpha2_to_alpha3( self::calling_code_to_alpha2( $calling_code ) );
+		}
+
+
+		/**
+		 * Converts a country calling code to an ISO 3166-numeric code.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @param string $calling_code country calling code (includes leading '+')
+		 * @return string ISO 3166-numeric code
+		 */
+		public static function calling_code_to_numeric( $calling_code ) {
+
+			return self::alpha2_to_numeric( self::calling_code_to_alpha2( $calling_code ) );
+		}
+
+
+		/**
+		 * Gets the flipped version of the calling codes array.
+		 *
+		 * Since array_flip will fail on the calling codes array due to
+		 * having some arrays as values, this custom function is necessary.
+		 *
+		 * @since 5.4.3-dev.1
+		 *
+		 * @return array
+		 */
+		public static function get_flipped_calling_codes() {
+
+			if ( null === self::$flipped_calling_codes ) {
+
+				$flipped_calling_codes = [];
+
+				foreach ( self::$calling_codes as $alpha2 => $calling_code ) {
+
+					if ( is_array( $calling_code ) ) {
+
+						foreach ( $calling_code as $sub_code ) {
+
+							$flipped_calling_codes[ $sub_code ] = $alpha2;
+						}
+					} else {
+
+						$flipped_calling_codes[ $calling_code ] = $alpha2;
+					}
+				}
+
+				self::$flipped_calling_codes = $flipped_calling_codes;
+			}
+
+			return self::$flipped_calling_codes;
+		}
+
+
+	}
+
+endif; // Class exists check

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Plugin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Plugin;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Plugin\\Lifecycle' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Plugin\\Lifecycle' ) ) :
 
 /**
  * Plugin lifecycle handler.
@@ -45,7 +45,7 @@ class Lifecycle {
 	/** @var string minimum milestone version */
 	private $milestone_version;
 
-	/** @var \SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Plugin plugin instance */
+	/** @var \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin plugin instance */
 	private $plugin;
 
 
@@ -54,9 +54,9 @@ class Lifecycle {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @param \SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Plugin $plugin plugin instance
+	 * @param \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin $plugin plugin instance
 	 */
-	public function __construct( \SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Plugin $plugin ) {
+	public function __construct( \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin $plugin ) {
 
 		$this->plugin = $plugin;
 
@@ -634,7 +634,7 @@ class Lifecycle {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @return \SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Plugin
+	 * @return \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin
 	 */
 	protected function get_plugin() {
 
@@ -654,7 +654,7 @@ class Lifecycle {
 	 */
 	public function do_update() {
 
-		\SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
+		\SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
 
 

--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -25,7 +25,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Admin\\Setup_Wizard' ) ) :
 

--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -21,13 +21,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Admin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Admin\\Setup_Wizard' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Admin\\Setup_Wizard' ) ) :
 
 /**
  * The plugin Setup Wizard class.

--- a/woocommerce/api/abstract-sv-wc-api-json-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-request.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_JSON_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_JSON_Request' ) ) :
 
 /**
  * Base JSON API request class.

--- a/woocommerce/api/abstract-sv-wc-api-json-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-request.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/api/abstract-sv-wc-api-json-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_JSON_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_JSON_Response' ) ) :
 
 
 /**

--- a/woocommerce/api/abstract-sv-wc-api-json-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/api/abstract-sv-wc-api-xml-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-request.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_XML_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_XML_Request' ) ) :
 
 /**
  * Base XML API request class.

--- a/woocommerce/api/abstract-sv-wc-api-xml-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-request.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/api/abstract-sv-wc-api-xml-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_XML_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_XML_Response' ) ) :
 
 /**
  * Base XML API response class.

--- a/woocommerce/api/abstract-sv-wc-api-xml-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_Base' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Base' ) ) :
 
 /**
  * # WooCommerce Plugin Framework API Base Class

--- a/woocommerce/api/class-sv-wc-api-exception.php
+++ b/woocommerce/api/class-sv-wc-api-exception.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Exception' ) ) :
 
 	/**
 	 * Plugin Framework API Exception - generic API Exception

--- a/woocommerce/api/class-sv-wc-api-exception.php
+++ b/woocommerce/api/class-sv-wc-api-exception.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/api/interface-sv-wc-api-request.php
+++ b/woocommerce/api/interface-sv-wc-api-request.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_Request' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Request' ) ) :
 
 /**
  * API Request

--- a/woocommerce/api/interface-sv-wc-api-request.php
+++ b/woocommerce/api/interface-sv-wc-api-request.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/api/interface-sv-wc-api-response.php
+++ b/woocommerce/api/interface-sv-wc-api-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Response' ) ) :
 
 /**
  * API Response

--- a/woocommerce/api/interface-sv-wc-api-response.php
+++ b/woocommerce/api/interface-sv-wc-api-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2019.nn.nn - version 5.4.3-dev.1
+ * Fix - Do not show the checkbox to save the payment method on the checkout page if not logged in and registration during checkout is disabled
+
 2019.08.27 - version 5.4.2
  * Tweak - Add a standard set of subscription details to orders payment data set by a gateway
  * Tweak - Add replacement helper methods to get the current screen in WordPress and check the screen ID

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Admin_Notice_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Admin_Notice_Handler' ) ) :
 
 /**
  * SkyVerge Admin Notice Handler Class

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Helper' ) ) :
 
 	/**
 	 * SkyVerge Helper Class

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -1006,7 +1006,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_He
 		 */
 		public static function convert_country_code( $code ) {
 
-			wc_deprecated_function( __METHOD__, '5.4.3-dev.1', 'SV_WC_Country_Helper::convert_alpha_country_code()' );
+			wc_deprecated_function( __METHOD__, '5.4.3-dev.1', Country_Helper::class . '::convert_alpha_country_code()' );
 
 			return Country_Helper::convert_alpha_country_code( $code );
 		}

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -1004,64 +1004,9 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_He
 		 */
 		public static function convert_country_code( $code ) {
 
-			// ISO 3166-alpha-2 => ISO 3166-alpha3
-			$countries = array(
-					'AF' => 'AFG', 'AL' => 'ALB', 'DZ' => 'DZA', 'AD' => 'AND', 'AO' => 'AGO',
-					'AG' => 'ATG', 'AR' => 'ARG', 'AM' => 'ARM', 'AU' => 'AUS', 'AT' => 'AUT',
-					'AZ' => 'AZE', 'BS' => 'BHS', 'BH' => 'BHR', 'BD' => 'BGD', 'BB' => 'BRB',
-					'BY' => 'BLR', 'BE' => 'BEL', 'BZ' => 'BLZ', 'BJ' => 'BEN', 'BT' => 'BTN',
-					'BO' => 'BOL', 'BA' => 'BIH', 'BW' => 'BWA', 'BR' => 'BRA', 'BN' => 'BRN',
-					'BG' => 'BGR', 'BF' => 'BFA', 'BI' => 'BDI', 'KH' => 'KHM', 'CM' => 'CMR',
-					'CA' => 'CAN', 'CV' => 'CPV', 'CF' => 'CAF', 'TD' => 'TCD', 'CL' => 'CHL',
-					'CN' => 'CHN', 'CO' => 'COL', 'KM' => 'COM', 'CD' => 'COD', 'CG' => 'COG',
-					'CR' => 'CRI', 'CI' => 'CIV', 'HR' => 'HRV', 'CU' => 'CUB', 'CY' => 'CYP',
-					'CZ' => 'CZE', 'DK' => 'DNK', 'DJ' => 'DJI', 'DM' => 'DMA', 'DO' => 'DOM',
-					'EC' => 'ECU', 'EG' => 'EGY', 'SV' => 'SLV', 'GQ' => 'GNQ', 'ER' => 'ERI',
-					'EE' => 'EST', 'ET' => 'ETH', 'FJ' => 'FJI', 'FI' => 'FIN', 'FR' => 'FRA',
-					'GA' => 'GAB', 'GM' => 'GMB', 'GE' => 'GEO', 'DE' => 'DEU', 'GH' => 'GHA',
-					'GR' => 'GRC', 'GD' => 'GRD', 'GT' => 'GTM', 'GN' => 'GIN', 'GW' => 'GNB',
-					'GY' => 'GUY', 'HT' => 'HTI', 'HN' => 'HND', 'HU' => 'HUN', 'IS' => 'ISL',
-					'IN' => 'IND', 'ID' => 'IDN', 'IR' => 'IRN', 'IQ' => 'IRQ', 'IE' => 'IRL',
-					'IL' => 'ISR', 'IT' => 'ITA', 'JM' => 'JAM', 'JP' => 'JPN', 'JO' => 'JOR',
-					'KZ' => 'KAZ', 'KE' => 'KEN', 'KI' => 'KIR', 'KP' => 'PRK', 'KR' => 'KOR',
-					'KW' => 'KWT', 'KG' => 'KGZ', 'LA' => 'LAO', 'LV' => 'LVA', 'LB' => 'LBN',
-					'LS' => 'LSO', 'LR' => 'LBR', 'LY' => 'LBY', 'LI' => 'LIE', 'LT' => 'LTU',
-					'LU' => 'LUX', 'MK' => 'MKD', 'MG' => 'MDG', 'MW' => 'MWI', 'MY' => 'MYS',
-					'MV' => 'MDV', 'ML' => 'MLI', 'MT' => 'MLT', 'MH' => 'MHL', 'MR' => 'MRT',
-					'MU' => 'MUS', 'MX' => 'MEX', 'FM' => 'FSM', 'MD' => 'MDA', 'MC' => 'MCO',
-					'MN' => 'MNG', 'ME' => 'MNE', 'MA' => 'MAR', 'MZ' => 'MOZ', 'MM' => 'MMR',
-					'NA' => 'NAM', 'NR' => 'NRU', 'NP' => 'NPL', 'NL' => 'NLD', 'NZ' => 'NZL',
-					'NI' => 'NIC', 'NE' => 'NER', 'NG' => 'NGA', 'NO' => 'NOR', 'OM' => 'OMN',
-					'PK' => 'PAK', 'PW' => 'PLW', 'PA' => 'PAN', 'PG' => 'PNG', 'PY' => 'PRY',
-					'PE' => 'PER', 'PH' => 'PHL', 'PL' => 'POL', 'PT' => 'PRT', 'QA' => 'QAT',
-					'RO' => 'ROU', 'RU' => 'RUS', 'RW' => 'RWA', 'KN' => 'KNA', 'LC' => 'LCA',
-					'VC' => 'VCT', 'WS' => 'WSM', 'SM' => 'SMR', 'ST' => 'STP', 'SA' => 'SAU',
-					'SN' => 'SEN', 'RS' => 'SRB', 'SC' => 'SYC', 'SL' => 'SLE', 'SG' => 'SGP',
-					'SK' => 'SVK', 'SI' => 'SVN', 'SB' => 'SLB', 'SO' => 'SOM', 'ZA' => 'ZAF',
-					'ES' => 'ESP', 'LK' => 'LKA', 'SD' => 'SDN', 'SR' => 'SUR', 'SZ' => 'SWZ',
-					'SE' => 'SWE', 'CH' => 'CHE', 'SY' => 'SYR', 'TJ' => 'TJK', 'TZ' => 'TZA',
-					'TH' => 'THA', 'TL' => 'TLS', 'TG' => 'TGO', 'TO' => 'TON', 'TT' => 'TTO',
-					'TN' => 'TUN', 'TR' => 'TUR', 'TM' => 'TKM', 'TV' => 'TUV', 'UG' => 'UGA',
-					'UA' => 'UKR', 'AE' => 'ARE', 'GB' => 'GBR', 'US' => 'USA', 'UY' => 'URY',
-					'UZ' => 'UZB', 'VU' => 'VUT', 'VA' => 'VAT', 'VE' => 'VEN', 'VN' => 'VNM',
-					'YE' => 'YEM', 'ZM' => 'ZMB', 'ZW' => 'ZWE', 'TW' => 'TWN', 'CX' => 'CXR',
-					'CC' => 'CCK', 'HM' => 'HMD', 'NF' => 'NFK', 'NC' => 'NCL', 'PF' => 'PYF',
-					'YT' => 'MYT', 'GP' => 'GLP', 'PM' => 'SPM', 'WF' => 'WLF', 'TF' => 'ATF',
-					'BV' => 'BVT', 'CK' => 'COK', 'NU' => 'NIU', 'TK' => 'TKL', 'GG' => 'GGY',
-					'IM' => 'IMN', 'JE' => 'JEY', 'AI' => 'AIA', 'BM' => 'BMU', 'IO' => 'IOT',
-					'VG' => 'VGB', 'KY' => 'CYM', 'FK' => 'FLK', 'GI' => 'GIB', 'MS' => 'MSR',
-					'PN' => 'PCN', 'SH' => 'SHN', 'GS' => 'SGS', 'TC' => 'TCA', 'MP' => 'MNP',
-					'PR' => 'PRI', 'AS' => 'ASM', 'UM' => 'UMI', 'GU' => 'GUM', 'VI' => 'VIR',
-					'HK' => 'HKG', 'MO' => 'MAC', 'FO' => 'FRO', 'GL' => 'GRL', 'GF' => 'GUF',
-					'MQ' => 'MTQ', 'RE' => 'REU', 'AX' => 'ALA', 'AW' => 'ABW', 'AN' => 'ANT',
-					'SJ' => 'SJM', 'AC' => 'ASC', 'TA' => 'TAA', 'AQ' => 'ATA', 'CW' => 'CUW',
-			);
+			SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.4.3-dev.1', 'SV_WC_Country_Helper::convert_alpha_country_code()' );
 
-			if ( 3 === strlen( $code ) ) {
-				$countries = array_flip( $countries );
-			}
-
-			return isset( $countries[ $code ] ) ? $countries[ $code ] : $code;
+			return SV_WC_Country_Helper::convert_alpha_country_code( $code );
 		}
 
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -999,14 +999,16 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_He
 		 * 2) given US, returns USA
 		 *
 		 * @since 4.2.0
+		 * @deprecated 5.4.3-dev
+		 *
 		 * @param string $code ISO-3166-alpha-2 or ISO-3166-alpha-3 country code
 		 * @return string country code
 		 */
 		public static function convert_country_code( $code ) {
 
-			SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.4.3-dev.1', 'SV_WC_Country_Helper::convert_alpha_country_code()' );
+			wc_deprecated_function( __METHOD__, '5.4.3-dev.1', 'SV_WC_Country_Helper::convert_alpha_country_code()' );
 
-			return SV_WC_Country_Helper::convert_alpha_country_code( $code );
+			return Country_Helper::convert_alpha_country_code( $code );
 		}
 
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Hook_Deprecator' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Hook_Deprecator' ) ) :
 
 /**
  * SkyVerge Hook Deprecator Class

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Plugin_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin_Compatibility' ) ) :
 
 /**
  * WooCommerce Compatibility Utility Class
@@ -124,7 +124,7 @@ class SV_WC_Plugin_Compatibility {
 				$format = wc_date_format();
 			}
 
-			if ( ! is_a( $date, '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_DateTime' ) ) { // TODO: verify this {CW 2017-07-18}
+			if ( ! is_a( $date, '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_DateTime' ) ) { // TODO: verify this {CW 2017-07-18}
 				return '';
 			}
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Plugin_Dependencies' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin_Dependencies' ) ) :
 
 class SV_WC_Plugin_Dependencies {
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wc-plugin-exception.php
+++ b/woocommerce/class-sv-wc-plugin-exception.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Plugin_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin_Exception' ) ) :
 
 	/**
 	 * Plugin Framework Exception - generic Exception

--- a/woocommerce/class-sv-wc-plugin-exception.php
+++ b/woocommerce/class-sv-wc-plugin-exception.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -418,6 +418,7 @@ abstract class SV_WC_Plugin {
 
 		// common utility methods
 		require_once( $framework_path . '/class-sv-wc-helper.php' );
+		require_once( $framework_path . '/Country_Helper.php' );
 
 		// backwards compatibility for older WC versions
 		require_once( $framework_path . '/class-sv-wc-plugin-compatibility.php' );

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Plugin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin' ) ) :
 
 /**
  * # WooCommerce Plugin Framework
@@ -36,13 +36,13 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Pl
  * plugin.  This class handles all the "non-feature" support tasks such
  * as verifying dependencies are met, loading the text domain, etc.
  *
- * @version 5.4.2
+ * @version 5.4.3-dev.1
  */
 abstract class SV_WC_Plugin {
 
 
 	/** Plugin Framework Version */
-	const VERSION = '5.4.2';
+	const VERSION = '5.4.3-dev.1';
 
 	/** @var object single instance of plugin */
 	protected static $instance;

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wp-admin-message-handler.php
+++ b/woocommerce/class-sv-wp-admin-message-handler.php
@@ -22,7 +22,7 @@
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/class-sv-wp-admin-message-handler.php
+++ b/woocommerce/class-sv-wp-admin-message-handler.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WP_Admin_Message_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Admin_Message_Handler' ) ) :
 
 /**
  * # WordPress Admin Message Handler Class

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Data_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Data_Compatibility' ) ) :
 
 /**
  * WooCommerce data compatibility class.

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/compatibility/class-sv-wc-datetime.php
+++ b/woocommerce/compatibility/class-sv-wc-datetime.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_DateTime' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_DateTime' ) ) :
 
 /**
  * Backports the \WC_DateTime class to WooCommerce pre-3.0.0

--- a/woocommerce/compatibility/class-sv-wc-datetime.php
+++ b/woocommerce/compatibility/class-sv-wc-datetime.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Order_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Order_Compatibility' ) ) :
 
 /**
  * WooCommerce order compatibility class.

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/compatibility/class-sv-wc-product-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-product-compatibility.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Product_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Product_Compatibility' ) ) :
 
 /**
  * WooCommerce product compatibility class.

--- a/woocommerce/compatibility/class-sv-wc-product-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-product-compatibility.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as FrameworkBase;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
 
 /**
  * The base hosted payment handler.

--- a/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
@@ -24,7 +24,7 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as FrameworkBase;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as FrameworkBase;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
 

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as FrameworkBase;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
 
 /**
  * The base payment handler class.

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -24,7 +24,7 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as FrameworkBase;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as FrameworkBase;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
 

--- a/woocommerce/payment-gateway/Handlers/Capture.php
+++ b/woocommerce/payment-gateway/Handlers/Capture.php
@@ -24,7 +24,7 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/Handlers/Capture.php
+++ b/woocommerce/payment-gateway/Handlers/Capture.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Payment_Gateway\\Handlers\\Capture' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Capture' ) ) :
 
 /**
  * The transaction capture handler.

--- a/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
+++ b/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
@@ -21,13 +21,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Payment_Gateway\Admin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
 
 /**
  * The payment gateway plugin Setup Wizard class.

--- a/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
+++ b/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
@@ -25,7 +25,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Admin_Order' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Admin_Order' ) ) :
 
 /**
  * Handle the admin order screens.

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 /**
  * The token editor.

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Admin_User_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Admin_User_Handler' ) ) :
 
 /**
  * Handle the admin user profile settings.

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
+++ b/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Response_Message_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Response_Message_Helper' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Response Message Helper

--- a/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
+++ b/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Authorization_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Authorization_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Authorization Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Create_Payment_Token_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Create_Payment_Token_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Create Payment Token Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Customer_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Customer_Response' ) ) :
 
 	/**
 	 * WooCommerce Direct Payment Gateway API Customer Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_API_Get_Tokenized_Payment_Methods_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Get_Tokenized_Payment_Methods_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Create Payment Token Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment Credit Card Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment eCheck Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Payment_Notification_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Payment_Notification_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment Credit Card Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Request' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Request' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Request

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_API' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_API_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API_Request' ) ) :
 
 /**
  * The Apple Pay API request object.

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' ) ) :
 
 /**
  * The Apple Pay API response object.

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API' ) ) :
 
 /**
  * Sets up the Apple Pay API.
@@ -56,7 +56,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 		$this->set_request_content_type_header( 'application/json' );
 		$this->set_request_accept_header( 'application/json' );
 
-		$this->set_response_handler( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' );
+		$this->set_response_handler( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' );
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_Payment_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Payment_Response' ) ) :
 
 /**
  * The Apple Pay payment response object.

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_Admin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Admin' ) ) :
 
 /**
  * Sets up the Apple Pay settings screen.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_AJAX' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_AJAX' ) ) :
 
 /**
  * The Apple Pay AJAX handler.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_Frontend' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Frontend' ) ) :
 
 /**
  * Sets up the Apple Pay front-end functionality.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay_Orders' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Orders' ) ) :
 
 /**
  * The Apple Pay order handler.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Apple_Pay' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay' ) ) :
 
 /**
  * Sets up Apple Pay support.
@@ -952,7 +952,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 
 		$accepted_card_types = ( $this->get_processing_gateway() ) ? $this->get_processing_gateway()->get_card_types() : array();
 
-		$accepted_card_types = array_map( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Helper::normalize_card_type', $accepted_card_types );
+		$accepted_card_types = array_map( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Helper::normalize_card_type', $accepted_card_types );
 
 		$valid_networks = array(
 			SV_WC_Payment_Gateway_Helper::CARD_TYPE_AMEX       => 'amex',

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Direct' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Direct' ) ) :
 
 /**
  * # WooCommerce Payment Gateway Framework Direct Gateway

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Helper' ) ) :
 
 /**
  * SkyVerge Payment Gateway Helper Class

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Hosted' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Hosted' ) ) :
 
 /**
  * # WooCommerce Payment Gateway Framework Hosted Gateway

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_My_Payment_Methods' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_My_Payment_Methods' ) ) :
 
 /**
  * My Payment Methods Class

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Payment_Form' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Form' ) ) :
 
 /**
  * Payment Form Class
@@ -977,7 +977,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		);
 
 		if ( $this->get_gateway()->supports_card_types() ) {
-			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_4_2\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
+			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
 		}
 
 		/**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -391,7 +391,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 
 		$defaults = $this->get_gateway()->get_payment_method_defaults();
 
-		$check_hint = sprintf( '<img title="%s" class="js-sv-wc-payment-gateway-echeck-form-check-hint" src="%s" width="16" height="16" />', esc_attr__( 'Where do I find this?', 'woocommerce-plugin-framework' ), esc_url( WC()->plugin_url() . '/assets/images/help.png' ) );
+		$check_hint = sprintf( '<img title="%s" alt="%s" class="js-sv-wc-payment-gateway-echeck-form-check-hint" src="%s" width="16" height="16" />', esc_attr__( 'Where do I find this?', 'woocommerce-plugin-framework' ), esc_attr__( 'Where do I find this?', 'woocommerce-plugin-framework' ), esc_url( WC()->plugin_url() . '/assets/images/help.png' ) );
 
 		$fields = array(
 			'routing-number' => array(
@@ -509,7 +509,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 
 		$image_url = \WC_HTTPS::force_https_url( $this->get_gateway()->get_plugin()->get_payment_gateway_framework_assets_url() . '/images/sample-check.png' );
 
-		$html = sprintf( '<div class="js-sv-wc-payment-gateway-echeck-form-sample-check" style="display: none;"><img width="541" height="270" src="%s" /></div>', esc_url( $image_url ) );;
+		$html = sprintf( '<div class="js-sv-wc-payment-gateway-echeck-form-sample-check" style="display: none;"><img width="541" height="270" src="%s" alt="%s" /></div>', esc_url( $image_url ), esc_attr__( 'Sample Check', 'woocommerce-plugin-framework' ) );
 
 		/**
 		 * Payment Gateway Payment Form Sample eCheck HTML.
@@ -915,7 +915,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 	 */
 	public function render_fieldset_start() {
 
-		printf( '<fieldset id="wc-%s-%s-form">', esc_attr( $this->get_gateway()->get_id_dasherized() ), esc_attr( $this->get_gateway()->get_payment_type() ) );
+		printf( '<fieldset id="wc-%s-%s-form" aria-label="%s"><legend style="display:none;">%s</legend>', esc_attr( $this->get_gateway()->get_id_dasherized() ), esc_attr( $this->get_gateway()->get_payment_type() ), esc_attr__( 'Payment Info', 'woocommerce-plugin-framework' ), esc_attr__( 'Payment Info', 'woocommerce-plugin-framework' ) );
 
 		printf( '<div class="wc-%1$s-new-payment-method-form js-wc-%1$s-new-payment-method-form">', esc_attr( $this->get_gateway()->get_id_dasherized() ) );
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -177,9 +177,19 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		// tokenization is allowed if tokenization is enabled on the gateway
 		$tokenization_allowed = $this->get_gateway()->supports_tokenization() && $this->get_gateway()->tokenization_enabled();
 
-		// on the pay page there is no way of creating an account, so disallow tokenization for guest customers
-		if ( $tokenization_allowed && is_checkout_pay_page() && ! is_user_logged_in() ) {
-			$tokenization_allowed = false;
+		if ( $tokenization_allowed && ! is_user_logged_in() ) {
+
+			if ( is_checkout_pay_page() ) {
+
+				// on the pay page there is no way of creating an account, so disallow tokenization for guest customers
+				$tokenization_allowed = false;
+
+			} else if ( is_checkout() ) {
+
+				// on the checkout page, only allow if account creation during checkout is enabled
+				$tokenization_allowed = WC()->checkout()->is_registration_enabled();
+
+			}
 		}
 
 		/**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Plugin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Plugin' ) ) :
 
 /**
  * # WooCommerce Payment Gateway Plugin Framework

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Privacy' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Privacy' ) ) :
 
 /**
  * The payment gateway privacy handler class.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway' ) ) :
 
 /**
  * WooCommerce Payment Gateway Framework

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
+++ b/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Exception' ) ) :
 
 /**
  * Payment Gateway Exception - generic payment failure Exception

--- a/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
+++ b/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Integration' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Integration' ) ) :
 
 /**
  * Abstract Integration

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
 
 /**
  * Pre-Orders Integration

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
 
 /**
  * Subscriptions Integration

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Payment_Token' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Token' ) ) :
 
 /**
  * WooCommerce Payment Gateway Token

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WC_Payment_Gateway_Payment_Tokens_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Tokens_Handler' ) ) :
 
 /**
  * Handle the payment tokenization related functionality.

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
+++ b/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
@@ -22,17 +22,17 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2\Payment_Gateway;
-use SkyVerge\WooCommerce\PluginFramework\v5_4_2\REST_API as Plugin_REST_API;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway;
+use SkyVerge\WooCommerce\PluginFramework\v5_4_3\REST_API as Plugin_REST_API;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\Payment_Gateway\\REST_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\REST_API' ) ) :
 
 /**
  * The payment gateway plugin REST API handler class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_2\REST_API
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_3\REST_API
  *
  * @since 5.2.0
  */
@@ -44,7 +44,7 @@ class REST_API extends Plugin_REST_API {
 	 *
 	 * Plugins can override this to add their own data.
 	 *
-	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_2\REST_API::get_system_status_data()
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_3\REST_API::get_system_status_data()
 	 *
 	 * @since 5.2.0
 	 *

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -26,7 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\REST_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\REST_API' ) ) :
 
 
 /**

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/utilities/class-sv-wp-async-request.php
+++ b/woocommerce/utilities/class-sv-wp-async-request.php
@@ -27,7 +27,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WP_Async_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Async_Request' ) ) :
 
 /**
  * SkyVerge Wordpress Async Request class

--- a/woocommerce/utilities/class-sv-wp-async-request.php
+++ b/woocommerce/utilities/class-sv-wp-async-request.php
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -27,7 +27,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WP_Background_Job_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Background_Job_Handler' ) ) :
 
 /**
  * SkyVerge WordPress Background Job Handler class

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -26,7 +26,7 @@
 
  defined( 'ABSPATH' ) or exit;
 
- if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_2\\SV_WP_Job_Batch_Handler' ) ) :
+ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Job_Batch_Handler' ) ) :
 
 /**
  * The job batch handler class.

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
- namespace SkyVerge\WooCommerce\PluginFramework\v5_4_2;
+ namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
 
  defined( 'ABSPATH' ) or exit;
 


### PR DESCRIPTION
# Summary

This release enhances the logic for displaying or not the tokenization checkbox on the payment form

### Stories

- [CH 15474](https://app.clubhouse.io/skyverge/story/15474/displaying-save-payment-checkbox-for-non-logged-in-users)

## Details

Only allow tokenization for guest customers in the checkout page if account creation during checkout is enabled.

## UI Changes

None.

## QA

### Setup

- Authorize.Net gateway is installed and configured with tokenization enabled
- The Framework from this branch is used instead of the previous version

### Cases

#### Logged in customer

1. Login as a customer
1. Add product(s) to your cart
1. Proceed to the checkout page
1. Select Authorize.Net payment method
    - [x] The tokenization checkbox "Securely Save to Account" is displayed

#### Guest customer with account creation during checkout enabled

1. Enable the "Allow customers to create an account during checkout" in your WC Accounts & Privacy settings
1. In an anonymous tab, add product(s) to your cart 
1. Proceed to the checkout page
1. Select Authorize.Net payment method
    - [x] The tokenization checkbox "Securely Save to Account" is displayed

#### Guest customer with account creation during checkout disabled

1. Disable the "Allow customers to create an account during checkout" in your WC Accounts & Privacy settings
1. In an anonymous tab, add product(s) to your cart 
1. Proceed to the checkout page
1. Select Authorize.Net payment method
    - [x] The tokenization checkbox "Securely Save to Account" is **not** displayed

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version