### PR TITLE
v5.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "skyverge/wc-plugin-framework",
     "description": "The official SkyVerge WooCommerce plugin framework",
-    "version": "5.4.3",
+    "version": "5.5.0-dev",
     "require-dev": {
         "lucatume/wp-browser": "^2.1"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.4.3",
+  "version": "5.5.0",
   "title": "WooCommerce Plugin Framework",
   "author": "SkyVerge Team",
   "homepage": "https://github.com/skyverge/wc-plugin-framework#readme",

--- a/tests/_archive/unit/Addresses/Address.php
+++ b/tests/_archive/unit/Addresses/Address.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit\Addresses;
 
 use SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for PluginFramework\Addresses\Address

--- a/tests/_archive/unit/Addresses/Customer_Address.php
+++ b/tests/_archive/unit/Addresses/Customer_Address.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit\Addresses;
 
 use SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for PluginFramework\Addresses\Address

--- a/tests/_archive/unit/helper.php
+++ b/tests/_archive/unit/helper.php
@@ -4,7 +4,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
 use \Patchwork as p;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Helper Class Unit Tests

--- a/tests/_archive/unit/payment-gateway-api-response-message-helper.php
+++ b/tests/_archive/unit/payment-gateway-api-response-message-helper.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_API_Response_Message_Helper

--- a/tests/_archive/unit/payment-gateway-helper.php
+++ b/tests/_archive/unit/payment-gateway-helper.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Helper

--- a/tests/_archive/unit/payment-gateway-payment-token.php
+++ b/tests/_archive/unit/payment-gateway-payment-token.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Payment_Token

--- a/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_API_Request

--- a/tests/_archive/unit/payment-gateway/apple-pay-api-response.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-api-response.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_API_Response

--- a/tests/_archive/unit/payment-gateway/apple-pay-payment-response.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-payment-response.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_Payment_Response

--- a/tests/_archive/unit/plugin.php
+++ b/tests/_archive/unit/plugin.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_4_3 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_5_0 as PluginFramework;
 
 /**
  * Plugin Test

--- a/tests/_support/plugins/test-plugin/includes/Plugin.php
+++ b/tests/_support/plugins/test-plugin/includes/Plugin.php
@@ -1,7 +1,7 @@
 <?php
 namespace SkyVerge\WooCommerce\TestPlugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/integration/PluginTest.php
+++ b/tests/integration/PluginTest.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the base plugin class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin
  */
 class PluginTest extends \Codeception\TestCase\WPTestCase {
 
@@ -152,7 +152,7 @@ class PluginTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_get_dependency_handler() {
 
-		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin_Dependencies', $this->get_plugin()->get_dependency_handler() );
+		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin_Dependencies', $this->get_plugin()->get_dependency_handler() );
 	}
 
 
@@ -161,7 +161,7 @@ class PluginTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_get_lifecycle_handler() {
 
-		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_4_3\Plugin\Lifecycle', $this->get_plugin()->get_lifecycle_handler() );
+		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_5_0\Plugin\Lifecycle', $this->get_plugin()->get_lifecycle_handler() );
 	}
 
 

--- a/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce-framework-plugin-loader-sample.php
@@ -58,7 +58,7 @@ class SV_WC_Framework_Plugin_Loader {
 	const MINIMUM_WC_VERSION = '3.0.9';
 
 	/** SkyVerge plugin framework version used by this plugin */
-	const FRAMEWORK_VERSION = '5.4.3'; // TODO: framework version
+	const FRAMEWORK_VERSION = '5.5.0'; // TODO: framework version
 
 	/** the plugin name, for displaying notices */
 	const PLUGIN_NAME = 'WooCommerce Framework Plugin'; // TODO: plugin name
@@ -157,7 +157,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @since 1.0.0
 	 */
-	protected function load_framework() {
+	private function load_framework() {
 
 		if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\' . $this->get_framework_version_namespace() . '\\SV_WC_Plugin' ) ) {
 			require_once( plugin_dir_path( __FILE__ ) . 'lib/skyverge/woocommerce/class-sv-wc-plugin.php' );
@@ -177,7 +177,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return string
 	 */
-	protected function get_framework_version_namespace() {
+	private function get_framework_version_namespace() {
 
 		return 'v' . str_replace( '.', '_', $this->get_framework_version() );
 	}
@@ -190,7 +190,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return string
 	 */
-	protected function get_framework_version() {
+	private function get_framework_version() {
 
 		return self::FRAMEWORK_VERSION;
 	}
@@ -200,6 +200,8 @@ class SV_WC_Framework_Plugin_Loader {
 	 * Checks the server environment and other factors and deactivates plugins as necessary.
 	 *
 	 * Based on http://wptavern.com/how-to-prevent-wordpress-plugins-from-activating-on-sites-with-incompatible-hosting-environments
+	 *
+	 * @internal
 	 *
 	 * @since 1.0.0
 	 */
@@ -213,8 +215,11 @@ class SV_WC_Framework_Plugin_Loader {
 		}
 	}
 
+
 	/**
 	 * Checks the environment on loading WordPress, just in case the environment changes after activation.
+	 *
+	 * @internal
 	 *
 	 * @since 1.0.0
 	 */
@@ -231,6 +236,8 @@ class SV_WC_Framework_Plugin_Loader {
 
 	/**
 	 * Adds notices for out-of-date WordPress and/or WooCommerce versions.
+	 *
+	 * @internal
 	 *
 	 * @since 1.0.0
 	 */
@@ -266,7 +273,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return bool
 	 */
-	protected function plugins_compatible() {
+	private function plugins_compatible() {
 
 		return $this->is_wp_compatible() && $this->is_wc_compatible();
 	}
@@ -279,7 +286,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return bool
 	 */
-	protected function is_wp_compatible() {
+	private function is_wp_compatible() {
 
 		if ( ! self::MINIMUM_WP_VERSION ) {
 			return true;
@@ -296,7 +303,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return bool
 	 */
-	protected function is_wc_compatible() {
+	private function is_wc_compatible() {
 
 		if ( ! self::MINIMUM_WC_VERSION ) {
 			return true;
@@ -308,6 +315,8 @@ class SV_WC_Framework_Plugin_Loader {
 
 	/**
 	 * Deactivates the plugin.
+	 *
+	 * @internal
 	 *
 	 * @since 1.0.0
 	 */
@@ -330,7 +339,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 * @param string $class the css class for the notice
 	 * @param string $message the notice message
 	 */
-	public function add_admin_notice( $slug, $class, $message ) {
+	private function add_admin_notice( $slug, $class, $message ) {
 
 		$this->notices[ $slug ] = array(
 			'class'   => $class,
@@ -342,6 +351,8 @@ class SV_WC_Framework_Plugin_Loader {
 	/**
 	 * Displays any admin notices added with \SV_WC_Framework_Plugin_Loader::add_admin_notice()
 	 *
+	 * @internal
+	 *
 	 * @since 1.0.0
 	 */
 	public function admin_notices() {
@@ -350,9 +361,7 @@ class SV_WC_Framework_Plugin_Loader {
 
 			?>
 			<div class="<?php echo esc_attr( $notice['class'] ); ?>">
-				<p>
-					<?php echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) ); ?>
-				</p>
+				<p><?php echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) ); ?></p>
 			</div>
 			<?php
 		}
@@ -368,7 +377,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return bool
 	 */
-	protected function is_environment_compatible() {
+	private function is_environment_compatible() {
 
 		return version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '>=' );
 	}
@@ -381,11 +390,9 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return string
 	 */
-	protected function get_environment_message() {
+	private function get_environment_message() {
 
-		$message = sprintf( 'The minimum PHP version required for this plugin is %1$s. You are running %2$s.', self::MINIMUM_PHP_VERSION, PHP_VERSION );
-
-		return $message;
+		return sprintf( 'The minimum PHP version required for this plugin is %1$s. You are running %2$s.', self::MINIMUM_PHP_VERSION, PHP_VERSION );
 	}
 
 

--- a/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce-framework-plugin-loader-sample.php
@@ -177,7 +177,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return string
 	 */
-	private function get_framework_version_namespace() {
+	public function get_framework_version_namespace() {
 
 		return 'v' . str_replace( '.', '_', $this->get_framework_version() );
 	}
@@ -190,7 +190,7 @@ class SV_WC_Framework_Plugin_Loader {
 	 *
 	 * @return string
 	 */
-	private function get_framework_version() {
+	public function get_framework_version() {
 
 		return self::FRAMEWORK_VERSION;
 	}

--- a/woocommerce/Addresses/Address.php
+++ b/woocommerce/Addresses/Address.php
@@ -28,11 +28,12 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Addresses\\Address' ) ) :
 
+
 /**
  * The base address data class.
  *
- * This serves as a standard address object to be passed around by plugins whenever dealing with address data, and
- * eliminates the need to rely on WooCommerce's address arrays.
+ * This serves as a standard address object to be passed around by plugins whenever dealing with address data.
+ * Eliminates the need to rely on WooCommerce's address arrays.
  *
  * @since 5.3.0
  */
@@ -179,7 +180,7 @@ class Address {
 	 */
 	protected function get_hash_data() {
 
-		return array(
+		return [
 			$this->get_line_1(),
 			$this->get_line_2(),
 			$this->get_line_3(),
@@ -187,7 +188,7 @@ class Address {
 			$this->get_region(),
 			$this->get_country(),
 			$this->get_postcode(),
-		);
+		];
 	}
 
 
@@ -286,5 +287,6 @@ class Address {
 
 
 }
+
 
 endif;

--- a/woocommerce/Addresses/Address.php
+++ b/woocommerce/Addresses/Address.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Addresses;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Addresses;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Addresses\\Address' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Addresses\\Address' ) ) :
 
 /**
  * The base address data class.

--- a/woocommerce/Addresses/Customer_Address.php
+++ b/woocommerce/Addresses/Customer_Address.php
@@ -22,12 +22,12 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Addresses;
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Addresses;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Addresses\\Customer_Address' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Addresses\\Customer_Address' ) ) :
 
 /**
  * The customer address data class.

--- a/woocommerce/Addresses/Customer_Address.php
+++ b/woocommerce/Addresses/Customer_Address.php
@@ -23,19 +23,16 @@
  */
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Addresses;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Addresses\\Customer_Address' ) ) :
 
+
 /**
  * The customer address data class.
  *
- * Adds customer-specific data to a base address, as used for a billing or shipping address that can include first
- * and last name.
- *
- * @see Address
+ * Adds customer-specific data to a base address, as used for a billing or shipping address that can include first and last name.
  *
  * @since 5.3.0
  */
@@ -90,12 +87,10 @@ class Customer_Address extends Address {
 	protected function get_hash_data() {
 
 		// add the first & last name to data used to generate the hash
-		$data = array_merge( array(
+		return array_merge( [
 			$this->get_first_name(),
 			$this->get_last_name(),
-		), parent::get_hash_data() );
-
-		return $data;
+		], parent::get_hash_data() );
 	}
 
 
@@ -138,17 +133,18 @@ class Customer_Address extends Address {
 	 */
 	public function set_from_order( \WC_Order $order, $type = 'billing' ) {
 
-		$this->set_first_name( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_first_name" ) );
-		$this->set_last_name( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_last_name" ) );
-		$this->set_line_1( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_address_1" ) );
-		$this->set_line_2( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_address_2" ) );
-		$this->set_locality( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_city" ) );
-		$this->set_region( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_state" ) );
-		$this->set_country( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_country" ) );
-		$this->set_postcode( Framework\SV_WC_Order_Compatibility::get_prop( $order, "{$type}_postcode" ) );
+		$this->set_first_name( $order->{"get_{$type}_first_name"}() );
+		$this->set_last_name( $order->{"get_{$type}_last_name"}() );
+		$this->set_line_1( $order->{"get_{$type}_address_1"}() );
+		$this->set_line_2( $order->{"get_{$type}_address_2"}() );
+		$this->set_locality( $order->{"get_{$type}_city"}() );
+		$this->set_region( $order->{"get_{$type}_state"}() );
+		$this->set_country( $order->{"get_{$type}_country"}() );
+		$this->set_postcode( $order->{"get_{$type}_postcode"}() );
 	}
 
 
 }
+
 
 endif;

--- a/woocommerce/Country_Helper.php
+++ b/woocommerce/Country_Helper.php
@@ -28,632 +28,634 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Country_Helper' ) ) :
 
+
+/**
+ * SkyVerge Country Helper Class
+ *
+ * The purpose of this class is to centralize country-related utility
+ * functions that are commonly used in SkyVerge plugins
+ *
+ * @since 5.4.3
+ */
+class Country_Helper {
+
+
+	/** @var array ISO 3166-alpha2 => ISO 3166-alpha3  */
+	static public $alpha3 = [
+		'AF' => 'AFG', 'AL' => 'ALB', 'DZ' => 'DZA', 'AD' => 'AND', 'AO' => 'AGO',
+		'AG' => 'ATG', 'AR' => 'ARG', 'AM' => 'ARM', 'AU' => 'AUS', 'AT' => 'AUT',
+		'AZ' => 'AZE', 'BS' => 'BHS', 'BH' => 'BHR', 'BD' => 'BGD', 'BB' => 'BRB',
+		'BY' => 'BLR', 'BE' => 'BEL', 'BZ' => 'BLZ', 'BJ' => 'BEN', 'BT' => 'BTN',
+		'BO' => 'BOL', 'BA' => 'BIH', 'BW' => 'BWA', 'BR' => 'BRA', 'BN' => 'BRN',
+		'BG' => 'BGR', 'BF' => 'BFA', 'BI' => 'BDI', 'KH' => 'KHM', 'CM' => 'CMR',
+		'CA' => 'CAN', 'CV' => 'CPV', 'CF' => 'CAF', 'TD' => 'TCD', 'CL' => 'CHL',
+		'CN' => 'CHN', 'CO' => 'COL', 'KM' => 'COM', 'CD' => 'COD', 'CG' => 'COG',
+		'CR' => 'CRI', 'CI' => 'CIV', 'HR' => 'HRV', 'CU' => 'CUB', 'CY' => 'CYP',
+		'CZ' => 'CZE', 'DK' => 'DNK', 'DJ' => 'DJI', 'DM' => 'DMA', 'DO' => 'DOM',
+		'EC' => 'ECU', 'EG' => 'EGY', 'SV' => 'SLV', 'GQ' => 'GNQ', 'ER' => 'ERI',
+		'EE' => 'EST', 'ET' => 'ETH', 'FJ' => 'FJI', 'FI' => 'FIN', 'FR' => 'FRA',
+		'GA' => 'GAB', 'GM' => 'GMB', 'GE' => 'GEO', 'DE' => 'DEU', 'GH' => 'GHA',
+		'GR' => 'GRC', 'GD' => 'GRD', 'GT' => 'GTM', 'GN' => 'GIN', 'GW' => 'GNB',
+		'GY' => 'GUY', 'HT' => 'HTI', 'HN' => 'HND', 'HU' => 'HUN', 'IS' => 'ISL',
+		'IN' => 'IND', 'ID' => 'IDN', 'IR' => 'IRN', 'IQ' => 'IRQ', 'IE' => 'IRL',
+		'IL' => 'ISR', 'IT' => 'ITA', 'JM' => 'JAM', 'JP' => 'JPN', 'JO' => 'JOR',
+		'KZ' => 'KAZ', 'KE' => 'KEN', 'KI' => 'KIR', 'KP' => 'PRK', 'KR' => 'KOR',
+		'KW' => 'KWT', 'KG' => 'KGZ', 'LA' => 'LAO', 'LV' => 'LVA', 'LB' => 'LBN',
+		'LS' => 'LSO', 'LR' => 'LBR', 'LY' => 'LBY', 'LI' => 'LIE', 'LT' => 'LTU',
+		'LU' => 'LUX', 'MK' => 'MKD', 'MG' => 'MDG', 'MW' => 'MWI', 'MY' => 'MYS',
+		'MV' => 'MDV', 'ML' => 'MLI', 'MT' => 'MLT', 'MH' => 'MHL', 'MR' => 'MRT',
+		'MU' => 'MUS', 'MX' => 'MEX', 'FM' => 'FSM', 'MD' => 'MDA', 'MC' => 'MCO',
+		'MN' => 'MNG', 'ME' => 'MNE', 'MA' => 'MAR', 'MZ' => 'MOZ', 'MM' => 'MMR',
+		'NA' => 'NAM', 'NR' => 'NRU', 'NP' => 'NPL', 'NL' => 'NLD', 'NZ' => 'NZL',
+		'NI' => 'NIC', 'NE' => 'NER', 'NG' => 'NGA', 'NO' => 'NOR', 'OM' => 'OMN',
+		'PK' => 'PAK', 'PW' => 'PLW', 'PA' => 'PAN', 'PG' => 'PNG', 'PY' => 'PRY',
+		'PE' => 'PER', 'PH' => 'PHL', 'PL' => 'POL', 'PT' => 'PRT', 'QA' => 'QAT',
+		'RO' => 'ROU', 'RU' => 'RUS', 'RW' => 'RWA', 'KN' => 'KNA', 'LC' => 'LCA',
+		'VC' => 'VCT', 'WS' => 'WSM', 'SM' => 'SMR', 'ST' => 'STP', 'SA' => 'SAU',
+		'SN' => 'SEN', 'RS' => 'SRB', 'SC' => 'SYC', 'SL' => 'SLE', 'SG' => 'SGP',
+		'SK' => 'SVK', 'SI' => 'SVN', 'SB' => 'SLB', 'SO' => 'SOM', 'ZA' => 'ZAF',
+		'ES' => 'ESP', 'LK' => 'LKA', 'SD' => 'SDN', 'SR' => 'SUR', 'SZ' => 'SWZ',
+		'SE' => 'SWE', 'CH' => 'CHE', 'SY' => 'SYR', 'TJ' => 'TJK', 'TZ' => 'TZA',
+		'TH' => 'THA', 'TL' => 'TLS', 'TG' => 'TGO', 'TO' => 'TON', 'TT' => 'TTO',
+		'TN' => 'TUN', 'TR' => 'TUR', 'TM' => 'TKM', 'TV' => 'TUV', 'UG' => 'UGA',
+		'UA' => 'UKR', 'AE' => 'ARE', 'GB' => 'GBR', 'US' => 'USA', 'UY' => 'URY',
+		'UZ' => 'UZB', 'VU' => 'VUT', 'VA' => 'VAT', 'VE' => 'VEN', 'VN' => 'VNM',
+		'YE' => 'YEM', 'ZM' => 'ZMB', 'ZW' => 'ZWE', 'TW' => 'TWN', 'CX' => 'CXR',
+		'CC' => 'CCK', 'HM' => 'HMD', 'NF' => 'NFK', 'NC' => 'NCL', 'PF' => 'PYF',
+		'YT' => 'MYT', 'GP' => 'GLP', 'PM' => 'SPM', 'WF' => 'WLF', 'TF' => 'ATF',
+		'BV' => 'BVT', 'CK' => 'COK', 'NU' => 'NIU', 'TK' => 'TKL', 'GG' => 'GGY',
+		'IM' => 'IMN', 'JE' => 'JEY', 'AI' => 'AIA', 'BM' => 'BMU', 'IO' => 'IOT',
+		'VG' => 'VGB', 'KY' => 'CYM', 'FK' => 'FLK', 'GI' => 'GIB', 'MS' => 'MSR',
+		'PN' => 'PCN', 'SH' => 'SHN', 'GS' => 'SGS', 'TC' => 'TCA', 'MP' => 'MNP',
+		'PR' => 'PRI', 'AS' => 'ASM', 'UM' => 'UMI', 'GU' => 'GUM', 'VI' => 'VIR',
+		'HK' => 'HKG', 'MO' => 'MAC', 'FO' => 'FRO', 'GL' => 'GRL', 'GF' => 'GUF',
+		'MQ' => 'MTQ', 'RE' => 'REU', 'AX' => 'ALA', 'AW' => 'ABW', 'AN' => 'ANT',
+		'SJ' => 'SJM', 'AC' => 'ASC', 'TA' => 'TAA', 'AQ' => 'ATA', 'CW' => 'CUW',
+	];
+
+	/** @var array ISO 3166-alpha2 => ISO 3166-numeric  */
+	static public $numeric = [
+		'AF' => '004', 'AX' => '248', 'AL' => '008', 'DZ' => '012', 'AS' => '016',
+		'AD' => '020', 'AO' => '024', 'AI' => '660', 'AQ' => '010', 'AG' => '028',
+		'AR' => '032', 'AM' => '051', 'AW' => '533', 'AU' => '036', 'AT' => '040',
+		'AZ' => '031', 'BS' => '044', 'BH' => '048', 'BD' => '050', 'BB' => '052',
+		'BY' => '112', 'BE' => '056', 'BZ' => '084', 'BJ' => '204', 'BM' => '060',
+		'BT' => '064', 'BO' => '068', 'BQ' => '535', 'BA' => '070', 'BW' => '072',
+		'BV' => '074', 'BR' => '076', 'IO' => '086', 'BN' => '096', 'BG' => '100',
+		'BF' => '854', 'BI' => '108', 'KH' => '116', 'CM' => '120', 'CA' => '124',
+		'CV' => '132', 'KY' => '136', 'CF' => '140', 'TD' => '148', 'CL' => '152',
+		'CN' => '156', 'CX' => '162', 'CC' => '166', 'CO' => '170', 'KM' => '174',
+		'CG' => '178', 'CD' => '180', 'CK' => '184', 'CR' => '188', 'CI' => '384',
+		'HR' => '191', 'CU' => '192', 'CW' => '531', 'CY' => '196', 'CZ' => '203',
+		'DK' => '208', 'DJ' => '262', 'DM' => '212', 'DO' => '214', 'EC' => '218',
+		'EG' => '818', 'SV' => '222', 'GQ' => '226', 'ER' => '232', 'EE' => '233',
+		'ET' => '231', 'FK' => '238', 'FO' => '234', 'FJ' => '242', 'FI' => '246',
+		'FR' => '250', 'GF' => '254', 'PF' => '258', 'TF' => '260', 'GA' => '266',
+		'GM' => '270', 'GE' => '268', 'DE' => '276', 'GH' => '288', 'GI' => '292',
+		'GR' => '300', 'GL' => '304', 'GD' => '308', 'GP' => '312', 'GU' => '316',
+		'GT' => '320', 'GG' => '831', 'GN' => '324', 'GW' => '624', 'GY' => '328',
+		'HT' => '332', 'HM' => '334', 'VA' => '336', 'HN' => '340', 'HK' => '344',
+		'HU' => '348', 'IS' => '352', 'IN' => '356', 'ID' => '360', 'IR' => '364',
+		'IQ' => '368', 'IE' => '372', 'IM' => '833', 'IL' => '376', 'IT' => '380',
+		'JM' => '388', 'JP' => '392', 'JE' => '832', 'JO' => '400', 'KZ' => '398',
+		'KE' => '404', 'KI' => '296', 'KP' => '408', 'KR' => '410', 'KW' => '414',
+		'KG' => '417', 'LA' => '418', 'LV' => '428', 'LB' => '422', 'LS' => '426',
+		'LR' => '430', 'LY' => '434', 'LI' => '438', 'LT' => '440', 'LU' => '442',
+		'MO' => '446', 'MK' => '807', 'MG' => '450', 'MW' => '454', 'MY' => '458',
+		'MV' => '462', 'ML' => '466', 'MT' => '470', 'MH' => '584', 'MQ' => '474',
+		'MR' => '478', 'MU' => '480', 'YT' => '175', 'MX' => '484', 'FM' => '583',
+		'MD' => '498', 'MC' => '492', 'MN' => '496', 'ME' => '499', 'MS' => '500',
+		'MA' => '504', 'MZ' => '508', 'MM' => '104', 'NA' => '516', 'NR' => '520',
+		'NP' => '524', 'NL' => '528', 'NC' => '540', 'NZ' => '554', 'NI' => '558',
+		'NE' => '562', 'NG' => '566', 'NU' => '570', 'NF' => '574', 'MP' => '580',
+		'NO' => '578', 'OM' => '512', 'PK' => '586', 'PW' => '585', 'PS' => '275',
+		'PA' => '591', 'PG' => '598', 'PY' => '600', 'PE' => '604', 'PH' => '608',
+		'PN' => '612', 'PL' => '616', 'PT' => '620', 'PR' => '630', 'QA' => '634',
+		'RE' => '638', 'RO' => '642', 'RU' => '643', 'RW' => '646', 'BL' => '652',
+		'SH' => '654', 'KN' => '659', 'LC' => '662', 'MF' => '663', 'PM' => '666',
+		'VC' => '670', 'WS' => '882', 'SM' => '674', 'ST' => '678', 'SA' => '682',
+		'SN' => '686', 'RS' => '688', 'SC' => '690', 'SL' => '694', 'SG' => '702',
+		'SX' => '534', 'SK' => '703', 'SI' => '705', 'SB' => '090', 'SO' => '706',
+		'ZA' => '710', 'GS' => '239', 'SS' => '728', 'ES' => '724', 'LK' => '144',
+		'SD' => '729', 'SR' => '740', 'SJ' => '744', 'SZ' => '748', 'SE' => '752',
+		'CH' => '756', 'SY' => '760', 'TW' => '158', 'TJ' => '762', 'TZ' => '834',
+		'TH' => '764', 'TL' => '626', 'TG' => '768', 'TK' => '772', 'TO' => '776',
+		'TT' => '780', 'TN' => '788', 'TR' => '792', 'TM' => '795', 'TC' => '796',
+		'TV' => '798', 'UG' => '800', 'UA' => '804', 'AE' => '784', 'GB' => '826',
+		'US' => '840', 'UM' => '581', 'UY' => '858', 'UZ' => '860', 'VU' => '548',
+		'VE' => '862', 'VN' => '704', 'VG' => '092', 'VI' => '850', 'WF' => '876',
+		'EH' => '732', 'YE' => '887', 'ZM' => '894', 'ZW' => '716',
+	];
+
+	/** @var array ISO 3166-alpha2 => phone calling code(s) */
+	static public $calling_codes = [
+		'BD' => '+880',
+		'BE' => '+32',
+		'BF' => '+226',
+		'BG' => '+359',
+		'BA' => '+387',
+		'BB' => '+1246',
+		'WF' => '+681',
+		'BL' => '+590',
+		'BM' => '+1441',
+		'BN' => '+673',
+		'BO' => '+591',
+		'BH' => '+973',
+		'BI' => '+257',
+		'BJ' => '+229',
+		'BT' => '+975',
+		'JM' => '+1876',
+		'BV' => '',
+		'BW' => '+267',
+		'WS' => '+685',
+		'BQ' => '+599',
+		'BR' => '+55',
+		'BS' => '+1242',
+		'JE' => '+441534',
+		'BY' => '+375',
+		'BZ' => '+501',
+		'RU' => '+7',
+		'RW' => '+250',
+		'RS' => '+381',
+		'TL' => '+670',
+		'RE' => '+262',
+		'TM' => '+993',
+		'TJ' => '+992',
+		'RO' => '+40',
+		'TK' => '+690',
+		'GW' => '+245',
+		'GU' => '+1671',
+		'GT' => '+502',
+		'GS' => '',
+		'GR' => '+30',
+		'GQ' => '+240',
+		'GP' => '+590',
+		'JP' => '+81',
+		'GY' => '+592',
+		'GG' => '+441481',
+		'GF' => '+594',
+		'GE' => '+995',
+		'GD' => '+1473',
+		'GB' => '+44',
+		'GA' => '+241',
+		'SV' => '+503',
+		'GN' => '+224',
+		'GM' => '+220',
+		'GL' => '+299',
+		'GI' => '+350',
+		'GH' => '+233',
+		'OM' => '+968',
+		'TN' => '+216',
+		'JO' => '+962',
+		'HR' => '+385',
+		'HT' => '+509',
+		'HU' => '+36',
+		'HK' => '+852',
+		'HN' => '+504',
+		'HM' => '',
+		'VE' => '+58',
+		'PR' => [
+			'+1787',
+			'+1939',
+		],
+		'PS' => '+970',
+		'PW' => '+680',
+		'PT' => '+351',
+		'SJ' => '+47',
+		'PY' => '+595',
+		'IQ' => '+964',
+		'PA' => '+507',
+		'PF' => '+689',
+		'PG' => '+675',
+		'PE' => '+51',
+		'PK' => '+92',
+		'PH' => '+63',
+		'PN' => '+870',
+		'PL' => '+48',
+		'PM' => '+508',
+		'ZM' => '+260',
+		'EH' => '+212',
+		'EE' => '+372',
+		'EG' => '+20',
+		'ZA' => '+27',
+		'EC' => '+593',
+		'IT' => '+39',
+		'VN' => '+84',
+		'SB' => '+677',
+		'ET' => '+251',
+		'SO' => '+252',
+		'ZW' => '+263',
+		'SA' => '+966',
+		'ES' => '+34',
+		'ER' => '+291',
+		'ME' => '+382',
+		'MD' => '+373',
+		'MG' => '+261',
+		'MF' => '+590',
+		'MA' => '+212',
+		'MC' => '+377',
+		'UZ' => '+998',
+		'MM' => '+95',
+		'ML' => '+223',
+		'MO' => '+853',
+		'MN' => '+976',
+		'MH' => '+692',
+		'MK' => '+389',
+		'MU' => '+230',
+		'MT' => '+356',
+		'MW' => '+265',
+		'MV' => '+960',
+		'MQ' => '+596',
+		'MP' => '+1670',
+		'MS' => '+1664',
+		'MR' => '+222',
+		'IM' => '+441624',
+		'UG' => '+256',
+		'TZ' => '+255',
+		'MY' => '+60',
+		'MX' => '+52',
+		'IL' => '+972',
+		'FR' => '+33',
+		'IO' => '+246',
+		'SH' => '+290',
+		'FI' => '+358',
+		'FJ' => '+679',
+		'FK' => '+500',
+		'FM' => '+691',
+		'FO' => '+298',
+		'NI' => '+505',
+		'NL' => '+31',
+		'NO' => '+47',
+		'NA' => '+264',
+		'VU' => '+678',
+		'NC' => '+687',
+		'NE' => '+227',
+		'NF' => '+672',
+		'NG' => '+234',
+		'NZ' => '+64',
+		'NP' => '+977',
+		'NR' => '+674',
+		'NU' => '+683',
+		'CK' => '+682',
+		'XK' => '',
+		'CI' => '+225',
+		'CH' => '+41',
+		'CO' => '+57',
+		'CN' => '+86',
+		'CM' => '+237',
+		'CL' => '+56',
+		'CC' => '+61',
+		'CA' => '+1',
+		'CG' => '+242',
+		'CF' => '+236',
+		'CD' => '+243',
+		'CZ' => '+420',
+		'CY' => '+357',
+		'CX' => '+61',
+		'CR' => '+506',
+		'CW' => '+599',
+		'CV' => '+238',
+		'CU' => '+53',
+		'SZ' => '+268',
+		'SY' => '+963',
+		'SX' => '+599',
+		'KG' => '+996',
+		'KE' => '+254',
+		'SS' => '+211',
+		'SR' => '+597',
+		'KI' => '+686',
+		'KH' => '+855',
+		'KN' => '+1869',
+		'KM' => '+269',
+		'ST' => '+239',
+		'SK' => '+421',
+		'KR' => '+82',
+		'SI' => '+386',
+		'KP' => '+850',
+		'KW' => '+965',
+		'SN' => '+221',
+		'SM' => '+378',
+		'SL' => '+232',
+		'SC' => '+248',
+		'KZ' => '+7',
+		'KY' => '+1345',
+		'SG' => '+65',
+		'SE' => '+46',
+		'SD' => '+249',
+		'DO' => [
+			'+1809',
+			'+1829',
+			'+1849',
+		],
+		'DM' => '+1767',
+		'DJ' => '+253',
+		'DK' => '+45',
+		'VG' => '+1284',
+		'DE' => '+49',
+		'YE' => '+967',
+		'DZ' => '+213',
+		'US' => '+1',
+		'UY' => '+598',
+		'YT' => '+262',
+		'UM' => '+1',
+		'LB' => '+961',
+		'LC' => '+1758',
+		'LA' => '+856',
+		'TV' => '+688',
+		'TW' => '+886',
+		'TT' => '+1868',
+		'TR' => '+90',
+		'LK' => '+94',
+		'LI' => '+423',
+		'LV' => '+371',
+		'TO' => '+676',
+		'LT' => '+370',
+		'LU' => '+352',
+		'LR' => '+231',
+		'LS' => '+266',
+		'TH' => '+66',
+		'TF' => '',
+		'TG' => '+228',
+		'TD' => '+235',
+		'TC' => '+1649',
+		'LY' => '+218',
+		'VA' => '+379',
+		'VC' => '+1784',
+		'AE' => '+971',
+		'AD' => '+376',
+		'AG' => '+1268',
+		'AF' => '+93',
+		'AI' => '+1264',
+		'VI' => '+1340',
+		'IS' => '+354',
+		'IR' => '+98',
+		'AM' => '+374',
+		'AL' => '+355',
+		'AO' => '+244',
+		'AQ' => '',
+		'AS' => '+1684',
+		'AR' => '+54',
+		'AU' => '+61',
+		'AT' => '+43',
+		'AW' => '+297',
+		'IN' => '+91',
+		'AX' => '+35818',
+		'AZ' => '+994',
+		'IE' => '+353',
+		'ID' => '+62',
+		'UA' => '+380',
+		'QA' => '+974',
+		'MZ' => '+258',
+	];
+
+
+	/** @var array flipped calling codes */
+	protected static $flipped_calling_codes;
+
+
 	/**
-	 * SkyVerge Country Helper Class
+	 * Convert a 2-character country code into its 3-character equivalent, or
+	 * vice-versa, e.g.
 	 *
-	 * The purpose of this class is to centralize country-related utility
-	 * functions that are commonly used in SkyVerge plugins
+	 * 1) given USA, returns US
+	 * 2) given US, returns USA
 	 *
 	 * @since 5.4.3
+	 *
+	 * @param string $code ISO-3166-alpha-2 or ISO-3166-alpha-3 country code
+	 * @return string country code
 	 */
-	class Country_Helper {
+	public static function convert_alpha_country_code( $code ) {
 
+		$countries = 3 === strlen( $code ) ? array_flip( self::$alpha3 ) : self::$alpha3;
 
-		/** @var array ISO 3166-alpha2 => ISO 3166-alpha3  */
-		static public $alpha3 = [
-			'AF' => 'AFG', 'AL' => 'ALB', 'DZ' => 'DZA', 'AD' => 'AND', 'AO' => 'AGO',
-			'AG' => 'ATG', 'AR' => 'ARG', 'AM' => 'ARM', 'AU' => 'AUS', 'AT' => 'AUT',
-			'AZ' => 'AZE', 'BS' => 'BHS', 'BH' => 'BHR', 'BD' => 'BGD', 'BB' => 'BRB',
-			'BY' => 'BLR', 'BE' => 'BEL', 'BZ' => 'BLZ', 'BJ' => 'BEN', 'BT' => 'BTN',
-			'BO' => 'BOL', 'BA' => 'BIH', 'BW' => 'BWA', 'BR' => 'BRA', 'BN' => 'BRN',
-			'BG' => 'BGR', 'BF' => 'BFA', 'BI' => 'BDI', 'KH' => 'KHM', 'CM' => 'CMR',
-			'CA' => 'CAN', 'CV' => 'CPV', 'CF' => 'CAF', 'TD' => 'TCD', 'CL' => 'CHL',
-			'CN' => 'CHN', 'CO' => 'COL', 'KM' => 'COM', 'CD' => 'COD', 'CG' => 'COG',
-			'CR' => 'CRI', 'CI' => 'CIV', 'HR' => 'HRV', 'CU' => 'CUB', 'CY' => 'CYP',
-			'CZ' => 'CZE', 'DK' => 'DNK', 'DJ' => 'DJI', 'DM' => 'DMA', 'DO' => 'DOM',
-			'EC' => 'ECU', 'EG' => 'EGY', 'SV' => 'SLV', 'GQ' => 'GNQ', 'ER' => 'ERI',
-			'EE' => 'EST', 'ET' => 'ETH', 'FJ' => 'FJI', 'FI' => 'FIN', 'FR' => 'FRA',
-			'GA' => 'GAB', 'GM' => 'GMB', 'GE' => 'GEO', 'DE' => 'DEU', 'GH' => 'GHA',
-			'GR' => 'GRC', 'GD' => 'GRD', 'GT' => 'GTM', 'GN' => 'GIN', 'GW' => 'GNB',
-			'GY' => 'GUY', 'HT' => 'HTI', 'HN' => 'HND', 'HU' => 'HUN', 'IS' => 'ISL',
-			'IN' => 'IND', 'ID' => 'IDN', 'IR' => 'IRN', 'IQ' => 'IRQ', 'IE' => 'IRL',
-			'IL' => 'ISR', 'IT' => 'ITA', 'JM' => 'JAM', 'JP' => 'JPN', 'JO' => 'JOR',
-			'KZ' => 'KAZ', 'KE' => 'KEN', 'KI' => 'KIR', 'KP' => 'PRK', 'KR' => 'KOR',
-			'KW' => 'KWT', 'KG' => 'KGZ', 'LA' => 'LAO', 'LV' => 'LVA', 'LB' => 'LBN',
-			'LS' => 'LSO', 'LR' => 'LBR', 'LY' => 'LBY', 'LI' => 'LIE', 'LT' => 'LTU',
-			'LU' => 'LUX', 'MK' => 'MKD', 'MG' => 'MDG', 'MW' => 'MWI', 'MY' => 'MYS',
-			'MV' => 'MDV', 'ML' => 'MLI', 'MT' => 'MLT', 'MH' => 'MHL', 'MR' => 'MRT',
-			'MU' => 'MUS', 'MX' => 'MEX', 'FM' => 'FSM', 'MD' => 'MDA', 'MC' => 'MCO',
-			'MN' => 'MNG', 'ME' => 'MNE', 'MA' => 'MAR', 'MZ' => 'MOZ', 'MM' => 'MMR',
-			'NA' => 'NAM', 'NR' => 'NRU', 'NP' => 'NPL', 'NL' => 'NLD', 'NZ' => 'NZL',
-			'NI' => 'NIC', 'NE' => 'NER', 'NG' => 'NGA', 'NO' => 'NOR', 'OM' => 'OMN',
-			'PK' => 'PAK', 'PW' => 'PLW', 'PA' => 'PAN', 'PG' => 'PNG', 'PY' => 'PRY',
-			'PE' => 'PER', 'PH' => 'PHL', 'PL' => 'POL', 'PT' => 'PRT', 'QA' => 'QAT',
-			'RO' => 'ROU', 'RU' => 'RUS', 'RW' => 'RWA', 'KN' => 'KNA', 'LC' => 'LCA',
-			'VC' => 'VCT', 'WS' => 'WSM', 'SM' => 'SMR', 'ST' => 'STP', 'SA' => 'SAU',
-			'SN' => 'SEN', 'RS' => 'SRB', 'SC' => 'SYC', 'SL' => 'SLE', 'SG' => 'SGP',
-			'SK' => 'SVK', 'SI' => 'SVN', 'SB' => 'SLB', 'SO' => 'SOM', 'ZA' => 'ZAF',
-			'ES' => 'ESP', 'LK' => 'LKA', 'SD' => 'SDN', 'SR' => 'SUR', 'SZ' => 'SWZ',
-			'SE' => 'SWE', 'CH' => 'CHE', 'SY' => 'SYR', 'TJ' => 'TJK', 'TZ' => 'TZA',
-			'TH' => 'THA', 'TL' => 'TLS', 'TG' => 'TGO', 'TO' => 'TON', 'TT' => 'TTO',
-			'TN' => 'TUN', 'TR' => 'TUR', 'TM' => 'TKM', 'TV' => 'TUV', 'UG' => 'UGA',
-			'UA' => 'UKR', 'AE' => 'ARE', 'GB' => 'GBR', 'US' => 'USA', 'UY' => 'URY',
-			'UZ' => 'UZB', 'VU' => 'VUT', 'VA' => 'VAT', 'VE' => 'VEN', 'VN' => 'VNM',
-			'YE' => 'YEM', 'ZM' => 'ZMB', 'ZW' => 'ZWE', 'TW' => 'TWN', 'CX' => 'CXR',
-			'CC' => 'CCK', 'HM' => 'HMD', 'NF' => 'NFK', 'NC' => 'NCL', 'PF' => 'PYF',
-			'YT' => 'MYT', 'GP' => 'GLP', 'PM' => 'SPM', 'WF' => 'WLF', 'TF' => 'ATF',
-			'BV' => 'BVT', 'CK' => 'COK', 'NU' => 'NIU', 'TK' => 'TKL', 'GG' => 'GGY',
-			'IM' => 'IMN', 'JE' => 'JEY', 'AI' => 'AIA', 'BM' => 'BMU', 'IO' => 'IOT',
-			'VG' => 'VGB', 'KY' => 'CYM', 'FK' => 'FLK', 'GI' => 'GIB', 'MS' => 'MSR',
-			'PN' => 'PCN', 'SH' => 'SHN', 'GS' => 'SGS', 'TC' => 'TCA', 'MP' => 'MNP',
-			'PR' => 'PRI', 'AS' => 'ASM', 'UM' => 'UMI', 'GU' => 'GUM', 'VI' => 'VIR',
-			'HK' => 'HKG', 'MO' => 'MAC', 'FO' => 'FRO', 'GL' => 'GRL', 'GF' => 'GUF',
-			'MQ' => 'MTQ', 'RE' => 'REU', 'AX' => 'ALA', 'AW' => 'ABW', 'AN' => 'ANT',
-			'SJ' => 'SJM', 'AC' => 'ASC', 'TA' => 'TAA', 'AQ' => 'ATA', 'CW' => 'CUW',
-		];
-
-		/** @var array ISO 3166-alpha2 => ISO 3166-numeric  */
-		static public $numeric = [
-			'AF' => '004', 'AX' => '248', 'AL' => '008', 'DZ' => '012', 'AS' => '016',
-			'AD' => '020', 'AO' => '024', 'AI' => '660', 'AQ' => '010', 'AG' => '028',
-			'AR' => '032', 'AM' => '051', 'AW' => '533', 'AU' => '036', 'AT' => '040',
-			'AZ' => '031', 'BS' => '044', 'BH' => '048', 'BD' => '050', 'BB' => '052',
-			'BY' => '112', 'BE' => '056', 'BZ' => '084', 'BJ' => '204', 'BM' => '060',
-			'BT' => '064', 'BO' => '068', 'BQ' => '535', 'BA' => '070', 'BW' => '072',
-			'BV' => '074', 'BR' => '076', 'IO' => '086', 'BN' => '096', 'BG' => '100',
-			'BF' => '854', 'BI' => '108', 'KH' => '116', 'CM' => '120', 'CA' => '124',
-			'CV' => '132', 'KY' => '136', 'CF' => '140', 'TD' => '148', 'CL' => '152',
-			'CN' => '156', 'CX' => '162', 'CC' => '166', 'CO' => '170', 'KM' => '174',
-			'CG' => '178', 'CD' => '180', 'CK' => '184', 'CR' => '188', 'CI' => '384',
-			'HR' => '191', 'CU' => '192', 'CW' => '531', 'CY' => '196', 'CZ' => '203',
-			'DK' => '208', 'DJ' => '262', 'DM' => '212', 'DO' => '214', 'EC' => '218',
-			'EG' => '818', 'SV' => '222', 'GQ' => '226', 'ER' => '232', 'EE' => '233',
-			'ET' => '231', 'FK' => '238', 'FO' => '234', 'FJ' => '242', 'FI' => '246',
-			'FR' => '250', 'GF' => '254', 'PF' => '258', 'TF' => '260', 'GA' => '266',
-			'GM' => '270', 'GE' => '268', 'DE' => '276', 'GH' => '288', 'GI' => '292',
-			'GR' => '300', 'GL' => '304', 'GD' => '308', 'GP' => '312', 'GU' => '316',
-			'GT' => '320', 'GG' => '831', 'GN' => '324', 'GW' => '624', 'GY' => '328',
-			'HT' => '332', 'HM' => '334', 'VA' => '336', 'HN' => '340', 'HK' => '344',
-			'HU' => '348', 'IS' => '352', 'IN' => '356', 'ID' => '360', 'IR' => '364',
-			'IQ' => '368', 'IE' => '372', 'IM' => '833', 'IL' => '376', 'IT' => '380',
-			'JM' => '388', 'JP' => '392', 'JE' => '832', 'JO' => '400', 'KZ' => '398',
-			'KE' => '404', 'KI' => '296', 'KP' => '408', 'KR' => '410', 'KW' => '414',
-			'KG' => '417', 'LA' => '418', 'LV' => '428', 'LB' => '422', 'LS' => '426',
-			'LR' => '430', 'LY' => '434', 'LI' => '438', 'LT' => '440', 'LU' => '442',
-			'MO' => '446', 'MK' => '807', 'MG' => '450', 'MW' => '454', 'MY' => '458',
-			'MV' => '462', 'ML' => '466', 'MT' => '470', 'MH' => '584', 'MQ' => '474',
-			'MR' => '478', 'MU' => '480', 'YT' => '175', 'MX' => '484', 'FM' => '583',
-			'MD' => '498', 'MC' => '492', 'MN' => '496', 'ME' => '499', 'MS' => '500',
-			'MA' => '504', 'MZ' => '508', 'MM' => '104', 'NA' => '516', 'NR' => '520',
-			'NP' => '524', 'NL' => '528', 'NC' => '540', 'NZ' => '554', 'NI' => '558',
-			'NE' => '562', 'NG' => '566', 'NU' => '570', 'NF' => '574', 'MP' => '580',
-			'NO' => '578', 'OM' => '512', 'PK' => '586', 'PW' => '585', 'PS' => '275',
-			'PA' => '591', 'PG' => '598', 'PY' => '600', 'PE' => '604', 'PH' => '608',
-			'PN' => '612', 'PL' => '616', 'PT' => '620', 'PR' => '630', 'QA' => '634',
-			'RE' => '638', 'RO' => '642', 'RU' => '643', 'RW' => '646', 'BL' => '652',
-			'SH' => '654', 'KN' => '659', 'LC' => '662', 'MF' => '663', 'PM' => '666',
-			'VC' => '670', 'WS' => '882', 'SM' => '674', 'ST' => '678', 'SA' => '682',
-			'SN' => '686', 'RS' => '688', 'SC' => '690', 'SL' => '694', 'SG' => '702',
-			'SX' => '534', 'SK' => '703', 'SI' => '705', 'SB' => '090', 'SO' => '706',
-			'ZA' => '710', 'GS' => '239', 'SS' => '728', 'ES' => '724', 'LK' => '144',
-			'SD' => '729', 'SR' => '740', 'SJ' => '744', 'SZ' => '748', 'SE' => '752',
-			'CH' => '756', 'SY' => '760', 'TW' => '158', 'TJ' => '762', 'TZ' => '834',
-			'TH' => '764', 'TL' => '626', 'TG' => '768', 'TK' => '772', 'TO' => '776',
-			'TT' => '780', 'TN' => '788', 'TR' => '792', 'TM' => '795', 'TC' => '796',
-			'TV' => '798', 'UG' => '800', 'UA' => '804', 'AE' => '784', 'GB' => '826',
-			'US' => '840', 'UM' => '581', 'UY' => '858', 'UZ' => '860', 'VU' => '548',
-			'VE' => '862', 'VN' => '704', 'VG' => '092', 'VI' => '850', 'WF' => '876',
-			'EH' => '732', 'YE' => '887', 'ZM' => '894', 'ZW' => '716',
-		];
-
-		/** @var array ISO 3166-alpha2 => phone calling code(s) */
-		static public $calling_codes = [
-			'BD' => '+880',
-			'BE' => '+32',
-			'BF' => '+226',
-			'BG' => '+359',
-			'BA' => '+387',
-			'BB' => '+1246',
-			'WF' => '+681',
-			'BL' => '+590',
-			'BM' => '+1441',
-			'BN' => '+673',
-			'BO' => '+591',
-			'BH' => '+973',
-			'BI' => '+257',
-			'BJ' => '+229',
-			'BT' => '+975',
-			'JM' => '+1876',
-			'BV' => '',
-			'BW' => '+267',
-			'WS' => '+685',
-			'BQ' => '+599',
-			'BR' => '+55',
-			'BS' => '+1242',
-			'JE' => '+441534',
-			'BY' => '+375',
-			'BZ' => '+501',
-			'RU' => '+7',
-			'RW' => '+250',
-			'RS' => '+381',
-			'TL' => '+670',
-			'RE' => '+262',
-			'TM' => '+993',
-			'TJ' => '+992',
-			'RO' => '+40',
-			'TK' => '+690',
-			'GW' => '+245',
-			'GU' => '+1671',
-			'GT' => '+502',
-			'GS' => '',
-			'GR' => '+30',
-			'GQ' => '+240',
-			'GP' => '+590',
-			'JP' => '+81',
-			'GY' => '+592',
-			'GG' => '+441481',
-			'GF' => '+594',
-			'GE' => '+995',
-			'GD' => '+1473',
-			'GB' => '+44',
-			'GA' => '+241',
-			'SV' => '+503',
-			'GN' => '+224',
-			'GM' => '+220',
-			'GL' => '+299',
-			'GI' => '+350',
-			'GH' => '+233',
-			'OM' => '+968',
-			'TN' => '+216',
-			'JO' => '+962',
-			'HR' => '+385',
-			'HT' => '+509',
-			'HU' => '+36',
-			'HK' => '+852',
-			'HN' => '+504',
-			'HM' => '',
-			'VE' => '+58',
-			'PR' => [
-				'+1787',
-				'+1939',
-			],
-			'PS' => '+970',
-			'PW' => '+680',
-			'PT' => '+351',
-			'SJ' => '+47',
-			'PY' => '+595',
-			'IQ' => '+964',
-			'PA' => '+507',
-			'PF' => '+689',
-			'PG' => '+675',
-			'PE' => '+51',
-			'PK' => '+92',
-			'PH' => '+63',
-			'PN' => '+870',
-			'PL' => '+48',
-			'PM' => '+508',
-			'ZM' => '+260',
-			'EH' => '+212',
-			'EE' => '+372',
-			'EG' => '+20',
-			'ZA' => '+27',
-			'EC' => '+593',
-			'IT' => '+39',
-			'VN' => '+84',
-			'SB' => '+677',
-			'ET' => '+251',
-			'SO' => '+252',
-			'ZW' => '+263',
-			'SA' => '+966',
-			'ES' => '+34',
-			'ER' => '+291',
-			'ME' => '+382',
-			'MD' => '+373',
-			'MG' => '+261',
-			'MF' => '+590',
-			'MA' => '+212',
-			'MC' => '+377',
-			'UZ' => '+998',
-			'MM' => '+95',
-			'ML' => '+223',
-			'MO' => '+853',
-			'MN' => '+976',
-			'MH' => '+692',
-			'MK' => '+389',
-			'MU' => '+230',
-			'MT' => '+356',
-			'MW' => '+265',
-			'MV' => '+960',
-			'MQ' => '+596',
-			'MP' => '+1670',
-			'MS' => '+1664',
-			'MR' => '+222',
-			'IM' => '+441624',
-			'UG' => '+256',
-			'TZ' => '+255',
-			'MY' => '+60',
-			'MX' => '+52',
-			'IL' => '+972',
-			'FR' => '+33',
-			'IO' => '+246',
-			'SH' => '+290',
-			'FI' => '+358',
-			'FJ' => '+679',
-			'FK' => '+500',
-			'FM' => '+691',
-			'FO' => '+298',
-			'NI' => '+505',
-			'NL' => '+31',
-			'NO' => '+47',
-			'NA' => '+264',
-			'VU' => '+678',
-			'NC' => '+687',
-			'NE' => '+227',
-			'NF' => '+672',
-			'NG' => '+234',
-			'NZ' => '+64',
-			'NP' => '+977',
-			'NR' => '+674',
-			'NU' => '+683',
-			'CK' => '+682',
-			'XK' => '',
-			'CI' => '+225',
-			'CH' => '+41',
-			'CO' => '+57',
-			'CN' => '+86',
-			'CM' => '+237',
-			'CL' => '+56',
-			'CC' => '+61',
-			'CA' => '+1',
-			'CG' => '+242',
-			'CF' => '+236',
-			'CD' => '+243',
-			'CZ' => '+420',
-			'CY' => '+357',
-			'CX' => '+61',
-			'CR' => '+506',
-			'CW' => '+599',
-			'CV' => '+238',
-			'CU' => '+53',
-			'SZ' => '+268',
-			'SY' => '+963',
-			'SX' => '+599',
-			'KG' => '+996',
-			'KE' => '+254',
-			'SS' => '+211',
-			'SR' => '+597',
-			'KI' => '+686',
-			'KH' => '+855',
-			'KN' => '+1869',
-			'KM' => '+269',
-			'ST' => '+239',
-			'SK' => '+421',
-			'KR' => '+82',
-			'SI' => '+386',
-			'KP' => '+850',
-			'KW' => '+965',
-			'SN' => '+221',
-			'SM' => '+378',
-			'SL' => '+232',
-			'SC' => '+248',
-			'KZ' => '+7',
-			'KY' => '+1345',
-			'SG' => '+65',
-			'SE' => '+46',
-			'SD' => '+249',
-			'DO' => [
-				'+1809',
-				'+1829',
-				'+1849',
-			],
-			'DM' => '+1767',
-			'DJ' => '+253',
-			'DK' => '+45',
-			'VG' => '+1284',
-			'DE' => '+49',
-			'YE' => '+967',
-			'DZ' => '+213',
-			'US' => '+1',
-			'UY' => '+598',
-			'YT' => '+262',
-			'UM' => '+1',
-			'LB' => '+961',
-			'LC' => '+1758',
-			'LA' => '+856',
-			'TV' => '+688',
-			'TW' => '+886',
-			'TT' => '+1868',
-			'TR' => '+90',
-			'LK' => '+94',
-			'LI' => '+423',
-			'LV' => '+371',
-			'TO' => '+676',
-			'LT' => '+370',
-			'LU' => '+352',
-			'LR' => '+231',
-			'LS' => '+266',
-			'TH' => '+66',
-			'TF' => '',
-			'TG' => '+228',
-			'TD' => '+235',
-			'TC' => '+1649',
-			'LY' => '+218',
-			'VA' => '+379',
-			'VC' => '+1784',
-			'AE' => '+971',
-			'AD' => '+376',
-			'AG' => '+1268',
-			'AF' => '+93',
-			'AI' => '+1264',
-			'VI' => '+1340',
-			'IS' => '+354',
-			'IR' => '+98',
-			'AM' => '+374',
-			'AL' => '+355',
-			'AO' => '+244',
-			'AQ' => '',
-			'AS' => '+1684',
-			'AR' => '+54',
-			'AU' => '+61',
-			'AT' => '+43',
-			'AW' => '+297',
-			'IN' => '+91',
-			'AX' => '+35818',
-			'AZ' => '+994',
-			'IE' => '+353',
-			'ID' => '+62',
-			'UA' => '+380',
-			'QA' => '+974',
-			'MZ' => '+258',
-		];
-
-
-		/** @var array flipped calling codes */
-		protected static $flipped_calling_codes;
-
-
-		/**
-		 * Convert a 2-character country code into its 3-character equivalent, or
-		 * vice-versa, e.g.
-		 *
-		 * 1) given USA, returns US
-		 * 2) given US, returns USA
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $code ISO-3166-alpha-2 or ISO-3166-alpha-3 country code
-		 * @return string country code
-		 */
-		public static function convert_alpha_country_code( $code ) {
-
-			$countries = 3 === strlen( $code ) ? array_flip( self::$alpha3 ) : self::$alpha3;
-
-			return isset( $countries[ $code ] ) ? $countries[ $code ] : $code;
-		}
-
-
-		/**
-		 * Converts an ISO 3166-alpha2 country code to an ISO 3166-alpha3 country code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $alpha2_code ISO 3166-alpha2 country code
-		 * @return string ISO 3166-alpha3 country code
-		 */
-		public static function alpha2_to_alpha3( $alpha2_code ) {
-
-			return isset( self::$alpha3[ $alpha2_code ] ) ? self::$alpha3[ $alpha2_code ] : '';
-		}
-
-
-		/**
-		 * Converts an ISO 3166-alpha2 country code to an ISO 3166-numeric country code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $alpha2_code ISO 3166-alpha2 country code
-		 * @return string ISO 3166-numeric country code
-		 */
-		public static function alpha2_to_numeric( $alpha2_code ) {
-
-			return isset( self::$numeric[ $alpha2_code ] ) ? self::$numeric[ $alpha2_code ] : '';
-		}
-
-
-		/**
-		 * Converts an ISO 3166-alpha2 country code to a calling code.
-		 *
-		 * This conversion is available in WC 3.6+ so we'll call out to that when available.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $alpha2_code ISO 3166-alpha2 country code
-		 * @return string calling code
-		 */
-		public static function alpha2_to_calling_code( $alpha2_code ) {
-
-			// check not only for the right version, but if the helper is loaded & available
-			if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.6.0' ) && WC() && isset( WC()->countries ) && is_callable( [ WC()->countries, 'get_country_calling_code' ] ) ) {
-
-				$calling_code = WC()->countries->get_country_calling_code( $alpha2_code );
-
-			} else {
-
-				$calling_code = isset( self::$calling_codes[ $alpha2_code ] ) ? self::$calling_codes[ $alpha2_code ] : '';
-
-				// we can't really know _which_ code is to be used, so use the first
-				$calling_code = is_array( $calling_code ) ? $calling_code[0] : $calling_code;
-			}
-
-			return $calling_code;
-		}
-
-
-		/**
-		 * Converts an ISO 3166-alpha3 country code to an ISO 3166-alpha2 country code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $alpha3_code ISO 3166-alpha3 country code
-		 * @return string ISO 3166-alpha2 country code
-		 */
-		public static function alpha3_to_alpha2( $alpha3_code ) {
-
-			$countries = array_flip( self::$alpha3 );
-
-			return isset( $countries[ $alpha3_code ] ) ? $countries[ $alpha3_code ] : '';
-		}
-
-
-		/**
-		 * Converts an ISO 3166-alpha3 country code to an ISO 3166-numeric country code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $alpha3_code ISO 3166-alpha3 country code
-		 * @return string ISO 3166-numeric country code
-		 */
-		public static function alpha3_to_numeric( $alpha3_code ) {
-			return self::alpha2_to_numeric( self::alpha3_to_alpha2( $alpha3_code ) );
-		}
-
-
-		/**
-		 * Converts an ISO 3166-alpha3 country code to a calling code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $alpha3_code ISO 3166-alpha3 country code
-		 * @return string calling code
-		 */
-		public static function alpha3_to_calling_code( $alpha3_code ) {
-			return self::alpha2_to_calling_code( self::alpha3_to_alpha2( $alpha3_code ) );
-		}
-
-
-		/**
-		 * Converts an ISO 3166-numeric country code to an ISO 3166-alpha2 code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $numeric ISO 3166-numeric country code
-		 * @return string ISO 3166-alpha2 country code
-		 */
-		public static function numeric_to_alpha2( $numeric ) {
-
-			$codes = array_flip( self::$numeric );
-
-			return isset( $codes[ $numeric ] ) ? $codes[ $numeric ] : '';
-		}
-
-
-		/**
-		 * Converts an ISO 3166-numeric country code to an ISO 3166-alpha3 code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $numeric ISO 3166-numeric country code
-		 * @return string ISO 3166-alpha3 country code
-		 */
-		public static function numeric_to_alpha3( $numeric ) {
-			return self::alpha2_to_alpha3( self::numeric_to_alpha2( $numeric ) );
-		}
-
-
-		/**
-		 * Converts an ISO 3166-numeric country code to a calling code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $numeric ISO 3166-numeric country code
-		 * @return string calling code
-		 */
-		public static function numeric_to_calling_code( $numeric ) {
-			return self::alpha2_to_calling_code( self::numeric_to_alpha2( $numeric ) );
-		}
-
-
-		/**
-		 * Converts a country calling code to an ISO 3166-alpha2 code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $calling_code country calling code (includes leading '+')
-		 * @return string ISO 3166-alpha2 code
-		 */
-		public static function calling_code_to_alpha2( $calling_code ) {
-
-			$flipped_calling_codes = self::get_flipped_calling_codes();
-
-			return isset( $flipped_calling_codes[ $calling_code ] ) ? $flipped_calling_codes[ $calling_code ] : '';
-		}
-
-
-		/**
-		 * Converts a country calling code to an ISO 3166-alpha3 code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $calling_code country calling code (includes leading '+')
-		 * @return string ISO 3166-alpha3 code
-		 */
-		public static function calling_code_to_alpha3( $calling_code ) {
-
-			return self::alpha2_to_alpha3( self::calling_code_to_alpha2( $calling_code ) );
-		}
-
-
-		/**
-		 * Converts a country calling code to an ISO 3166-numeric code.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @param string $calling_code country calling code (includes leading '+')
-		 * @return string ISO 3166-numeric code
-		 */
-		public static function calling_code_to_numeric( $calling_code ) {
-
-			return self::alpha2_to_numeric( self::calling_code_to_alpha2( $calling_code ) );
-		}
-
-
-		/**
-		 * Gets the flipped version of the calling codes array.
-		 *
-		 * Since array_flip will fail on the calling codes array due to
-		 * having some arrays as values, this custom function is necessary.
-		 *
-		 * @since 5.4.3
-		 *
-		 * @return array
-		 */
-		public static function get_flipped_calling_codes() {
-
-			if ( null === self::$flipped_calling_codes ) {
-
-				$flipped_calling_codes = [];
-
-				foreach ( self::$calling_codes as $alpha2 => $calling_code ) {
-
-					if ( is_array( $calling_code ) ) {
-
-						foreach ( $calling_code as $sub_code ) {
-
-							$flipped_calling_codes[ $sub_code ] = $alpha2;
-						}
-					} else {
-
-						$flipped_calling_codes[ $calling_code ] = $alpha2;
-					}
-				}
-
-				self::$flipped_calling_codes = $flipped_calling_codes;
-			}
-
-			return self::$flipped_calling_codes;
-		}
-
-
+		return isset( $countries[ $code ] ) ? $countries[ $code ] : $code;
 	}
 
-endif; // Class exists check
+
+	/**
+	 * Converts an ISO 3166-alpha2 country code to an ISO 3166-alpha3 country code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $alpha2_code ISO 3166-alpha2 country code
+	 * @return string ISO 3166-alpha3 country code
+	 */
+	public static function alpha2_to_alpha3( $alpha2_code ) {
+
+		return isset( self::$alpha3[ $alpha2_code ] ) ? self::$alpha3[ $alpha2_code ] : '';
+	}
+
+
+	/**
+	 * Converts an ISO 3166-alpha2 country code to an ISO 3166-numeric country code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $alpha2_code ISO 3166-alpha2 country code
+	 * @return string ISO 3166-numeric country code
+	 */
+	public static function alpha2_to_numeric( $alpha2_code ) {
+
+		return isset( self::$numeric[ $alpha2_code ] ) ? self::$numeric[ $alpha2_code ] : '';
+	}
+
+
+	/**
+	 * Converts an ISO 3166-alpha2 country code to a calling code.
+	 *
+	 * This conversion is available in WC 3.6+ so we'll call out to that when available.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $alpha2_code ISO 3166-alpha2 country code
+	 * @return string calling code
+	 */
+	public static function alpha2_to_calling_code( $alpha2_code ) {
+
+		// check not only for the right version, but if the helper is loaded & available
+		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.6.0' ) && WC() && isset( WC()->countries ) && is_callable( [ WC()->countries, 'get_country_calling_code' ] ) ) {
+
+			$calling_code = WC()->countries->get_country_calling_code( $alpha2_code );
+
+		} else {
+
+			$calling_code = isset( self::$calling_codes[ $alpha2_code ] ) ? self::$calling_codes[ $alpha2_code ] : '';
+
+			// we can't really know _which_ code is to be used, so use the first
+			$calling_code = is_array( $calling_code ) ? $calling_code[0] : $calling_code;
+		}
+
+		return $calling_code;
+	}
+
+
+	/**
+	 * Converts an ISO 3166-alpha3 country code to an ISO 3166-alpha2 country code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $alpha3_code ISO 3166-alpha3 country code
+	 * @return string ISO 3166-alpha2 country code
+	 */
+	public static function alpha3_to_alpha2( $alpha3_code ) {
+
+		$countries = array_flip( self::$alpha3 );
+
+		return isset( $countries[ $alpha3_code ] ) ? $countries[ $alpha3_code ] : '';
+	}
+
+
+	/**
+	 * Converts an ISO 3166-alpha3 country code to an ISO 3166-numeric country code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $alpha3_code ISO 3166-alpha3 country code
+	 * @return string ISO 3166-numeric country code
+	 */
+	public static function alpha3_to_numeric( $alpha3_code ) {
+		return self::alpha2_to_numeric( self::alpha3_to_alpha2( $alpha3_code ) );
+	}
+
+
+	/**
+	 * Converts an ISO 3166-alpha3 country code to a calling code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $alpha3_code ISO 3166-alpha3 country code
+	 * @return string calling code
+	 */
+	public static function alpha3_to_calling_code( $alpha3_code ) {
+		return self::alpha2_to_calling_code( self::alpha3_to_alpha2( $alpha3_code ) );
+	}
+
+
+	/**
+	 * Converts an ISO 3166-numeric country code to an ISO 3166-alpha2 code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $numeric ISO 3166-numeric country code
+	 * @return string ISO 3166-alpha2 country code
+	 */
+	public static function numeric_to_alpha2( $numeric ) {
+
+		$codes = array_flip( self::$numeric );
+
+		return isset( $codes[ $numeric ] ) ? $codes[ $numeric ] : '';
+	}
+
+
+	/**
+	 * Converts an ISO 3166-numeric country code to an ISO 3166-alpha3 code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $numeric ISO 3166-numeric country code
+	 * @return string ISO 3166-alpha3 country code
+	 */
+	public static function numeric_to_alpha3( $numeric ) {
+		return self::alpha2_to_alpha3( self::numeric_to_alpha2( $numeric ) );
+	}
+
+
+	/**
+	 * Converts an ISO 3166-numeric country code to a calling code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $numeric ISO 3166-numeric country code
+	 * @return string calling code
+	 */
+	public static function numeric_to_calling_code( $numeric ) {
+		return self::alpha2_to_calling_code( self::numeric_to_alpha2( $numeric ) );
+	}
+
+
+	/**
+	 * Converts a country calling code to an ISO 3166-alpha2 code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $calling_code country calling code (includes leading '+')
+	 * @return string ISO 3166-alpha2 code
+	 */
+	public static function calling_code_to_alpha2( $calling_code ) {
+
+		$flipped_calling_codes = self::get_flipped_calling_codes();
+
+		return isset( $flipped_calling_codes[ $calling_code ] ) ? $flipped_calling_codes[ $calling_code ] : '';
+	}
+
+
+	/**
+	 * Converts a country calling code to an ISO 3166-alpha3 code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $calling_code country calling code (includes leading '+')
+	 * @return string ISO 3166-alpha3 code
+	 */
+	public static function calling_code_to_alpha3( $calling_code ) {
+
+		return self::alpha2_to_alpha3( self::calling_code_to_alpha2( $calling_code ) );
+	}
+
+
+	/**
+	 * Converts a country calling code to an ISO 3166-numeric code.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @param string $calling_code country calling code (includes leading '+')
+	 * @return string ISO 3166-numeric code
+	 */
+	public static function calling_code_to_numeric( $calling_code ) {
+
+		return self::alpha2_to_numeric( self::calling_code_to_alpha2( $calling_code ) );
+	}
+
+
+	/**
+	 * Gets the flipped version of the calling codes array.
+	 *
+	 * Since array_flip will fail on the calling codes array due to
+	 * having some arrays as values, this custom function is necessary.
+	 *
+	 * @since 5.4.3
+	 *
+	 * @return array
+	 */
+	public static function get_flipped_calling_codes() {
+
+		if ( null === self::$flipped_calling_codes ) {
+
+			$flipped_calling_codes = [];
+
+			foreach ( self::$calling_codes as $alpha2 => $calling_code ) {
+
+				if ( is_array( $calling_code ) ) {
+
+					foreach ( $calling_code as $sub_code ) {
+
+						$flipped_calling_codes[ $sub_code ] = $alpha2;
+					}
+				} else {
+
+					$flipped_calling_codes[ $calling_code ] = $alpha2;
+				}
+			}
+
+			self::$flipped_calling_codes = $flipped_calling_codes;
+		}
+
+		return self::$flipped_calling_codes;
+	}
+
+
+}
+
+
+endif;

--- a/woocommerce/Country_Helper.php
+++ b/woocommerce/Country_Helper.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Country_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Country_Helper' ) ) :
 
 	/**
 	 * SkyVerge Country Helper Class

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -24,9 +24,12 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Plugin;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Plugin\\Lifecycle' ) ) :
+
 
 /**
  * Plugin lifecycle handler.
@@ -40,12 +43,12 @@ class Lifecycle {
 
 
 	/** @var array the version numbers that have an upgrade routine */
-	protected $upgrade_versions = array();
+	protected $upgrade_versions = [];
 
 	/** @var string minimum milestone version */
 	private $milestone_version;
 
-	/** @var \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin plugin instance */
+	/** @var SV_WC_Plugin plugin instance */
 	private $plugin;
 
 
@@ -54,9 +57,9 @@ class Lifecycle {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @param \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin $plugin plugin instance
+	 * @param SV_WC_Plugin $plugin plugin instance
 	 */
-	public function __construct( \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin $plugin ) {
+	public function __construct( SV_WC_Plugin $plugin ) {
 
 		$this->plugin = $plugin;
 
@@ -634,7 +637,7 @@ class Lifecycle {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @return \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin
+	 * @return SV_WC_Plugin
 	 */
 	protected function get_plugin() {
 
@@ -654,10 +657,11 @@ class Lifecycle {
 	 */
 	public function do_update() {
 
-		\SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
+		wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
 
 
 }
+
 
 endif;

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Plugin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Plugin;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Plugin\\Lifecycle' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Plugin\\Lifecycle' ) ) :
 
 /**
  * Plugin lifecycle handler.
@@ -45,7 +45,7 @@ class Lifecycle {
 	/** @var string minimum milestone version */
 	private $milestone_version;
 
-	/** @var \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin plugin instance */
+	/** @var \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin plugin instance */
 	private $plugin;
 
 
@@ -54,9 +54,9 @@ class Lifecycle {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @param \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin $plugin plugin instance
+	 * @param \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin $plugin plugin instance
 	 */
-	public function __construct( \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin $plugin ) {
+	public function __construct( \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin $plugin ) {
 
 		$this->plugin = $plugin;
 
@@ -634,7 +634,7 @@ class Lifecycle {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @return \SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin
+	 * @return \SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin
 	 */
 	protected function get_plugin() {
 
@@ -654,7 +654,7 @@ class Lifecycle {
 	 */
 	public function do_update() {
 
-		\SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
+		\SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
 
 

--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -29,6 +29,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Admin\\Setup_Wizard' ) ) :
 
+
 /**
  * The plugin Setup Wizard class.
  *
@@ -1005,7 +1006,7 @@ abstract class Setup_Wizard {
 
 		} catch ( Framework\SV_WC_Plugin_Exception $exception ) {
 
-			Framework\SV_WC_Plugin_Compatibility::wc_doing_it_wrong( __METHOD__, $exception->getMessage(), '5.2.2' );
+			wc_doing_it_wrong( __METHOD__, $exception->getMessage(), '5.2.2' );
 
 			return false;
 		}
@@ -1294,5 +1295,6 @@ abstract class Setup_Wizard {
 
 
 }
+
 
 endif;

--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -104,7 +104,7 @@ abstract class Setup_Wizard {
 				$this->add_hooks();
 
 				// mark the wizard as complete if specifically requested
-				if ( Framework\SV_WC_Helper::get_request( "wc_{$this->id}_setup_wizard_complete" ) ) {
+				if ( Framework\SV_WC_Helper::get_requested_value( "wc_{$this->id}_setup_wizard_complete" ) ) {
 					$this->complete_setup();
 				}
 			}
@@ -247,8 +247,8 @@ abstract class Setup_Wizard {
 	protected function init_setup() {
 
 		// get a step ID from $_GET
-		$current_step   = sanitize_key( Framework\SV_WC_Helper::get_request( 'step' ) );
-		$current_action = sanitize_key( Framework\SV_WC_Helper::get_request( 'action' ) );
+		$current_step   = sanitize_key( Framework\SV_WC_Helper::get_requested_value( 'step' ) );
+		$current_action = sanitize_key( Framework\SV_WC_Helper::get_requested_value( 'action' ) );
 
 		if ( ! $current_action ) {
 
@@ -296,7 +296,7 @@ abstract class Setup_Wizard {
 	public function render_page() {
 
 		// maybe save and move onto the next step
-		$error_message = Framework\SV_WC_Helper::get_post( 'save_step' ) ? $this->save_step( $this->current_step ) : '';
+		$error_message = Framework\SV_WC_Helper::get_posted_value( 'save_step' ) ? $this->save_step( $this->current_step ) : '';
 
 		$page_title = sprintf(
 			/* translators: Placeholders: %s - plugin name */
@@ -353,7 +353,7 @@ abstract class Setup_Wizard {
 		try {
 
 			// bail early if the nonce is bad
-			if ( ! wp_verify_nonce( Framework\SV_WC_Helper::get_post( 'nonce' ), "wc_{$this->id}_setup_wizard_save" ) ) {
+			if ( ! wp_verify_nonce( Framework\SV_WC_Helper::get_posted_value( 'nonce' ), "wc_{$this->id}_setup_wizard_save" ) ) {
 				throw new Framework\SV_WC_Plugin_Exception( $error_message );
 			}
 
@@ -1038,7 +1038,7 @@ abstract class Setup_Wizard {
 	 */
 	public function is_setup_page() {
 
-		return is_admin() && $this->get_slug() === Framework\SV_WC_Helper::get_request( 'page' );
+		return is_admin() && $this->get_slug() === Framework\SV_WC_Helper::get_requested_value( 'page' );
 	}
 
 
@@ -1080,7 +1080,7 @@ abstract class Setup_Wizard {
 	 */
 	public function is_finished() {
 
-		return self::ACTION_FINISH === Framework\SV_WC_Helper::get_request( 'action' );
+		return self::ACTION_FINISH === Framework\SV_WC_Helper::get_requested_value( 'action' );
 	}
 
 

--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -21,13 +21,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Admin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Admin\\Setup_Wizard' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Admin\\Setup_Wizard' ) ) :
 
 /**
  * The plugin Setup Wizard class.

--- a/woocommerce/api/abstract-sv-wc-api-json-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_JSON_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_JSON_Request' ) ) :
 
 /**
  * Base JSON API request class.

--- a/woocommerce/api/abstract-sv-wc-api-json-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-request.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_JSON_Request' ) ) :
 
+
 /**
  * Base JSON API request class.
  *
@@ -130,4 +131,5 @@ abstract class SV_WC_API_JSON_Request implements SV_WC_API_Request {
 
 }
 
-endif; // class exists check
+
+endif;

--- a/woocommerce/api/abstract-sv-wc-api-json-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-response.php
@@ -101,4 +101,5 @@ abstract class SV_WC_API_JSON_Response implements SV_WC_API_Response {
 
 }
 
-endif; // class exists check
+
+endif;

--- a/woocommerce/api/abstract-sv-wc-api-json-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_JSON_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_JSON_Response' ) ) :
 
 
 /**

--- a/woocommerce/api/abstract-sv-wc-api-xml-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-request.php
@@ -28,12 +28,14 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_XML_Request' ) ) :
 
+
 /**
  * Base XML API request class.
  *
  * @since 4.3.0
  */
 abstract class SV_WC_API_XML_Request implements SV_WC_API_Request {
+
 
 	/** @var string the request method, one of HEAD, GET, PUT, PATCH, POST, DELETE */
 	protected $method;
@@ -132,7 +134,7 @@ abstract class SV_WC_API_XML_Request implements SV_WC_API_Request {
 	 */
 	public function get_request_data() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __FUNCTION__, '5.0.0', 'SV_WC_API_XML_Request::get_data' );
+		wc_deprecated_function( __METHOD__, '5.0.0', 'SV_WC_API_XML_Request::get_data' );
 
 		return $this->get_data();
 	}
@@ -210,4 +212,5 @@ abstract class SV_WC_API_XML_Request implements SV_WC_API_Request {
 
 }
 
-endif; // class exists check
+
+endif;

--- a/woocommerce/api/abstract-sv-wc-api-xml-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_XML_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_XML_Request' ) ) :
 
 /**
  * Base XML API request class.

--- a/woocommerce/api/abstract-sv-wc-api-xml-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_XML_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_XML_Response' ) ) :
 
 /**
  * Base XML API response class.

--- a/woocommerce/api/abstract-sv-wc-api-xml-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_XML_Response' ) ) :
 
+
 /**
  * Base XML API response class.
  *
@@ -133,4 +134,5 @@ abstract class SV_WC_API_XML_Response implements SV_WC_API_Response {
 
 }
 
-endif; // class exists check
+
+endif;

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Base' ) ) :
 
+
 /**
  * # WooCommerce Plugin Framework API Base Class
  *
@@ -841,5 +842,6 @@ abstract class SV_WC_API_Base {
 
 
 }
+
 
 endif;

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Base' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Base' ) ) :
 
 /**
  * # WooCommerce Plugin Framework API Base Class

--- a/woocommerce/api/class-sv-wc-api-exception.php
+++ b/woocommerce/api/class-sv-wc-api-exception.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Exception' ) ) :
 
 	/**
 	 * Plugin Framework API Exception - generic API Exception

--- a/woocommerce/api/class-sv-wc-api-exception.php
+++ b/woocommerce/api/class-sv-wc-api-exception.php
@@ -28,9 +28,11 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Exception' ) ) :
 
-	/**
-	 * Plugin Framework API Exception - generic API Exception
-	 */
-	class SV_WC_API_Exception extends SV_WC_Plugin_Exception { }
 
-endif;  // class exists check
+/**
+ * Plugin Framework API Exception - generic API Exception
+ */
+class SV_WC_API_Exception extends SV_WC_Plugin_Exception { }
+
+
+endif;

--- a/woocommerce/api/interface-sv-wc-api-request.php
+++ b/woocommerce/api/interface-sv-wc-api-request.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Request' ) ) :
 
+
 /**
  * API Request
  */
@@ -92,4 +93,5 @@ interface SV_WC_API_Request {
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/api/interface-sv-wc-api-request.php
+++ b/woocommerce/api/interface-sv-wc-api-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Request' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Request' ) ) :
 
 /**
  * API Request

--- a/woocommerce/api/interface-sv-wc-api-response.php
+++ b/woocommerce/api/interface-sv-wc-api-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Response' ) ) :
 
+
 /**
  * API Response
  */
@@ -54,4 +55,5 @@ interface SV_WC_API_Response {
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/api/interface-sv-wc-api-response.php
+++ b/woocommerce/api/interface-sv-wc-api-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Response' ) ) :
 
 /**
  * API Response

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,6 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.0-dev
- * Feature - Adds SV_Helpers and SV_Plugin_Compatibility class aliases for restricted namespace-free usage of helper methods and compatibility methods
  * Misc - Deprecate backwards compatibility methods for unsupported WooCommerce and PHP versions
 
 2019.09.05 - version 5.4.3

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -3,6 +3,7 @@
 2019.nn.nn - version 5.5.0-dev
  * Feature - Add a plugin helper method to retrieve a template part while consistently passing the default template path to `wc_get_template()`
  * Misc - Deprecate backwards compatibility methods for unsupported WooCommerce and PHP versions
+ * Misc - Replace `SV_WC_Helper::get_post()` and `SV_WC_Helper::get_request()` with `SV_WC_Helper::get_posted_value()` and `SV_WC_Helper::get_requested_value()`
 
 2019.09.05 - version 5.4.3
  * Fix - Do not show the checkbox to save the payment method on the checkout page if not logged in and registration during checkout is disabled

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2019.nn.nn - version 5.5.0-dev
+
 2019.09.05 - version 5.4.3
  * Fix - Do not show the checkbox to save the payment method on the checkout page if not logged in and registration during checkout is disabled
  * Misc - Add a Country_Helper class to assist converting country codes to and from various formats

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.0-dev
- * Misc - Deprecated backwards compatibility methods for unsupported WooCommerce and PHP versions
+ * Misc - Deprecate backwards compatibility methods for unsupported WooCommerce and PHP versions
 
 2019.09.05 - version 5.4.3
  * Fix - Do not show the checkbox to save the payment method on the checkout page if not logged in and registration during checkout is disabled

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.0-dev
+ * Misc - Deprecated backwards compatibility methods for unsupported WooCommerce and PHP versions
 
 2019.09.05 - version 5.4.3
  * Fix - Do not show the checkbox to save the payment method on the checkout page if not logged in and registration during checkout is disabled

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.0-dev
+ * Feature - Adds SV_Helpers and SV_Plugin_Compatibility class aliases for restricted namespace-free usage of helper methods and compatibility methods
  * Misc - Deprecate backwards compatibility methods for unsupported WooCommerce and PHP versions
 
 2019.09.05 - version 5.4.3

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Admin_Notice_Handler' ) ) :
 
+
 /**
  * SkyVerge Admin Notice Handler Class
  *
@@ -425,6 +426,8 @@ class SV_WC_Admin_Notice_Handler {
 		return $this->plugin;
 	}
 
+
 }
 
-endif; // Class exists check
+
+endif;

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Admin_Notice_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Admin_Notice_Handler' ) ) :
 
 /**
  * SkyVerge Admin Notice Handler Class

--- a/woocommerce/class-sv-wc-framework-bootstrap.php
+++ b/woocommerce/class-sv-wc-framework-bootstrap.php
@@ -403,4 +403,5 @@ class SV_WC_Framework_Bootstrap {
 // instantiate the class
 SV_WC_Framework_Bootstrap::instance();
 
+
 endif;

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -546,36 +546,82 @@ class SV_WC_Helper {
 
 
 	/**
-	 * Safely get and trim data from $_POST
+	 * Safely gets and trims data from $_POST.
 	 *
 	 * @since 3.0.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param string $key array key to get from $_POST array
 	 * @return string value from $_POST or blank string if $_POST[ $key ] is not set
 	 */
 	public static function get_post( $key ) {
 
-		if ( isset( $_POST[ $key ] ) ) {
-			return trim( $_POST[ $key ] );
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::get_posted_data()' );
 
-		return '';
+		return self::get_posted_value( $key );
 	}
 
 
 	/**
-	 * Safely get and trim data from $_REQUEST
+	 * Safely gets a value from $_POST.
+	 *
+	 * If the expected data is a string also trims it.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $key posted data key
+	 * @param int|float|array|bool|null|string $default default data type to return (default empty string)
+	 * @return int|float|array|bool|null|string posted data value if key found, or default
+	 */
+	public static function get_posted_value( $key, $default = '' ) {
+
+		$value = $default;
+
+		if ( isset( $_POST[ $key ] ) ) {
+			$value = is_string( $_POST[ $key ] ) ? trim( $_POST[ $key ] ) : $_POST[ $key ];
+		}
+
+		return $value;
+	}
+
+
+	/**
+	 * Safely gets and trims data from $_REQUEST.
 	 *
 	 * @since 3.0.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param string $key array key to get from $_REQUEST array
 	 * @return string value from $_REQUEST or blank string if $_REQUEST[ $key ] is not set
 	 */
 	public static function get_request( $key ) {
 
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::get_posted_data()' );
+
+		return self::get_requested_value( $key );
+	}
+
+
+	/**
+	 * Safely gets a value from $_REQUEST.
+	 *
+	 * If the expected data is a string also trims it.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $key posted data key
+	 * @param int|float|array|bool|null|string $default default data type to return (default empty string)
+	 * @return int|float|array|bool|null|string posted data value if key found, or default
+	 */
+	public static function get_requested_value( $key, $default = '' ) {
+
+		$value = $default;
+
 		if ( isset( $_REQUEST[ $key ] ) ) {
-			return trim( $_REQUEST[ $key ] );
+			$value = is_string( $_REQUEST[ $key ] ) ? trim( $_REQUEST[ $key ] ) : $_REQUEST[ $key ];
 		}
 
-		return '';
+		return $value;
 	}
 
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -975,9 +975,4 @@ class SV_WC_Helper {
 }
 
 
-// Allow calling methods of this class with a generic alias where using namespaces isn't safe, such as template files.
-// NOTE: Use with caution!
-class_alias( SV_WC_Helper::class, 'SV_Helper' );
-
-
 endif;

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Helper' ) ) :
 
 	/**
 	 * SkyVerge Helper Class

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -975,4 +975,9 @@ class SV_WC_Helper {
 }
 
 
+// Allow calling methods of this class with a generic alias where using namespaces isn't safe, such as template files.
+// NOTE: Use with caution!
+class_alias( SV_WC_Helper::class, 'SV_Helper' );
+
+
 endif;

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -556,7 +556,7 @@ class SV_WC_Helper {
 	 */
 	public static function get_post( $key ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::get_posted_data()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::get_posted_value()' );
 
 		return self::get_posted_value( $key );
 	}
@@ -596,7 +596,7 @@ class SV_WC_Helper {
 	 */
 	public static function get_request( $key ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::get_posted_data()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::get_requested_value()' );
 
 		return self::get_requested_value( $key );
 	}

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -28,1043 +28,951 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Helper' ) ) :
 
+
+/**
+ * SkyVerge Helper Class
+ *
+ * The purpose of this class is to centralize common utility functions that
+ * are commonly used in SkyVerge plugins
+ *
+ * @since 2.2.0
+ */
+class SV_WC_Helper {
+
+
+	/** encoding used for mb_*() string functions */
+	const MB_ENCODING = 'UTF-8';
+
+
+	/** String manipulation functions (all multi-byte safe) ***************/
+
 	/**
-	 * SkyVerge Helper Class
+	 * Returns true if the haystack string starts with needle
 	 *
-	 * The purpose of this class is to centralize common utility functions that
-	 * are commonly used in SkyVerge plugins
+	 * Note: case-sensitive
 	 *
 	 * @since 2.2.0
+	 * @param string $haystack
+	 * @param string $needle
+	 * @return bool
 	 */
-	class SV_WC_Helper {
+	public static function str_starts_with( $haystack, $needle ) {
 
-
-		/** encoding used for mb_*() string functions */
-		const MB_ENCODING = 'UTF-8';
-
-
-		/** String manipulation functions (all multi-byte safe) ***************/
-
-		/**
-		 * Returns true if the haystack string starts with needle
-		 *
-		 * Note: case-sensitive
-		 *
-		 * @since 2.2.0
-		 * @param string $haystack
-		 * @param string $needle
-		 * @return bool
-		 */
-		public static function str_starts_with( $haystack, $needle ) {
-
-			if ( self::multibyte_loaded() ) {
-
-				if ( '' === $needle ) {
-					return true;
-				}
-
-				return 0 === mb_strpos( $haystack, $needle, 0, self::MB_ENCODING );
-
-			} else {
-
-				$needle = self::str_to_ascii( $needle );
-
-				if ( '' === $needle ) {
-					return true;
-				}
-
-				return 0 === strpos( self::str_to_ascii( $haystack ), self::str_to_ascii( $needle ) );
-			}
-		}
-
-
-		/**
-		 * Return true if the haystack string ends with needle
-		 *
-		 * Note: case-sensitive
-		 *
-		 * @since 2.2.0
-		 * @param string $haystack
-		 * @param string $needle
-		 * @return bool
-		 */
-		public static function str_ends_with( $haystack, $needle ) {
+		if ( self::multibyte_loaded() ) {
 
 			if ( '' === $needle ) {
 				return true;
 			}
 
-			if ( self::multibyte_loaded() ) {
+			return 0 === mb_strpos( $haystack, $needle, 0, self::MB_ENCODING );
 
-				return mb_substr( $haystack, -mb_strlen( $needle, self::MB_ENCODING ), null, self::MB_ENCODING ) === $needle;
+		} else {
 
-			} else {
+			$needle = self::str_to_ascii( $needle );
 
-				$haystack = self::str_to_ascii( $haystack );
-				$needle   = self::str_to_ascii( $needle );
+			if ( '' === $needle ) {
+				return true;
+			}
 
-				return substr( $haystack, -strlen( $needle ) ) === $needle;
+			return 0 === strpos( self::str_to_ascii( $haystack ), self::str_to_ascii( $needle ) );
+		}
+	}
+
+
+	/**
+	 * Return true if the haystack string ends with needle
+	 *
+	 * Note: case-sensitive
+	 *
+	 * @since 2.2.0
+	 * @param string $haystack
+	 * @param string $needle
+	 * @return bool
+	 */
+	public static function str_ends_with( $haystack, $needle ) {
+
+		if ( '' === $needle ) {
+			return true;
+		}
+
+		if ( self::multibyte_loaded() ) {
+
+			return mb_substr( $haystack, -mb_strlen( $needle, self::MB_ENCODING ), null, self::MB_ENCODING ) === $needle;
+
+		} else {
+
+			$haystack = self::str_to_ascii( $haystack );
+			$needle   = self::str_to_ascii( $needle );
+
+			return substr( $haystack, -strlen( $needle ) ) === $needle;
+		}
+	}
+
+
+	/**
+	 * Returns true if the needle exists in haystack
+	 *
+	 * Note: case-sensitive
+	 *
+	 * @since 2.2.0
+	 * @param string $haystack
+	 * @param string $needle
+	 * @return bool
+	 */
+	public static function str_exists( $haystack, $needle ) {
+
+		if ( self::multibyte_loaded() ) {
+
+			if ( '' === $needle ) {
+				return false;
+			}
+
+			return false !== mb_strpos( $haystack, $needle, 0, self::MB_ENCODING );
+
+		} else {
+
+			$needle = self::str_to_ascii( $needle );
+
+			if ( '' === $needle ) {
+				return false;
+			}
+
+			return false !== strpos( self::str_to_ascii( $haystack ), self::str_to_ascii( $needle ) );
+		}
+	}
+
+
+	/**
+	 * Truncates a given $string after a given $length if string is longer than
+	 * $length. The last characters will be replaced with the $omission string
+	 * for a total length not exceeding $length
+	 *
+	 * @since 2.2.0
+	 * @param string $string text to truncate
+	 * @param int $length total desired length of string, including omission
+	 * @param string $omission omission text, defaults to '...'
+	 * @return string
+	 */
+	public static function str_truncate( $string, $length, $omission = '...' ) {
+
+		if ( self::multibyte_loaded() ) {
+
+			// bail if string doesn't need to be truncated
+			if ( mb_strlen( $string, self::MB_ENCODING ) <= $length ) {
+				return $string;
+			}
+
+			$length -= mb_strlen( $omission, self::MB_ENCODING );
+
+			return mb_substr( $string, 0, $length, self::MB_ENCODING ) . $omission;
+
+		} else {
+
+			$string = self::str_to_ascii( $string );
+
+			// bail if string doesn't need to be truncated
+			if ( strlen( $string ) <= $length ) {
+				return $string;
+			}
+
+			$length -= strlen( $omission );
+
+			return substr( $string, 0, $length ) . $omission;
+		}
+	}
+
+
+	/**
+	 * Returns a string with all non-ASCII characters removed. This is useful
+	 * for any string functions that expect only ASCII chars and can't
+	 * safely handle UTF-8. Note this only allows ASCII chars in the range
+	 * 33-126 (newlines/carriage returns are stripped)
+	 *
+	 * @since 2.2.0
+	 * @param string $string string to make ASCII
+	 * @return string
+	 */
+	public static function str_to_ascii( $string ) {
+
+		// strip ASCII chars 32 and under
+		$string = filter_var( $string, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW );
+
+		// strip ASCII chars 127 and higher
+		return filter_var( $string, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH );
+	}
+
+
+	/**
+	 * Return a string with insane UTF-8 characters removed, like invisible
+	 * characters, unused code points, and other weirdness. It should
+	 * accept the common types of characters defined in Unicode.
+	 *
+	 * The following are allowed characters:
+	 *
+	 * p{L} - any kind of letter from any language
+	 * p{Mn} - a character intended to be combined with another character without taking up extra space (e.g. accents, umlauts, etc.)
+	 * p{Mc} - a character intended to be combined with another character that takes up extra space (vowel signs in many Eastern languages)
+	 * p{Nd} - a digit zero through nine in any script except ideographic scripts
+	 * p{Zs} - a whitespace character that is invisible, but does take up space
+	 * p{P} - any kind of punctuation character
+	 * p{Sm} - any mathematical symbol
+	 * p{Sc} - any currency sign
+	 *
+	 * pattern definitions from http://www.regular-expressions.info/unicode.html
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $string
+	 * @return string
+	 */
+	public static function str_to_sane_utf8( $string ) {
+
+		$sane_string = preg_replace( '/[^\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Zs}\p{P}\p{Sm}\p{Sc}]/u', '', $string );
+
+		// preg_replace with the /u modifier can return null or false on failure
+		return ( is_null( $sane_string ) || false === $sane_string ) ? $string : $sane_string;
+	}
+
+
+	/**
+	 * Helper method to check if the multibyte extension is loaded, which
+	 * indicates it's safe to use the mb_*() string methods
+	 *
+	 * @since 2.2.0
+	 * @return bool
+	 */
+	protected static function multibyte_loaded() {
+
+		return extension_loaded( 'mbstring' );
+	}
+
+
+	/** Array functions ***************************************************/
+
+
+	/**
+	 * Insert the given element after the given key in the array
+	 *
+	 * Sample usage:
+	 *
+	 * given
+	 *
+	 * array( 'item_1' => 'foo', 'item_2' => 'bar' )
+	 *
+	 * array_insert_after( $array, 'item_1', array( 'item_1.5' => 'w00t' ) )
+	 *
+	 * becomes
+	 *
+	 * array( 'item_1' => 'foo', 'item_1.5' => 'w00t', 'item_2' => 'bar' )
+	 *
+	 * @since 2.2.0
+	 * @param array $array array to insert the given element into
+	 * @param string $insert_key key to insert given element after
+	 * @param array $element element to insert into array
+	 * @return array
+	 */
+	public static function array_insert_after( Array $array, $insert_key, Array $element ) {
+
+		$new_array = array();
+
+		foreach ( $array as $key => $value ) {
+
+			$new_array[ $key ] = $value;
+
+			if ( $insert_key == $key ) {
+
+				foreach ( $element as $k => $v ) {
+					$new_array[ $k ] = $v;
+				}
 			}
 		}
 
+		return $new_array;
+	}
 
-		/**
-		 * Returns true if the needle exists in haystack
-		 *
-		 * Note: case-sensitive
-		 *
-		 * @since 2.2.0
-		 * @param string $haystack
-		 * @param string $needle
-		 * @return bool
-		 */
-		public static function str_exists( $haystack, $needle ) {
 
-			if ( self::multibyte_loaded() ) {
+	/**
+	 * Convert array into XML by recursively generating child elements
+	 *
+	 * First instantiate a new XML writer object:
+	 *
+	 * $xml = new XMLWriter();
+	 *
+	 * Open in memory (alternatively you can use a local URI for file output)
+	 *
+	 * $xml->openMemory();
+	 *
+	 * Then start the document
+	 *
+	 * $xml->startDocument( '1.0', 'UTF-8' );
+	 *
+	 * Don't forget to end the document and output the memory
+	 *
+	 * $xml->endDocument();
+	 *
+	 * $your_xml_string = $xml->outputMemory();
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param \XMLWriter $xml_writer XML writer instance
+	 * @param string|array $element_key name for element, e.g. <per_page>
+	 * @param string|array $element_value value for element, e.g. 100
+	 */
+	public static function array_to_xml( $xml_writer, $element_key, $element_value = array() ) {
 
-				if ( '' === $needle ) {
-					return false;
+		if ( is_array( $element_value ) ) {
+
+			// handle attributes
+			if ( '@attributes' === $element_key ) {
+
+				foreach ( $element_value as $attribute_key => $attribute_value ) {
+
+					$xml_writer->startAttribute( $attribute_key );
+					$xml_writer->text( $attribute_value );
+					$xml_writer->endAttribute();
 				}
 
-				return false !== mb_strpos( $haystack, $needle, 0, self::MB_ENCODING );
-
-			} else {
-
-				$needle = self::str_to_ascii( $needle );
-
-				if ( '' === $needle ) {
-					return false;
-				}
-
-				return false !== strpos( self::str_to_ascii( $haystack ), self::str_to_ascii( $needle ) );
-			}
-		}
-
-
-		/**
-		 * Truncates a given $string after a given $length if string is longer than
-		 * $length. The last characters will be replaced with the $omission string
-		 * for a total length not exceeding $length
-		 *
-		 * @since 2.2.0
-		 * @param string $string text to truncate
-		 * @param int $length total desired length of string, including omission
-		 * @param string $omission omission text, defaults to '...'
-		 * @return string
-		 */
-		public static function str_truncate( $string, $length, $omission = '...' ) {
-
-			if ( self::multibyte_loaded() ) {
-
-				// bail if string doesn't need to be truncated
-				if ( mb_strlen( $string, self::MB_ENCODING ) <= $length ) {
-					return $string;
-				}
-
-				$length -= mb_strlen( $omission, self::MB_ENCODING );
-
-				return mb_substr( $string, 0, $length, self::MB_ENCODING ) . $omission;
-
-			} else {
-
-				$string = self::str_to_ascii( $string );
-
-				// bail if string doesn't need to be truncated
-				if ( strlen( $string ) <= $length ) {
-					return $string;
-				}
-
-				$length -= strlen( $omission );
-
-				return substr( $string, 0, $length ) . $omission;
-			}
-		}
-
-
-		/**
-		 * Returns a string with all non-ASCII characters removed. This is useful
-		 * for any string functions that expect only ASCII chars and can't
-		 * safely handle UTF-8. Note this only allows ASCII chars in the range
-		 * 33-126 (newlines/carriage returns are stripped)
-		 *
-		 * @since 2.2.0
-		 * @param string $string string to make ASCII
-		 * @return string
-		 */
-		public static function str_to_ascii( $string ) {
-
-			// strip ASCII chars 32 and under
-			$string = filter_var( $string, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW );
-
-			// strip ASCII chars 127 and higher
-			return filter_var( $string, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH );
-		}
-
-
-		/**
-		 * Return a string with insane UTF-8 characters removed, like invisible
-		 * characters, unused code points, and other weirdness. It should
-		 * accept the common types of characters defined in Unicode.
-		 *
-		 * The following are allowed characters:
-		 *
-		 * p{L} - any kind of letter from any language
-		 * p{Mn} - a character intended to be combined with another character without taking up extra space (e.g. accents, umlauts, etc.)
-		 * p{Mc} - a character intended to be combined with another character that takes up extra space (vowel signs in many Eastern languages)
-		 * p{Nd} - a digit zero through nine in any script except ideographic scripts
-		 * p{Zs} - a whitespace character that is invisible, but does take up space
-		 * p{P} - any kind of punctuation character
-		 * p{Sm} - any mathematical symbol
-		 * p{Sc} - any currency sign
-		 *
-		 * pattern definitions from http://www.regular-expressions.info/unicode.html
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param string $string
-		 * @return string
-		 */
-		public static function str_to_sane_utf8( $string ) {
-
-			$sane_string = preg_replace( '/[^\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Zs}\p{P}\p{Sm}\p{Sc}]/u', '', $string );
-
-			// preg_replace with the /u modifier can return null or false on failure
-			return ( is_null( $sane_string ) || false === $sane_string ) ? $string : $sane_string;
-		}
-
-
-		/**
-		 * Helper method to check if the multibyte extension is loaded, which
-		 * indicates it's safe to use the mb_*() string methods
-		 *
-		 * @since 2.2.0
-		 * @return bool
-		 */
-		protected static function multibyte_loaded() {
-
-			return extension_loaded( 'mbstring' );
-		}
-
-
-		/** Array functions ***************************************************/
-
-
-		/**
-		 * Insert the given element after the given key in the array
-		 *
-		 * Sample usage:
-		 *
-		 * given
-		 *
-		 * array( 'item_1' => 'foo', 'item_2' => 'bar' )
-		 *
-		 * array_insert_after( $array, 'item_1', array( 'item_1.5' => 'w00t' ) )
-		 *
-		 * becomes
-		 *
-		 * array( 'item_1' => 'foo', 'item_1.5' => 'w00t', 'item_2' => 'bar' )
-		 *
-		 * @since 2.2.0
-		 * @param array $array array to insert the given element into
-		 * @param string $insert_key key to insert given element after
-		 * @param array $element element to insert into array
-		 * @return array
-		 */
-		public static function array_insert_after( Array $array, $insert_key, Array $element ) {
-
-			$new_array = array();
-
-			foreach ( $array as $key => $value ) {
-
-				$new_array[ $key ] = $value;
-
-				if ( $insert_key == $key ) {
-
-					foreach ( $element as $k => $v ) {
-						$new_array[ $k ] = $v;
-					}
-				}
+				return;
 			}
 
-			return $new_array;
-		}
+			// handle multi-elements (e.g. multiple <Order> elements)
+			if ( is_numeric( key( $element_value ) ) ) {
 
+				// recursively generate child elements
+				foreach ( $element_value as $child_element_key => $child_element_value ) {
 
-		/**
-		 * Convert array into XML by recursively generating child elements
-		 *
-		 * First instantiate a new XML writer object:
-		 *
-		 * $xml = new XMLWriter();
-		 *
-		 * Open in memory (alternatively you can use a local URI for file output)
-		 *
-		 * $xml->openMemory();
-		 *
-		 * Then start the document
-		 *
-		 * $xml->startDocument( '1.0', 'UTF-8' );
-		 *
-		 * Don't forget to end the document and output the memory
-		 *
-		 * $xml->endDocument();
-		 *
-		 * $your_xml_string = $xml->outputMemory();
-		 *
-		 * @since 2.2.0
-		 * @param \XMLWriter $xml_writer XML writer instance
-		 * @param string|array $element_key name for element, e.g. <per_page>
-		 * @param string|array $element_value value for element, e.g. 100
-		 * @return string generated XML
-		 */
-		public static function array_to_xml( $xml_writer, $element_key, $element_value = array() ) {
-
-			if ( is_array( $element_value ) ) {
-
-				// handle attributes
-				if ( '@attributes' === $element_key ) {
-					foreach ( $element_value as $attribute_key => $attribute_value ) {
-
-						$xml_writer->startAttribute( $attribute_key );
-						$xml_writer->text( $attribute_value );
-						$xml_writer->endAttribute();
-					}
-					return;
-				}
-
-				// handle multi-elements (e.g. multiple <Order> elements)
-				if ( is_numeric( key( $element_value ) ) ) {
-
-					// recursively generate child elements
-					foreach ( $element_value as $child_element_key => $child_element_value ) {
-
-						$xml_writer->startElement( $element_key );
-
-						foreach ( $child_element_value as $sibling_element_key => $sibling_element_value ) {
-							self::array_to_xml( $xml_writer, $sibling_element_key, $sibling_element_value );
-						}
-
-						$xml_writer->endElement();
-					}
-
-				} else {
-
-					// start root element
 					$xml_writer->startElement( $element_key );
 
-					// recursively generate child elements
-					foreach ( $element_value as $child_element_key => $child_element_value ) {
-						self::array_to_xml( $xml_writer, $child_element_key, $child_element_value );
+					foreach ( $child_element_value as $sibling_element_key => $sibling_element_value ) {
+						self::array_to_xml( $xml_writer, $sibling_element_key, $sibling_element_value );
 					}
 
-					// end root element
 					$xml_writer->endElement();
 				}
 
 			} else {
 
-				// handle single elements
-				if ( '@value' == $element_key ) {
+				// start root element
+				$xml_writer->startElement( $element_key );
 
-					$xml_writer->text( $element_value );
-
-				} else {
-
-					// wrap element in CDATA tags if it contains illegal characters
-					if ( false !== strpos( $element_value, '<' ) || false !== strpos( $element_value, '>' ) ) {
-
-						$xml_writer->startElement( $element_key );
-						$xml_writer->writeCdata( $element_value );
-						$xml_writer->endElement();
-
-					} else {
-
-						$xml_writer->writeElement( $element_key, $element_value );
-					}
-
+				// recursively generate child elements
+				foreach ( $element_value as $child_element_key => $child_element_value ) {
+					self::array_to_xml( $xml_writer, $child_element_key, $child_element_value );
 				}
 
-				return;
-			}
-		}
-
-
-		/**
-		 * Lists an array as text.
-		 *
-		 * Takes an array and returns a list like "one, two, three, and four"
-		 * with a (mandatory) oxford comma.
-		 *
-		 * @since 5.2.0
-		 *
-		 * @param array $items items to list
-		 * @param string|null $conjunction coordinating conjunction, like "or" or "and"
-		 * @param string $separator list separator, like a comma
-		 * @return string
-		 */
-		public static function list_array_items( array $items, $conjunction = null, $separator = '' ) {
-
-			if ( ! is_string( $conjunction ) ) {
-				$conjunction = _x( 'and', 'coordinating conjunction for a list of items: a, b, and c', 'woocommerce-plugin-framework' );
+				// end root element
+				$xml_writer->endElement();
 			}
 
-			// append the conjunction to the last item
-			if ( count( $items ) > 1 ) {
+		} else {
 
-				$last_item = array_pop( $items );
+			// handle single elements
+			if ( '@value' === $element_key ) {
 
-				array_push( $items, trim( "{$conjunction} {$last_item}" ) );
-
-				// only use a comma if needed and no separator was passed
-				if ( count( $items ) < 3 ) {
-					$separator = ' ';
-				} elseif ( ! is_string( $separator ) || '' === $separator ) {
-					$separator = ', ';
-				}
-			}
-
-			return implode( $separator, $items );
-		}
-
-
-		/** Number helper functions *******************************************/
-
-
-		/**
-		 * Format a number with 2 decimal points, using a period for the decimal
-		 * separator and no thousands separator.
-		 *
-		 * Commonly used for payment gateways which require amounts in this format.
-		 *
-		 * @since 3.0.0
-		 * @param float $number
-		 * @return string
-		 */
-		public static function number_format( $number ) {
-
-			return number_format( (float) $number, 2, '.', '' );
-		}
-
-
-		/** WooCommerce helper functions **************************************/
-
-
-		/**
-		 * Get order line items (products) in a neatly-formatted array of objects
-		 * with properties:
-		 *
-		 * + id - item ID
-		 * + name - item name, usually product title, processed through htmlentities()
-		 * + description - formatted item meta (e.g. Size: Medium, Color: blue), processed through htmlentities()
-		 * + quantity - item quantity
-		 * + item_total - item total (line total divided by quantity, excluding tax & rounded)
-		 * + line_total - line item total (excluding tax & rounded)
-		 * + meta - formatted item meta array
-		 * + product - item product or null if getting product from item failed
-		 * + item - raw item array
-		 *
-		 * @since 3.0.0
-		 * @param \WC_Order $order
-		 * @return \stdClass[] array of line item objects
-		 */
-		public static function get_order_line_items( $order ) {
-
-			$line_items = array();
-
-			foreach ( $order->get_items() as $id => $item ) {
-
-				$line_item = new \stdClass();
-
-				// TODO: remove when WC 3.0 can be required
-				$name     = $item instanceof \WC_Order_Item_Product ? $item->get_name() : $item['name'];
-				$quantity = $item instanceof \WC_Order_Item_Product ? $item->get_quantity() : $item['qty'];
-
-				$item_desc = array();
-
-				$product = ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_1() ) ? $item->get_product() : $order->get_product_from_item( $item );
-
-				// add SKU to description if available
-				if ( is_callable( array( $product, 'get_sku' ) ) && $product->get_sku() ) {
-					$item_desc[] = sprintf( 'SKU: %s', $product->get_sku() );
-				}
-
-				$item_meta = SV_WC_Order_Compatibility::get_item_formatted_meta_data( $item, '_', true );
-
-				if ( ! empty( $item_meta ) ) {
-
-					foreach ( $item_meta as $meta ) {
-						$item_desc[] = sprintf( '%s: %s', $meta['label'], $meta['value'] );
-					}
-				}
-
-				$item_desc = implode( ', ', $item_desc );
-
-				$line_item->id          = $id;
-				$line_item->name        = htmlentities( $name, ENT_QUOTES, 'UTF-8', false );
-				$line_item->description = htmlentities( $item_desc, ENT_QUOTES, 'UTF-8', false );
-				$line_item->quantity    = $quantity;
-				$line_item->item_total  = isset( $item['recurring_line_total'] ) ? $item['recurring_line_total'] : $order->get_item_total( $item );
-				$line_item->line_total  = $order->get_line_total( $item );
-				$line_item->meta        = $item_meta;
-				$line_item->product     = is_object( $product ) ? $product : null;
-				$line_item->item        = $item;
-
-				$line_items[] = $line_item;
-			}
-
-			return $line_items;
-		}
-
-
-		/**
-		 * Determines if an order contains only virtual products.
-		 *
-		 * @since 4.5.0
-		 * @param \WC_Order $order the order object
-		 * @return bool
-		 */
-		public static function is_order_virtual( \WC_Order $order ) {
-
-			$is_virtual = true;
-
-			foreach ( $order->get_items() as $item ) {
-
-				if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-					$product = $item->get_product();
-				} else {
-					$product = $order->get_product_from_item( $item );
-				}
-
-				// once we've found one non-virtual product we know we're done, break out of the loop
-				if ( $product && ! $product->is_virtual() ) {
-					$is_virtual = false;
-					break;
-				}
-			}
-
-			return $is_virtual;
-		}
-
-
-		/**
-		 * Safely get and trim data from $_POST
-		 *
-		 * @since 3.0.0
-		 * @param string $key array key to get from $_POST array
-		 * @return string value from $_POST or blank string if $_POST[ $key ] is not set
-		 */
-		public static function get_post( $key ) {
-
-			if ( isset( $_POST[ $key ] ) ) {
-				return trim( $_POST[ $key ] );
-			}
-
-			return '';
-		}
-
-
-		/**
-		 * Safely get and trim data from $_REQUEST
-		 *
-		 * @since 3.0.0
-		 * @param string $key array key to get from $_REQUEST array
-		 * @return string value from $_REQUEST or blank string if $_REQUEST[ $key ] is not set
-		 */
-		public static function get_request( $key ) {
-
-			if ( isset( $_REQUEST[ $key ] ) ) {
-				return trim( $_REQUEST[ $key ] );
-			}
-
-			return '';
-		}
-
-
-		/**
-		 * Get the count of notices added, either for all notices (default) or for one
- 		 * particular notice type specified by $notice_type.
-		 *
-		 * WC notice functions are not available in the admin
-		 *
-		 * @since 3.0.2
-		 * @param string $notice_type The name of the notice type - either error, success or notice. [optional]
-		 * @return int
-		 */
-		public static function wc_notice_count( $notice_type = '' ) {
-
-			if ( function_exists( 'wc_notice_count' ) ) {
-				return wc_notice_count( $notice_type );
-			}
-
-			return 0;
-		}
-
-
-		/**
-		 * Add and store a notice.
-		 *
-		 * WC notice functions are not available in the admin
-		 *
-		 * @since 3.0.2
-		 * @param string $message The text to display in the notice.
-		 * @param string $notice_type The singular name of the notice type - either error, success or notice. [optional]
-		 */
-		public static function wc_add_notice( $message, $notice_type = 'success' ) {
-
-			if ( function_exists( 'wc_add_notice' ) ) {
-				wc_add_notice( $message, $notice_type );
-			}
-		}
-
-
-		/**
-		 * Print a single notice immediately
-		 *
-		 * WC notice functions are not available in the admin
-		 *
-		 * @since 3.0.2
-		 * @param string $message The text to display in the notice.
-		 * @param string $notice_type The singular name of the notice type - either error, success or notice. [optional]
-		 */
-		public static function wc_print_notice( $message, $notice_type = 'success' ) {
-
-			if ( function_exists( 'wc_print_notice' ) ) {
-				wc_print_notice( $message, $notice_type );
-			}
-		}
-
-
-		/**
-		 * Gets the full URL to the log file for a given $handle
-		 *
-		 * @since 4.0.0
-		 * @param string $handle log handle
-		 * @return string URL to the WC log file identified by $handle
-		 */
-		public static function get_wc_log_file_url( $handle ) {
-			return admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&log_file=%s-%s-log', $handle, sanitize_file_name( wp_hash( $handle ) ) ) );
-		}
-
-
-		/**
-		 * Gets the current WordPress site name.
-		 *
-		 * This is helpful for retrieving the actual site name instead of the
-		 * network name on multisite installations.
-		 *
-		 * @since 4.6.0
-		 * @return string
-		 */
-		public static function get_site_name() {
-
-			return ( is_multisite() ) ? get_blog_details()->blogname : get_bloginfo( 'name' );
-		}
-
-
-		/** JavaScript helper functions ***************************************/
-
-
-		/**
-		 * Enhanced search JavaScript (Select2)
-		 *
-		 * Enqueues JavaScript required for AJAX search with Select2.
-		 *
-		 * Example usage:
-		 *    <input type="hidden" class="sv-wc-enhanced-search" name="category_ids" data-multiple="true" style="min-width: 300px;"
-		 *       data-action="wc_cart_notices_json_search_product_categories"
-		 *       data-nonce="<?php echo wp_create_nonce( 'search-categories' ); ?>"
-		 *       data-request_data = "<?php echo esc_attr( json_encode( array( 'field_name' => 'something_exciting', 'default' => 'default_label' ) ) ) ?>"
-		 *       data-placeholder="<?php esc_attr_e( 'Search for a category&hellip;', 'wc-cart-notices' ) ?>"
-		 *       data-allow_clear="true"
-		 *       data-selected="<?php
-		 *          $json_ids    = array();
-		 *          if ( isset( $notice->data['categories'] ) ) {
-		 *             foreach ( $notice->data['categories'] as $value => $title ) {
-		 *                $json_ids[ esc_attr( $value ) ] = esc_html( $title );
-		 *             }
-		 *          }
-		 *          echo esc_attr( json_encode( $json_ids ) );
-		 *       ?>"
-		 *       value="<?php echo implode( ',', array_keys( $json_ids ) ); ?>" />
-		 *
-		 * - `data-selected` can be a json encoded associative array like Array( 'key' => 'value' )
-		 * - `value` should be a comma-separated list of selected keys
-		 * - `data-request_data` can be used to pass any additional data to the AJAX request
-		 *
-		 * @codeCoverageIgnore no need to unit test this since it's mostly JS
-		 * @since 3.1.0
-		 */
-		public static function render_select2_ajax() {
-
-			if ( ! did_action( 'sv_wc_select2_ajax_rendered' ) ) {
-
-				$javascript = "( function(){
-					if ( ! $().select2 ) return;
-				";
-
-				// Ensure localized strings are used.
-				$javascript .= "
-
-					function getEnhancedSelectFormatString() {
-
-						if ( 'undefined' !== typeof wc_select_params ) {
-							wc_enhanced_select_params = wc_select_params;
-						}
-
-						if ( 'undefined' === typeof wc_enhanced_select_params ) {
-							return {};
-						}
-
-						var formatString = {
-							formatMatches: function( matches ) {
-								if ( 1 === matches ) {
-									return wc_enhanced_select_params.i18n_matches_1;
-								}
-
-								return wc_enhanced_select_params.i18n_matches_n.replace( '%qty%', matches );
-							},
-							formatNoMatches: function() {
-								return wc_enhanced_select_params.i18n_no_matches;
-							},
-							formatAjaxError: function( jqXHR, textStatus, errorThrown ) {
-								return wc_enhanced_select_params.i18n_ajax_error;
-							},
-							formatInputTooShort: function( input, min ) {
-								var number = min - input.length;
-
-								if ( 1 === number ) {
-									return wc_enhanced_select_params.i18n_input_too_short_1
-								}
-
-								return wc_enhanced_select_params.i18n_input_too_short_n.replace( '%qty%', number );
-							},
-							formatInputTooLong: function( input, max ) {
-								var number = input.length - max;
-
-								if ( 1 === number ) {
-									return wc_enhanced_select_params.i18n_input_too_long_1
-								}
-
-								return wc_enhanced_select_params.i18n_input_too_long_n.replace( '%qty%', number );
-							},
-							formatSelectionTooBig: function( limit ) {
-								if ( 1 === limit ) {
-									return wc_enhanced_select_params.i18n_selection_too_long_1;
-								}
-
-								return wc_enhanced_select_params.i18n_selection_too_long_n.replace( '%qty%', number );
-							},
-							formatLoadMore: function( pageNumber ) {
-								return wc_enhanced_select_params.i18n_load_more;
-							},
-							formatSearching: function() {
-								return wc_enhanced_select_params.i18n_searching;
-							}
-						};
-
-						return formatString;
-					}
-				";
-
-				// Handle Select2 AJAX call according to Select2 version bundled with WC.
-				if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-
-					$javascript .= "
-
-						$( 'select.sv-wc-enhanced-search' ).filter( ':not(.enhanced)' ).each( function() {
-
-							var select2_args = {
-								allowClear:         $( this ).data( 'allow_clear' ) ? true : false,
-								placeholder:        $( this ).data( 'placeholder' ),
-								minimumInputLength: $( this ).data( 'minimum_input_length' ) ? $( this ).data( 'minimum_input_length' ) : '3',
-								escapeMarkup:       function( m ) {
-									return m;
-								},
-								ajax:               {
-									url:            '" . esc_js( admin_url( 'admin-ajax.php' ) ) . "',
-									dataType:       'json',
-									cache:          true,
-									delay:          250,
-									data:           function( params ) {
-										return {
-											term:         params.term,
-											request_data: $( this ).data( 'request_data' ) ? $( this ).data( 'request_data' ) : {},
-											action:       $( this ).data( 'action' ) || 'woocommerce_json_search_products_and_variations',
-											security:     $( this ).data( 'nonce' )
-										};
-									},
-									processResults: function( data, params ) {
-										var terms = [];
-										if ( data ) {
-											$.each( data, function( id, text ) {
-												terms.push( { id: id, text: text } );
-											});
-										}
-										return { results: terms };
-									}
-								}
-							};
-
-							select2_args = $.extend( select2_args, getEnhancedSelectFormatString() );
-
-							$( this ).select2( select2_args ).addClass( 'enhanced' );
-						} );
-					";
-
-				} else {
-
-					$javascript .= "
-
-						$( ':input.sv-wc-enhanced-search' ).filter( ':not(.enhanced)' ).each( function() {
-
-							var select2_args = {
-								allowClear:         $( this ).data( 'allow_clear' ) ? true : false,
-								placeholder:        $( this ).data( 'placeholder' ),
-								minimumInputLength: $( this ).data( 'minimum_input_length' ) ? $( this ).data( 'minimum_input_length' ) : '3',
-								escapeMarkup:       function( m ) {
-									return m;
-								},
-								ajax:               {
-									url:         '" . esc_js( admin_url( 'admin-ajax.php' ) ) . "',
-									dataType:    'json',
-									cache:       true,
-									quietMillis: 250,
-									data:        function( term, page ) {
-										return {
-											term:         term,
-											request_data: $( this ).data( 'request_data' ) ? $( this ).data( 'request_data' ) : {},
-											action:       $( this ).data( 'action' ) || 'woocommerce_json_search_products_and_variations',
-											security:     $( this ).data( 'nonce' )
-										};
-									},
-									results:     function( data, page ) {
-										var terms = [];
-										if ( data ) {
-											$.each( data, function( id, text ) {
-												terms.push( { id: id, text: text } );
-											});
-										}
-										return { results: terms };
-									}
-								}
-							};
-
-							if ( $( this ).data( 'multiple' ) === true ) {
-
-								select2_args.multiple        = true;
-								select2_args.initSelection   = function( element, callback ) {
-									var data     = $.parseJSON( element.attr( 'data-selected' ) );
-									var selected = [];
-
-									$( element.val().split( ',' ) ).each( function( i, val ) {
-										selected.push( { id: val, text: data[ val ] } );
-									} );
-									return callback( selected );
-								};
-								select2_args.formatSelection = function( data ) {
-									return '<div class=\"selected-option\" data-id=\"' + data.id + '\">' + data.text + '</div>';
-								};
-
-							} else {
-
-								select2_args.multiple        = false;
-								select2_args.initSelection   = function( element, callback ) {
-									var data = {id: element.val(), text: element.attr( 'data-selected' )};
-									return callback( data );
-								};
-							}
-
-							select2_args = $.extend( select2_args, getEnhancedSelectFormatString() );
-
-							$( this ).select2( select2_args ).addClass( 'enhanced' );
-						} );
-					";
-				}
-
-				$javascript .= "} )();";
-
-				wc_enqueue_js( $javascript );
-
-				/**
-				 * WC Select2 Ajax Rendered Action.
-				 *
-				 * Fired when an Ajax select2 is rendered.
-				 *
-				 * @since 3.1.0
-				 */
-				do_action( 'sv_wc_select2_ajax_rendered' );
-			}
-		}
-
-
-		/** Framework translation functions ***********************************/
-
-
-		/**
-		 * Gettext `__()` wrapper for framework-translated strings
-		 *
-		 * Warning! This function should only be used if an existing
-		 * translation from the framework is to be used. It should
-		 * never be called for plugin-specific or untranslated strings!
-		 * Untranslated = not registered via string literal.
-		 *
-		 * @since 4.1.0
-		 * @param string $text
-		 * @return string translated text
-		 */
-		public static function f__( $text ) {
-
-			return __( $text, 'woocommerce-plugin-framework' );
-		}
-
-
-		/**
-		 * Gettext `_e()` wrapper for framework-translated strings
-		 *
-		 * Warning! This function should only be used if an existing
-		 * translation from the framework is to be used. It should
-		 * never be called for plugin-specific or untranslated strings!
-		 * Untranslated = not registered via string literal.
-		 *
-		 * @since 4.1.0
-		 * @param string $text
-		 */
-		public static function f_e( $text ) {
-
-			_e( $text, 'woocommerce-plugin-framework' );
-		}
-
-
-		/**
-		 * Gettext `_x()` wrapper for framework-translated strings
-		 *
-		 * Warning! This function should only be used if an existing
-		 * translation from the framework is to be used. It should
-		 * never be called for plugin-specific or untranslated strings!
-		 * Untranslated = not registered via string literal.
-		 *
-		 * @since 4.1.0
-		 * @param string $text
-		 * @return string translated text
-		 */
-		public static function f_x( $text, $context ) {
-
-			return _x( $text, $context, 'woocommerce-plugin-framework' );
-		}
-
-
-		/** Misc functions ****************************************************/
-
-
-		/**
-		 * Gets the WordPress current screen.
-		 *
-		 * @see get_current_screen() replacement which is always available, unlike the WordPress core function
-		 *
-		 * @since 5.4.2
-		 *
-		 * @return \WP_Screen|null
-		 */
-		public static function get_current_screen() {
-			global $current_screen;
-
-			return $current_screen ?: null;
-		}
-
-
-		/**
-		 * Checks if the current screen matches a specified ID.
-		 *
-		 * This helps avoiding using the get_current_screen() function which is not always available,
-		 * or setting the substitute global $current_screen every time a check needs to be performed.
-		 *
-		 * @since 5.4.2
-		 *
-		 * @param string $id id (or property) to compare
-		 * @param string $prop optional property to compare, defaults to screen id
-		 * @return bool
-		 */
-		public static function is_current_screen( $id, $prop = 'id' ) {
-			global $current_screen;
-
-			return isset( $current_screen->$prop ) && $id === $current_screen->$prop;
-		}
-
-
-		/**
-		 * Convert a 2-character country code into its 3-character equivalent, or
-		 * vice-versa, e.g.
-		 *
-		 * 1) given USA, returns US
-		 * 2) given US, returns USA
-		 *
-		 * @since 4.2.0
-		 * @deprecated 5.4.3
-		 *
-		 * @param string $code ISO-3166-alpha-2 or ISO-3166-alpha-3 country code
-		 * @return string country code
-		 */
-		public static function convert_country_code( $code ) {
-
-			wc_deprecated_function( __METHOD__, '5.4.3', Country_Helper::class . '::convert_alpha_country_code()' );
-
-			return Country_Helper::convert_alpha_country_code( $code );
-		}
-
-
-		/**
-		 * Displays a notice if the provided hook has not yet run.
-		 *
-		 * @since 5.2.0
-		 *
-		 * @param string $hook action hook to check
-		 * @param string $method method/function name
-		 * @param string $version version the notice was added
-		 */
-		public static function maybe_doing_it_early( $hook, $method, $version ) {
-
-			if ( ! did_action( $hook ) ) {
-				SV_WC_Plugin_Compatibility::wc_doing_it_wrong( $method, "This should only be called after '{$hook}'", $version );
-			}
-		}
-
-
-		/**
-		 * Triggers a PHP error.
-		 *
-		 * This wrapper method ensures AJAX isn't broken in the process.
-		 *
-		 * @since 4.6.0
-		 * @param string $message the error message
-		 * @param int $type Optional. The error type. Defaults to E_USER_NOTICE
-		 */
-		public static function trigger_error( $message, $type = E_USER_NOTICE ) {
-
-			if ( is_callable( 'is_ajax' ) && is_ajax() ) {
-
-				switch ( $type ) {
-
-					case E_USER_NOTICE:
-						$prefix = 'Notice: ';
-					break;
-
-					case E_USER_WARNING:
-						$prefix = 'Warning: ';
-					break;
-
-					default:
-						$prefix = '';
-				}
-
-				error_log( $prefix . $message );
+				$xml_writer->text( $element_value );
 
 			} else {
 
-				trigger_error( $message, $type );
+				// wrap element in CDATA tags if it contains illegal characters
+				if ( false !== strpos( $element_value, '<' ) || false !== strpos( $element_value, '>' ) ) {
+
+					$xml_writer->startElement( $element_key );
+					$xml_writer->writeCdata( $element_value );
+					$xml_writer->endElement();
+
+				} else {
+
+					$xml_writer->writeElement( $element_key, $element_value );
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * Lists an array as text.
+	 *
+	 * Takes an array and returns a list like "one, two, three, and four"
+	 * with a (mandatory) oxford comma.
+	 *
+	 * @since 5.2.0
+	 *
+	 * @param array $items items to list
+	 * @param string|null $conjunction coordinating conjunction, like "or" or "and"
+	 * @param string $separator list separator, like a comma
+	 * @return string
+	 */
+	public static function list_array_items( array $items, $conjunction = null, $separator = '' ) {
+
+		if ( ! is_string( $conjunction ) ) {
+			$conjunction = _x( 'and', 'coordinating conjunction for a list of items: a, b, and c', 'woocommerce-plugin-framework' );
+		}
+
+		// append the conjunction to the last item
+		if ( count( $items ) > 1 ) {
+
+			$last_item = array_pop( $items );
+
+			array_push( $items, trim( "{$conjunction} {$last_item}" ) );
+
+			// only use a comma if needed and no separator was passed
+			if ( count( $items ) < 3 ) {
+				$separator = ' ';
+			} elseif ( ! is_string( $separator ) || '' === $separator ) {
+				$separator = ', ';
 			}
 		}
 
-
+		return implode( $separator, $items );
 	}
 
-endif; // Class exists check
+
+	/** Number helper functions *******************************************/
+
+
+	/**
+	 * Format a number with 2 decimal points, using a period for the decimal
+	 * separator and no thousands separator.
+	 *
+	 * Commonly used for payment gateways which require amounts in this format.
+	 *
+	 * @since 3.0.0
+	 * @param float $number
+	 * @return string
+	 */
+	public static function number_format( $number ) {
+
+		return number_format( (float) $number, 2, '.', '' );
+	}
+
+
+	/** WooCommerce helper functions **************************************/
+
+
+	/**
+	 * Gets order line items (products) as an array of objects.
+	 *
+	 * Object properties:
+	 *
+	 * + id          - item ID
+	 * + name        - item name, usually product title, processed through htmlentities()
+	 * + description - formatted item meta (e.g. Size: Medium, Color: blue), processed through htmlentities()
+	 * + quantity    - item quantity
+	 * + item_total  - item total (line total divided by quantity, excluding tax & rounded)
+	 * + line_total  - line item total (excluding tax & rounded)
+	 * + meta        - formatted item meta array
+	 * + product     - item product or null if getting product from item failed
+	 * + item        - raw item array
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param \WC_Order $order
+	 * @return \stdClass[] array of line item objects
+	 */
+	public static function get_order_line_items( $order ) {
+
+		$line_items = [];
+
+		/** @var \WC_Order_Item_Product $item */
+		foreach ( $order->get_items() as $id => $item ) {
+
+			$line_item = new \stdClass();
+			$product   = $item->get_product();
+			$name      = $item->get_name();
+			$quantity  = $item->get_quantity();
+			$item_desc = [];
+
+			// add SKU to description if available
+			if ( $sku = $product->get_sku() ) {
+				$item_desc[] = sprintf( 'SKU: %s', $sku );
+			}
+
+			$item_meta = SV_WC_Order_Compatibility::get_item_formatted_meta_data( $item, '_', true );
+
+			if ( ! empty( $item_meta ) ) {
+
+				foreach ( $item_meta as $meta ) {
+
+					$item_desc[] = sprintf( '%s: %s', $meta['label'], $meta['value'] );
+				}
+			}
+
+			$item_desc = implode( ', ', $item_desc );
+
+			$line_item->id          = $id;
+			$line_item->name        = htmlentities( $name, ENT_QUOTES, 'UTF-8', false );
+			$line_item->description = htmlentities( $item_desc, ENT_QUOTES, 'UTF-8', false );
+			$line_item->quantity    = $quantity;
+			$line_item->item_total  = isset( $item['recurring_line_total'] ) ? $item['recurring_line_total'] : $order->get_item_total( $item );
+			$line_item->line_total  = $order->get_line_total( $item );
+			$line_item->meta        = $item_meta;
+			$line_item->product     = is_object( $product ) ? $product : null;
+			$line_item->item        = $item;
+
+			$line_items[] = $line_item;
+		}
+
+		return $line_items;
+	}
+
+
+	/**
+	 * Determines if an order contains only virtual products.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param \WC_Order $order the order object
+	 * @return bool
+	 */
+	public static function is_order_virtual( \WC_Order $order ) {
+
+		$is_virtual = true;
+
+		/** @var \WC_Order_Item_Product $item */
+		foreach ( $order->get_items() as $item ) {
+
+			$product = $item->get_product();
+
+			// once we've found one non-virtual product we know we're done, break out of the loop
+			if ( $product && ! $product->is_virtual() ) {
+
+				$is_virtual = false;
+				break;
+			}
+		}
+
+		return $is_virtual;
+	}
+
+
+	/**
+	 * Safely get and trim data from $_POST
+	 *
+	 * @since 3.0.0
+	 * @param string $key array key to get from $_POST array
+	 * @return string value from $_POST or blank string if $_POST[ $key ] is not set
+	 */
+	public static function get_post( $key ) {
+
+		if ( isset( $_POST[ $key ] ) ) {
+			return trim( $_POST[ $key ] );
+		}
+
+		return '';
+	}
+
+
+	/**
+	 * Safely get and trim data from $_REQUEST
+	 *
+	 * @since 3.0.0
+	 * @param string $key array key to get from $_REQUEST array
+	 * @return string value from $_REQUEST or blank string if $_REQUEST[ $key ] is not set
+	 */
+	public static function get_request( $key ) {
+
+		if ( isset( $_REQUEST[ $key ] ) ) {
+			return trim( $_REQUEST[ $key ] );
+		}
+
+		return '';
+	}
+
+
+	/**
+	 * Get the count of notices added, either for all notices (default) or for one
+	 * particular notice type specified by $notice_type.
+	 *
+	 * WC notice functions are not available in the admin
+	 *
+	 * @since 3.0.2
+	 * @param string $notice_type The name of the notice type - either error, success or notice. [optional]
+	 * @return int
+	 */
+	public static function wc_notice_count( $notice_type = '' ) {
+
+		if ( function_exists( 'wc_notice_count' ) ) {
+			return wc_notice_count( $notice_type );
+		}
+
+		return 0;
+	}
+
+
+	/**
+	 * Add and store a notice.
+	 *
+	 * WC notice functions are not available in the admin
+	 *
+	 * @since 3.0.2
+	 * @param string $message The text to display in the notice.
+	 * @param string $notice_type The singular name of the notice type - either error, success or notice. [optional]
+	 */
+	public static function wc_add_notice( $message, $notice_type = 'success' ) {
+
+		if ( function_exists( 'wc_add_notice' ) ) {
+			wc_add_notice( $message, $notice_type );
+		}
+	}
+
+
+	/**
+	 * Print a single notice immediately
+	 *
+	 * WC notice functions are not available in the admin
+	 *
+	 * @since 3.0.2
+	 * @param string $message The text to display in the notice.
+	 * @param string $notice_type The singular name of the notice type - either error, success or notice. [optional]
+	 */
+	public static function wc_print_notice( $message, $notice_type = 'success' ) {
+
+		if ( function_exists( 'wc_print_notice' ) ) {
+			wc_print_notice( $message, $notice_type );
+		}
+	}
+
+
+	/**
+	 * Gets the full URL to the log file for a given $handle
+	 *
+	 * @since 4.0.0
+	 * @param string $handle log handle
+	 * @return string URL to the WC log file identified by $handle
+	 */
+	public static function get_wc_log_file_url( $handle ) {
+		return admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&log_file=%s-%s-log', $handle, sanitize_file_name( wp_hash( $handle ) ) ) );
+	}
+
+
+	/**
+	 * Gets the current WordPress site name.
+	 *
+	 * This is helpful for retrieving the actual site name instead of the
+	 * network name on multisite installations.
+	 *
+	 * @since 4.6.0
+	 * @return string
+	 */
+	public static function get_site_name() {
+
+		return ( is_multisite() ) ? get_blog_details()->blogname : get_bloginfo( 'name' );
+	}
+
+
+	/** JavaScript helper functions ***************************************/
+
+
+	/**
+	 * Enhanced search JavaScript (Select2)
+	 *
+	 * Enqueues JavaScript required for AJAX search with Select2.
+	 *
+	 * @codeCoverageIgnore no need to unit test this since it's mostly JavaScript
+	 *
+	 * @since 3.1.0
+	 */
+	public static function render_select2_ajax() {
+
+		if ( ! did_action( 'sv_wc_select2_ajax_rendered' ) ) {
+
+			$javascript = "( function(){
+				if ( ! $().select2 ) return;
+			";
+
+			// Ensure localized strings are used.
+			$javascript .= "
+
+				function getEnhancedSelectFormatString() {
+
+					if ( 'undefined' !== typeof wc_select_params ) {
+						wc_enhanced_select_params = wc_select_params;
+					}
+
+					if ( 'undefined' === typeof wc_enhanced_select_params ) {
+						return {};
+					}
+
+					var formatString = {
+						formatMatches: function( matches ) {
+							if ( 1 === matches ) {
+								return wc_enhanced_select_params.i18n_matches_1;
+							}
+
+							return wc_enhanced_select_params.i18n_matches_n.replace( '%qty%', matches );
+						},
+						formatNoMatches: function() {
+							return wc_enhanced_select_params.i18n_no_matches;
+						},
+						formatAjaxError: function( jqXHR, textStatus, errorThrown ) {
+							return wc_enhanced_select_params.i18n_ajax_error;
+						},
+						formatInputTooShort: function( input, min ) {
+							var number = min - input.length;
+
+							if ( 1 === number ) {
+								return wc_enhanced_select_params.i18n_input_too_short_1
+							}
+
+							return wc_enhanced_select_params.i18n_input_too_short_n.replace( '%qty%', number );
+						},
+						formatInputTooLong: function( input, max ) {
+							var number = input.length - max;
+
+							if ( 1 === number ) {
+								return wc_enhanced_select_params.i18n_input_too_long_1
+							}
+
+							return wc_enhanced_select_params.i18n_input_too_long_n.replace( '%qty%', number );
+						},
+						formatSelectionTooBig: function( limit ) {
+							if ( 1 === limit ) {
+								return wc_enhanced_select_params.i18n_selection_too_long_1;
+							}
+
+							return wc_enhanced_select_params.i18n_selection_too_long_n.replace( '%qty%', number );
+						},
+						formatLoadMore: function( pageNumber ) {
+							return wc_enhanced_select_params.i18n_load_more;
+						},
+						formatSearching: function() {
+							return wc_enhanced_select_params.i18n_searching;
+						}
+					};
+
+					return formatString;
+				}
+			";
+
+			$javascript .= "
+
+				$( 'select.sv-wc-enhanced-search' ).filter( ':not(.enhanced)' ).each( function() {
+
+					var select2_args = {
+						allowClear:         $( this ).data( 'allow_clear' ) ? true : false,
+						placeholder:        $( this ).data( 'placeholder' ),
+						minimumInputLength: $( this ).data( 'minimum_input_length' ) ? $( this ).data( 'minimum_input_length' ) : '3',
+						escapeMarkup:       function( m ) {
+							return m;
+						},
+						ajax:               {
+							url:            '" . esc_js( admin_url( 'admin-ajax.php' ) ) . "',
+							dataType:       'json',
+							cache:          true,
+							delay:          250,
+							data:           function( params ) {
+								return {
+									term:         params.term,
+									request_data: $( this ).data( 'request_data' ) ? $( this ).data( 'request_data' ) : {},
+									action:       $( this ).data( 'action' ) || 'woocommerce_json_search_products_and_variations',
+									security:     $( this ).data( 'nonce' )
+								};
+							},
+							processResults: function( data, params ) {
+								var terms = [];
+								if ( data ) {
+									$.each( data, function( id, text ) {
+										terms.push( { id: id, text: text } );
+									});
+								}
+								return { results: terms };
+							}
+						}
+					};
+
+					select2_args = $.extend( select2_args, getEnhancedSelectFormatString() );
+
+					$( this ).select2( select2_args ).addClass( 'enhanced' );
+				} );
+			";
+
+			$javascript .= '} )();';
+
+			wc_enqueue_js( $javascript );
+
+			/**
+			 * WC Select2 Ajax Rendered Action.
+			 *
+			 * Fired when an Ajax select2 is rendered.
+			 *
+			 * @since 3.1.0
+			 */
+			do_action( 'sv_wc_select2_ajax_rendered' );
+		}
+	}
+
+
+	/** Framework translation functions ***********************************/
+
+
+	/**
+	 * Gettext `__()` wrapper for framework-translated strings
+	 *
+	 * Warning! This function should only be used if an existing
+	 * translation from the framework is to be used. It should
+	 * never be called for plugin-specific or untranslated strings!
+	 * Untranslated = not registered via string literal.
+	 *
+	 * @since 4.1.0
+	 * @param string $text
+	 * @return string translated text
+	 */
+	public static function f__( $text ) {
+
+		return __( $text, 'woocommerce-plugin-framework' );
+	}
+
+
+	/**
+	 * Gettext `_e()` wrapper for framework-translated strings
+	 *
+	 * Warning! This function should only be used if an existing
+	 * translation from the framework is to be used. It should
+	 * never be called for plugin-specific or untranslated strings!
+	 * Untranslated = not registered via string literal.
+	 *
+	 * @since 4.1.0
+	 * @param string $text
+	 */
+	public static function f_e( $text ) {
+
+		_e( $text, 'woocommerce-plugin-framework' );
+	}
+
+
+	/**
+	 * Gettext `_x()` wrapper for framework-translated strings
+	 *
+	 * Warning! This function should only be used if an existing
+	 * translation from the framework is to be used. It should
+	 * never be called for plugin-specific or untranslated strings!
+	 * Untranslated = not registered via string literal.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $text
+	 * @param string $context
+	 * @return string translated text
+	 */
+	public static function f_x( $text, $context ) {
+
+		return _x( $text, $context, 'woocommerce-plugin-framework' );
+	}
+
+
+	/** Misc functions ****************************************************/
+
+
+	/**
+	 * Gets the WordPress current screen.
+	 *
+	 * @see get_current_screen() replacement which is always available, unlike the WordPress core function
+	 *
+	 * @since 5.4.2
+	 *
+	 * @return \WP_Screen|null
+	 */
+	public static function get_current_screen() {
+		global $current_screen;
+
+		return $current_screen ?: null;
+	}
+
+
+	/**
+	 * Checks if the current screen matches a specified ID.
+	 *
+	 * This helps avoiding using the get_current_screen() function which is not always available,
+	 * or setting the substitute global $current_screen every time a check needs to be performed.
+	 *
+	 * @since 5.4.2
+	 *
+	 * @param string $id id (or property) to compare
+	 * @param string $prop optional property to compare, defaults to screen id
+	 * @return bool
+	 */
+	public static function is_current_screen( $id, $prop = 'id' ) {
+		global $current_screen;
+
+		return isset( $current_screen->$prop ) && $id === $current_screen->$prop;
+	}
+
+
+	/**
+	 * Convert a 2-character country code into its 3-character equivalent, or
+	 * vice-versa, e.g.
+	 *
+	 * 1) given USA, returns US
+	 * 2) given US, returns USA
+	 *
+	 * @since 4.2.0
+	 * @deprecated 5.4.3
+	 *
+	 * @param string $code ISO-3166-alpha-2 or ISO-3166-alpha-3 country code
+	 * @return string country code
+	 */
+	public static function convert_country_code( $code ) {
+
+		wc_deprecated_function( __METHOD__, '5.4.3', Country_Helper::class . '::convert_alpha_country_code()' );
+
+		return Country_Helper::convert_alpha_country_code( $code );
+	}
+
+
+	/**
+	 * Displays a notice if the provided hook has not yet run.
+	 *
+	 * @since 5.2.0
+	 *
+	 * @param string $hook action hook to check
+	 * @param string $method method/function name
+	 * @param string $version version the notice was added
+	 */
+	public static function maybe_doing_it_early( $hook, $method, $version ) {
+
+		if ( ! did_action( $hook ) ) {
+			wc_doing_it_wrong( $method, "This should only be called after '{$hook}'", $version );
+		}
+	}
+
+
+	/**
+	 * Triggers a PHP error.
+	 *
+	 * This wrapper method ensures AJAX isn't broken in the process.
+	 *
+	 * @since 4.6.0
+	 * @param string $message the error message
+	 * @param int $type Optional. The error type. Defaults to E_USER_NOTICE
+	 */
+	public static function trigger_error( $message, $type = E_USER_NOTICE ) {
+
+		if ( is_callable( 'is_ajax' ) && is_ajax() ) {
+
+			switch ( $type ) {
+
+				case E_USER_NOTICE:
+					$prefix = 'Notice: ';
+				break;
+
+				case E_USER_WARNING:
+					$prefix = 'Warning: ';
+				break;
+
+				default:
+					$prefix = '';
+			}
+
+			error_log( $prefix . $message );
+
+		} else {
+
+			trigger_error( $message, $type );
+		}
+	}
+
+
+}
+
+
+endif;

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Hook_Deprecator' ) ) :
 
+
 /**
  * SkyVerge Hook Deprecator Class
  *
@@ -195,4 +196,4 @@ class SV_WC_Hook_Deprecator {
 }
 
 
-endif; // class exists check
+endif;

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Hook_Deprecator' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Hook_Deprecator' ) ) :
 
 /**
  * SkyVerge Hook Deprecator Class

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -446,4 +446,9 @@ class SV_WC_Plugin_Compatibility {
 }
 
 
+// Allow calling methods of this class with a generic alias where using namespaces isn't safe, such as template files.
+// NOTE: Use with caution!
+class_alias( SV_WC_Plugin_Compatibility::class, 'SV_Plugin_Compatibility' );
+
+
 endif;

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -446,9 +446,4 @@ class SV_WC_Plugin_Compatibility {
 }
 
 
-// Allow calling methods of this class with a generic alias where using namespaces isn't safe, such as template files.
-// NOTE: Use with caution!
-class_alias( SV_WC_Plugin_Compatibility::class, 'SV_Plugin_Compatibility' );
-
-
 endif;

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -63,7 +63,7 @@ class SV_WC_Plugin_Compatibility {
 
 		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_is_paid_statuses()' );
 
-		return wc_get_is_paid_statuses();
+		return (array) wc_get_is_paid_statuses();
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -197,7 +197,7 @@ class SV_WC_Plugin_Compatibility {
 		$wc_version = self::get_wc_version();
 
 		// accounts for semver cases like 3.0 being equal to 3.0.0
-		return $wc_version === $version || version_compare( $wc_version, $version, '=' );
+		return $wc_version === $version || ( $wc_version && version_compare( $wc_version, $version, '=' ) );
 	}
 
 
@@ -473,7 +473,7 @@ class SV_WC_Plugin_Compatibility {
 		$subscriptions_version = self::get_wc_subscriptions_version();
 
 		// accounts for semver cases like 2.2 being equal to 2.2.0
-		return $version === $subscriptions_version || version_compare( $version, $subscriptions_version, '=' );
+		return $version === $subscriptions_version || ( $subscriptions_version && version_compare( $version, $subscriptions_version, '=' ) );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin_Compatibility' ) ) :
 
+
 /**
  * WooCommerce Compatibility Utility Class
  *
@@ -54,25 +55,23 @@ class SV_WC_Plugin_Compatibility {
 	 * Gets the statuses that are considered "paid".
 	 *
 	 * @since 5.1.0
+	 * @deprecated 5.5.0
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function wc_get_is_paid_statuses() {
 
-		if ( self::is_wc_version_gte_3_0() ) {
-			return wc_get_is_paid_statuses();
-		} else {
-			return (array) apply_filters( 'woocommerce_order_is_paid_statuses', array( 'processing', 'completed' ) );
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_is_paid_statuses()' );
+
+		return wc_get_is_paid_statuses();
 	}
 
 
 	/**
 	 * Logs a doing_it_wrong message.
 	 *
-	 * Backports wc_doing_it_wrong() to WC 2.6.
-	 *
 	 * @since 5.0.1
+	 * @deprecated 5.5.0
 	 *
 	 * @param string $function function used
 	 * @param string $message message to log
@@ -80,33 +79,17 @@ class SV_WC_Plugin_Compatibility {
 	 */
 	public static function wc_doing_it_wrong( $function, $message, $version ) {
 
-		if ( self::is_wc_version_gte( '3.0' ) ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_doing_it_wrong()' );
 
-			wc_doing_it_wrong( $function, $message, $version );
-
-		} else {
-
-			$message .= ' Backtrace: ' . wp_debug_backtrace_summary();
-
-			if ( is_ajax() ) {
-
-				do_action( 'doing_it_wrong_run', $function, $message, $version );
-				error_log( "{$function} was called incorrectly. {$message}. This message was added in version {$version}." );
-
-			} else {
-
-				_doing_it_wrong( $function, $message, $version );
-			}
-		}
+		wc_doing_it_wrong( $function, $message, $version );
 	}
 
 
 	/**
 	 * Formats a date for output.
 	 *
-	 * Backports WC 3.0.0's wc_format_datetime() to older versions.
-	 *
-	 * @since  4.6.0
+	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_DateTime|SV_WC_DateTime $date date object
 	 * @param string $format date format
@@ -114,51 +97,27 @@ class SV_WC_Plugin_Compatibility {
 	 */
 	public static function wc_format_datetime( $date, $format = '' ) {
 
-		if ( self::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_format_datetime()' );
 
-			return wc_format_datetime( $date, $format );
-
-		} else {
-
-			if ( ! $format ) {
-				$format = wc_date_format();
-			}
-
-			if ( ! is_a( $date, '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_DateTime' ) ) { // TODO: verify this {CW 2017-07-18}
-				return '';
-			}
-
-			return $date->date_i18n( $format );
-		}
+		return wc_format_datetime( $date, $format );
 	}
 
 
 	/**
 	 * Logs a deprecated function notice.
 	 *
-	 * @since  5.0.0
+	 * @since 5.0.0
+	 * @deprecated 5.5.0
 	 *
-	 * @param  string $function deprecated function name
-	 * @param  string $version deprecated-since version
-	 * @param  string $replacement replacement function name
+	 * @param string $function deprecated function name
+	 * @param string $version deprecated-since version
+	 * @param string $replacement replacement function name
 	 */
 	public static function wc_deprecated_function( $function, $version, $replacement = null ) {
 
-		if ( self::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_deprecated_function()' );
 
-			wc_deprecated_function( $function, $version, $replacement );
-
-		} else {
-
-			if ( is_ajax() ) {
-				do_action( 'deprecated_function_run', $function, $replacement, $version );
-				$log_string  = "The {$function} function is deprecated since version {$version}.";
-				$log_string .= $replacement ? " Replace with {$replacement}." : '';
-				error_log( $log_string );
-			} else {
-				_deprecated_function( $function, $version, $replacement );
-			}
-		}
+		wc_deprecated_function( $function, $version, $replacement );
 	}
 
 
@@ -213,10 +172,11 @@ class SV_WC_Plugin_Compatibility {
 
 
 	/**
-	 * Helper method to get the version of the currently installed WooCommerce
+	 * Gets the version of the currently installed WooCommerce.
 	 *
 	 * @since 3.0.0
-	 * @return string woocommerce version number or null
+	 *
+	 * @return string|null Woocommerce version number or null if undetermined
 	 */
 	public static function get_wc_version() {
 
@@ -228,10 +188,15 @@ class SV_WC_Plugin_Compatibility {
 	 * Determines if the installed version of WooCommerce is 3.0 or greater.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @return bool
 	 */
 	public static function is_wc_version_gte_3_0() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '3.0', '>=' );
+
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::is_wc_version_gte()' );
+
+		return self::is_wc_version_gte( '3.0' );
 	}
 
 
@@ -239,10 +204,15 @@ class SV_WC_Plugin_Compatibility {
 	 * Determines if the installed version of WooCommerce is less than 3.0.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @return bool
 	 */
 	public static function is_wc_version_lt_3_0() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '3.0', '<' );
+
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::is_wc_version_lt()' );
+
+		return self::is_wc_version_lt( '3.0' );
 	}
 
 
@@ -250,10 +220,15 @@ class SV_WC_Plugin_Compatibility {
 	 * Determines if the installed version of WooCommerce is 3.1 or greater.
 	 *
 	 * @since 4.6.5
+	 * @deprecated 5.5.0
+	 *
 	 * @return bool
 	 */
 	public static function is_wc_version_gte_3_1() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '3.1', '>=' );
+
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::is_wc_version_gte()' );
+
+		return self::is_wc_version_gte( '3.1' );
 	}
 
 
@@ -261,16 +236,20 @@ class SV_WC_Plugin_Compatibility {
 	 * Determines if the installed version of WooCommerce is less than 3.1.
 	 *
 	 * @since 4.6.5
+	 * @deprecated 5.5.0
+	 *
 	 * @return bool
 	 */
 	public static function is_wc_version_lt_3_1() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '3.1', '<' );
+
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::is_wc_version_lt()' );
+
+		return self::is_wc_version_lt( '3.1' );
 	}
 
 
 	/**
-	 * Determines if the installed version of WooCommerce meets or exceeds the
-	 * passed version.
+	 * Determines if the installed version of WooCommerce is equal or greater than a given version.
 	 *
 	 * @since 4.7.3
 	 *
@@ -278,13 +257,15 @@ class SV_WC_Plugin_Compatibility {
 	 * @return bool
 	 */
 	public static function is_wc_version_gte( $version ) {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), $version, '>=' );
+
+		$wc_version = self::get_wc_version();
+
+		return $wc_version && version_compare( $wc_version, $version, '>=' );
 	}
 
 
 	/**
-	 * Determines if the installed version of WooCommerce is lower than the
-	 * passed version.
+	 * Determines if the installed version of WooCommerce is lower than a given version.
 	 *
 	 * @since 4.7.3
 	 *
@@ -292,19 +273,26 @@ class SV_WC_Plugin_Compatibility {
 	 * @return bool
 	 */
 	public static function is_wc_version_lt( $version ) {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), $version, '<' );
+
+		$wc_version = self::get_wc_version();
+
+		return $wc_version && version_compare( $wc_version, $version, '<' );
 	}
 
 
 	/**
-	 * Returns true if the installed version of WooCommerce is greater than $version
+	 * Determines if the installed version of WooCommerce is greater than a given version.
 	 *
 	 * @since 2.0.0
+	 *
 	 * @param string $version the version to compare
-	 * @return boolean true if the installed version of WooCommerce is > $version
+	 * @return bool
 	 */
 	public static function is_wc_version_gt( $version ) {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), $version, '>' );
+
+		$wc_version = self::get_wc_version();
+
+		return $wc_version && version_compare( $wc_version, $version, '>' );
 	}
 
 
@@ -319,6 +307,7 @@ class SV_WC_Plugin_Compatibility {
 	 * TODO: Add WP version check when https://core.trac.wordpress.org/ticket/18857 is addressed {BR 2016-12-12}
 	 *
 	 * @since 4.6.0
+	 *
 	 * @param string $slug slug for the screen ID to normalize (minus `woocommerce_page_`)
 	 * @return string normalized screen ID
 	 */
@@ -379,24 +368,74 @@ class SV_WC_Plugin_Compatibility {
 
 
 	/**
-	 * Returns true if the installed version of WooCommerce Subscriptions is
-	 * 2.0.0 or greater
+	 * Determines if the installed version of WooCommerce Subscriptions is 2.0.0 or greater.
 	 *
 	 * @since 4.1.0
-	 * @return boolean
+	 * @deprecated 5.5.0
+	 *
+	 * @return bool
 	 */
 	public static function is_wc_subscriptions_version_gte_2_0() {
 
-		return self::get_wc_subscriptions_version() && version_compare( self::get_wc_subscriptions_version(), '2.0-beta-1', '>=' );
+		wc_deprecated_function( __METHOD__, '5.5.0', __CLASS__ . '::is_wc_subscriptions_version_gte()' );
+
+		return self::is_wc_subscriptions_version_gte( '2.0' );
 	}
 
 
 	/**
-	 * Helper method to get the version of the currently installed WooCommerce
-	 * Subscriptions
+	 * Determines if the installed version of WooCommerce Subscriptions matches or exceeds a given version.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $version version number to compare
+	 * @return bool
+	 */
+	public static function is_wc_subscriptions_version_gte( $version ) {
+
+		$subscriptions_version = self::get_wc_subscriptions_version();
+
+		return $subscriptions_version && version_compare( $subscriptions_version, $version, '>=' );
+	}
+
+	/**
+	 * Determines if the installed version of WooCommerce Subscriptions exceeds a given version.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $version version number to compare
+	 * @return bool
+	 */
+	public static function is_wc_subscriptions_version_gt( $version ) {
+
+		$subscriptions_version = self::get_wc_subscriptions_version();
+
+		return $subscriptions_version && version_compare( $subscriptions_version, $version, '>' );
+	}
+
+
+	/**
+	 * Determines if the installed version of WooCommerce Subscriptions is lower than a given version.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $version version number to compare
+	 * @return bool
+	 */
+	public static function is_wc_subscriptions_version_lt( $version ) {
+
+		$subscriptions_version = self::get_wc_subscriptions_version();
+
+		return $subscriptions_version && version_compare( $subscriptions_version, $version, '<' );
+	}
+
+
+	/**
+	 * Gets the version of the currently installed WooCommerce Subscriptions.
 	 *
 	 * @since 4.1.0
-	 * @return string WooCommerce Subscriptions version number or null if not found.
+	 *
+	 * @return string|null WooCommerce Subscriptions version number or null if not found
 	 */
 	protected static function get_wc_subscriptions_version() {
 
@@ -407,4 +446,4 @@ class SV_WC_Plugin_Compatibility {
 }
 
 
-endif; // Class exists check
+endif;

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin_Compatibility' ) ) :
 
 /**
  * WooCommerce Compatibility Utility Class
@@ -124,7 +124,7 @@ class SV_WC_Plugin_Compatibility {
 				$format = wc_date_format();
 			}
 
-			if ( ! is_a( $date, '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_DateTime' ) ) { // TODO: verify this {CW 2017-07-18}
+			if ( ! is_a( $date, '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_DateTime' ) ) { // TODO: verify this {CW 2017-07-18}
 				return '';
 			}
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -61,7 +61,7 @@ class SV_WC_Plugin_Compatibility {
 	 */
 	public static function wc_get_is_paid_statuses() {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_is_paid_statuses()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '(array) wc_get_is_paid_statuses()' );
 
 		return (array) wc_get_is_paid_statuses();
 	}
@@ -181,6 +181,23 @@ class SV_WC_Plugin_Compatibility {
 	public static function get_wc_version() {
 
 		return defined( 'WC_VERSION' ) && WC_VERSION ? WC_VERSION : null;
+	}
+
+
+	/**
+	 * Determines if the installed WooCommerce version matches a specific version.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $version semver
+	 * @return bool
+	 */
+	public static function is_wc_version( $version ) {
+
+		$wc_version = self::get_wc_version();
+
+		// accounts for semver cases like 3.0 being equal to 3.0.0
+		return $wc_version === $version || version_compare( $wc_version, $version, '=' );
 	}
 
 
@@ -440,6 +457,23 @@ class SV_WC_Plugin_Compatibility {
 	protected static function get_wc_subscriptions_version() {
 
 		return class_exists( 'WC_Subscriptions' ) && ! empty( \WC_Subscriptions::$version ) ? \WC_Subscriptions::$version : null;
+	}
+
+
+	/**
+	 * Determines if the installed WooCommerce Subscriptions version matches a specific version.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $version semver
+	 * @return bool
+	 */
+	protected static function is_wc_subscriptions_version( $version ) {
+
+		$subscriptions_version = self::get_wc_subscriptions_version();
+
+		// accounts for semver cases like 2.2 being equal to 2.2.0
+		return $version === $subscriptions_version || version_compare( $version, $subscriptions_version, '=' );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -331,7 +331,7 @@ class SV_WC_Plugin_Dependencies {
 	 */
 	public function get_missing_php_extensions() {
 
-		$missing_extensions = array();
+		$missing_extensions = [];
 
 		foreach ( $this->get_php_extensions() as $extension ) {
 
@@ -366,7 +366,7 @@ class SV_WC_Plugin_Dependencies {
 	 */
 	public function get_missing_php_functions() {
 
-		$missing_functions = array();
+		$missing_functions = [];
 
 		foreach ( $this->get_php_functions() as $function ) {
 
@@ -401,9 +401,7 @@ class SV_WC_Plugin_Dependencies {
 	 */
 	public function get_incompatible_php_settings() {
 
-		$incompatible_settings = array();
-
-		$dependences = $this->get_php_settings();
+		$incompatible_settings = [];
 
 		if ( function_exists( 'ini_get' ) ) {
 
@@ -415,7 +413,7 @@ class SV_WC_Plugin_Dependencies {
 					continue;
 				}
 
-				if ( is_integer( $expected ) ) {
+				if ( is_int( $expected ) ) {
 
 					// determine if this is a size string, like "10MB"
 					$is_size = ! is_numeric( substr( $actual, -1 ) );
@@ -424,19 +422,19 @@ class SV_WC_Plugin_Dependencies {
 
 					if ( $actual_num < $expected ) {
 
-						$incompatible_settings[ $setting ] = array(
+						$incompatible_settings[ $setting ] = [
 							'expected' => $is_size ? size_format( $expected ) : $expected,
 							'actual'   => $is_size ? size_format( $actual_num ) : $actual,
 							'type'     => 'min',
-						);
+						];
 					}
 
 				} elseif ( $actual !== $expected ) {
 
-					$incompatible_settings[ $setting ] = array(
+					$incompatible_settings[ $setting ] = [
 						'expected' => $expected,
 						'actual'   => $actual,
-					);
+					];
 				}
 			}
 		}

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin_Dependencies' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin_Dependencies' ) ) :
 
 class SV_WC_Plugin_Dependencies {
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -28,6 +28,12 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin_Dependencies' ) ) :
 
+
+/**
+ * Plugin dependencies handler.
+ *
+ * @since 5.2.0
+ */
 class SV_WC_Plugin_Dependencies {
 
 
@@ -46,6 +52,8 @@ class SV_WC_Plugin_Dependencies {
 
 	/**
 	 * Constructs the class.
+	 *
+	 * @since 5.2.0
 	 *
 	 * @param SV_WC_Plugin $plugin plugin instance
 	 * @param array $args {
@@ -262,21 +270,6 @@ class SV_WC_Plugin_Dependencies {
 
 			$this->add_admin_notice( 'sv-wc-deprecated-php-version', $message, 'error' );
 		}
-
-		// display a notice that WC < 3.0 support will soon be dropped
-		if ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.0' ) ) {
-
-			$message = sprintf(
-				/* translators: Placeholders: %1$s - WooCommerce version number, %2$s - <strong>, %3$s - </strong>, %4$s - Plugin name, %5$s - <a> tag, %6$s - </a> tag */
-				__( 'Hey there! We\'ve noticed that your site is running version %1$s of WooCommerce, but %2$sWooCommerce 3.0 or higher will soon be required%3$s by %4$s. We recommend you %5$supdate WooCommerce%6$s to the latest version as soon as possible.', 'woocommerce-plugin-framework' ),
-				esc_html( SV_WC_Plugin_Compatibility::get_wc_version() ),
-				'<strong>', '</strong>',
-				esc_html( $this->get_plugin()->get_plugin_name() ),
-				'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">', '</a>'
-			);
-
-			$this->add_admin_notice( 'sv-wc-deprecated-wc-version', $message, 'warning' );
-		}
 	}
 
 
@@ -470,5 +463,6 @@ class SV_WC_Plugin_Dependencies {
 
 
 }
+
 
 endif;

--- a/woocommerce/class-sv-wc-plugin-exception.php
+++ b/woocommerce/class-sv-wc-plugin-exception.php
@@ -28,9 +28,11 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin_Exception' ) ) :
 
-	/**
-	 * Plugin Framework Exception - generic Exception
-	 */
-	class SV_WC_Plugin_Exception extends \Exception { }
 
-endif;  // class exists check
+/**
+ * Plugin Framework Exception - generic Exception
+ */
+class SV_WC_Plugin_Exception extends \Exception { }
+
+
+endif;

--- a/woocommerce/class-sv-wc-plugin-exception.php
+++ b/woocommerce/class-sv-wc-plugin-exception.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin_Exception' ) ) :
 
 	/**
 	 * Plugin Framework Exception - generic Exception

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -37,7 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Pl
  * plugin.  This class handles all the "non-feature" support tasks such
  * as verifying dependencies are met, loading the text domain, etc.
  *
- * @version 5.4.3
+ * @version 5.5.0-dev
  */
 abstract class SV_WC_Plugin {
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Plugin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin' ) ) :
 
 /**
  * # WooCommerce Plugin Framework

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Plugin' ) ) :
 
+
 /**
  * # WooCommerce Plugin Framework
  *
@@ -271,7 +272,7 @@ abstract class SV_WC_Plugin {
 		// initialize the plugin admin
 		add_action( 'admin_init', array( $this, 'init_admin' ), 0 );
 
-		// hook for translations seperately to ensure they're loaded
+		// hook for translations separately to ensure they're loaded
 		add_action( 'init', array( $this, 'load_translations' ) );
 
 		// add the admin notices
@@ -285,11 +286,7 @@ abstract class SV_WC_Plugin {
 		$this->add_api_request_logging();
 
 		// add any PHP incompatibilities to the system status report
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-			add_filter( 'woocommerce_system_status_environment_rows', array( $this, 'add_system_status_php_information' ) );
-		} else {
-			add_filter( 'woocommerce_debug_posting', array( $this, 'add_system_status_php_information' ) );
-		}
+		add_filter( 'woocommerce_system_status_environment_rows', array( $this, 'add_system_status_php_information' ) );
 	}
 
 
@@ -1172,7 +1169,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function do_install() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_lifecycle_handler() ) . '::init()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_lifecycle_handler() ) . '::init()' );
 
 		$this->get_lifecycle_handler()->init();
 	}
@@ -1188,7 +1185,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function install_default_settings( array $settings ) {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_lifecycle_handler() ) . '::install_default_settings()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_lifecycle_handler() ) . '::install_default_settings()' );
 
 		$this->get_lifecycle_handler()->install_default_settings( $settings );
 	}
@@ -1203,7 +1200,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function activate() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
+		wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
 
 
@@ -1215,7 +1212,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function deactivate() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
+		wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
 
 
@@ -1229,7 +1226,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function get_missing_extension_dependencies() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_missing_php_extensions()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_missing_php_extensions()' );
 
 		return $this->get_dependency_handler()->get_missing_php_extensions();
 	}
@@ -1245,7 +1242,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function get_missing_function_dependencies() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_missing_php_functions()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_missing_php_functions()' );
 
 		return $this->get_dependency_handler()->get_missing_php_functions();
 	}
@@ -1261,7 +1258,7 @@ abstract class SV_WC_Plugin {
 	 */
 	public function get_incompatible_php_settings() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_incompatible_php_settings()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_incompatible_php_settings()' );
 
 		return $this->get_dependency_handler()->get_incompatible_php_settings();
 	}
@@ -1277,7 +1274,7 @@ abstract class SV_WC_Plugin {
 	 */
 	protected function get_dependencies() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
+		wc_deprecated_function( __METHOD__, '5.2.0' );
 
 		return array();
 	}
@@ -1293,7 +1290,7 @@ abstract class SV_WC_Plugin {
 	 */
 	protected function get_extension_dependencies() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_php_extensions()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_php_extensions()' );
 
 		return $this->get_dependency_handler()->get_php_extensions();
 	}
@@ -1309,7 +1306,7 @@ abstract class SV_WC_Plugin {
 	 */
 	protected function get_function_dependencies() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_php_functions()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_php_functions()' );
 
 		return $this->get_dependency_handler()->get_php_functions();
 	}
@@ -1325,7 +1322,7 @@ abstract class SV_WC_Plugin {
 	 */
 	protected function get_php_settings_dependencies() {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_php_settings()' );
+		wc_deprecated_function( __METHOD__, '5.2.0', get_class( $this->get_dependency_handler() ) . '::get_php_settings()' );
 
 		return $this->get_dependency_handler()->get_php_settings();
 	}
@@ -1339,12 +1336,13 @@ abstract class SV_WC_Plugin {
 	 *
 	 * @param array $dependencies the environment dependencies
 	 */
-	protected function set_dependencies( $dependencies = array() ) {
+	protected function set_dependencies( $dependencies = [] ) {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.2.0' );
+		wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
 
 
 }
 
-endif; // Class exists check
+
+endif;

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -42,7 +42,7 @@ abstract class SV_WC_Plugin {
 
 
 	/** Plugin Framework Version */
-	const VERSION = '5.4.3';
+	const VERSION = '5.5.0-dev';
 
 	/** @var object single instance of plugin */
 	protected static $instance;

--- a/woocommerce/class-sv-wp-admin-message-handler.php
+++ b/woocommerce/class-sv-wp-admin-message-handler.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Admin_Message_Handler' ) ) :
 
+
 /**
  * # WordPress Admin Message Handler Class
  *
@@ -433,4 +434,5 @@ class SV_WP_Admin_Message_Handler {
 
 }
 
-endif; // class exists check
+
+endif;

--- a/woocommerce/class-sv-wp-admin-message-handler.php
+++ b/woocommerce/class-sv-wp-admin-message-handler.php
@@ -22,11 +22,11 @@
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Admin_Message_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Admin_Message_Handler' ) ) :
 
 /**
  * # WordPress Admin Message Handler Class

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Data_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Data_Compatibility' ) ) :
 
 /**
  * WooCommerce data compatibility class.

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -28,50 +28,37 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Data_Compatibility' ) ) :
 
+
 /**
  * WooCommerce data compatibility class.
  *
  * @since 4.6.0
+ * @deprecated 5.5.0
  */
 abstract class SV_WC_Data_Compatibility {
+
+
+	/** @deprecated 5.5.0 backwards compatibility property map */
+	protected static $compat_props = [];
 
 
 	/**
 	 * Gets an object property.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Data $object the data object, likely \WC_Order or \WC_Product
 	 * @param string $prop the property name
 	 * @param string $context if 'view' then the value will be filtered
-	 * @param array $compat_props Compatibility properties.
+	 * @param array $compat_props compatibility properties unused since 5.5.0
 	 * @return mixed
 	 */
-	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = array() ) {
+	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = [] ) {
 
-		$value = '';
+		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data methods' );
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-
-			if ( is_callable( array( $object, "get_{$prop}" ) ) ) {
- 				$value = $object->{"get_{$prop}"}( $context );
- 			}
-
-		} else {
-
-			// backport the property name
-			if ( isset( $compat_props[ $prop ] ) ) {
-				$prop = $compat_props[ $prop ];
-			}
-
-			// if this is the 'view' context and there is an accessor method, use it
-			if ( is_callable( array( $object, "get_{$prop}" ) ) && 'view' === $context ) {
-				$value = $object->{"get_{$prop}"}();
-			} else {
-				$value = $object->$prop;
-			}
-		}
-
-		return $value;
+		return $object->{"get_{$prop}"}( $context );
 	}
 
 
@@ -81,30 +68,18 @@ abstract class SV_WC_Data_Compatibility {
 	 * Note that this does not save any data to the database.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Data $object the data object, likely \WC_Order or \WC_Product
 	 * @param array $props the new properties as $key => $value
-	 * @param array $compat_props Compatibility properties.
-	 * @return \WC_Data
+	 * @param array $compat_props compatibility properties, unused since 5.5.0
+	 * @return bool|\WP_Error
 	 */
-	public static function set_props( $object, $props, $compat_props = array() ) {
+	public static function set_props( $object, $props, $compat_props = [] ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::set_props()' );
 
-			$object->set_props( $props );
-
-		} else {
-
-			foreach ( $props as $prop => $value ) {
-
-				if ( isset( $compat_props[ $prop ] ) ) {
-					$prop = $compat_props[ $prop ];
-				}
-
-				$object->$prop = $value;
-			}
-		}
-
-		return $object;
+		return $object->set_props( $props );
 	}
 
 
@@ -112,6 +87,8 @@ abstract class SV_WC_Data_Compatibility {
 	 * Gets an object's stored meta value.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Data $object the data object, likely \WC_Order or \WC_Product
 	 * @param string $key the meta key
 	 * @param bool $single whether to get the meta as a single item. Defaults to `true`
@@ -120,18 +97,9 @@ abstract class SV_WC_Data_Compatibility {
 	 */
 	public static function get_meta( $object, $key = '', $single = true, $context = 'edit' ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::get_meta()' );
 
-			$value = $object->get_meta( $key, $single, $context );
-
-		} else {
-
-			$object_id = is_callable( array( $object, 'get_id' ) ) ? $object->get_id() : $object->id;
-
-			$value = get_post_meta( $object_id, $key, $single );
-		}
-
-		return $value;
+		return $object->get_meta( $key, $single, $context );
 	}
 
 
@@ -139,25 +107,19 @@ abstract class SV_WC_Data_Compatibility {
 	 * Stores an object meta value.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Data $object the data object, likely \WC_Order or \WC_Product
 	 * @param string $key the meta key
 	 * @param string $value the meta value
-	 * @param bool $unique Optional. Whether the meta should be unique.
+	 * @param bool $unique optional: whether the meta should be unique
 	 */
 	public static function add_meta_data( $object, $key, $value, $unique = false ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::add_meta_data()' );
 
-			$object->add_meta_data( $key, $value, $unique );
-
-			$object->save_meta_data();
-
-		} else {
-
-			$object_id = is_callable( array( $object, 'get_id' ) ) ? $object->get_id() : $object->id;
-
-			add_post_meta( $object_id, $key, $value, $unique );
-		}
+		$object->add_meta_data( $key, $value, $unique );
+		$object->save_meta_data();
 	}
 
 
@@ -165,25 +127,19 @@ abstract class SV_WC_Data_Compatibility {
 	 * Updates an object's stored meta value.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Data $object the data object, likely \WC_Order or \WC_Product
 	 * @param string $key the meta key
 	 * @param string $value the meta value
-	 * @param int|string $meta_id Optional. The specific meta ID to update
+	 * @param int|string $meta_id optional: the specific meta ID to update
 	 */
 	public static function update_meta_data( $object, $key, $value, $meta_id = '' ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::update_meta_data()' );
 
-			$object->update_meta_data( $key, $value, $meta_id );
-
-			$object->save_meta_data();
-
-		} else {
-
-			$object_id = is_callable( array( $object, 'get_id' ) ) ? $object->get_id() : $object->id;
-
-			update_post_meta( $object_id, $key, $value );
-		}
+		$object->update_meta_data( $key, $value, $meta_id );
+		$object->save_meta_data();
 	}
 
 
@@ -191,27 +147,21 @@ abstract class SV_WC_Data_Compatibility {
 	 * Deletes an object's stored meta value.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Data $object the data object, likely \WC_Order or \WC_Product
 	 * @param string $key the meta key
 	 */
 	public static function delete_meta_data( $object, $key ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::delete_meta_data()' );
 
-			$object->delete_meta_data( $key );
-
-			$object->save_meta_data();
-
-		} else {
-
-			$object_id = is_callable( array( $object, 'get_id' ) ) ? $object->get_id() : $object->id;
-
-			delete_post_meta( $object_id, $key );
-		}
+		$object->delete_meta_data( $key );
+		$object->save_meta_data();
 	}
 
 
 }
 
 
-endif; // Class exists check
+endif;

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -58,7 +58,7 @@ abstract class SV_WC_Data_Compatibility {
 	 */
 	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = [] ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data methods' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Data::get_prop()' );
 
 		return is_callable( [ $object, "get_{$prop}" ] ) ? $object->{"get_{$prop}"}( $context ) : null;
 	}
@@ -79,7 +79,7 @@ abstract class SV_WC_Data_Compatibility {
 	 */
 	public static function set_props( $object, $props, $compat_props = [] ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::set_props()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Data::set_props()' );
 
 		return $object->set_props( $props );
 	}
@@ -99,7 +99,7 @@ abstract class SV_WC_Data_Compatibility {
 	 */
 	public static function get_meta( $object, $key = '', $single = true, $context = 'edit' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::get_meta()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Data::get_meta()' );
 
 		return $object->get_meta( $key, $single, $context );
 	}
@@ -118,7 +118,7 @@ abstract class SV_WC_Data_Compatibility {
 	 */
 	public static function add_meta_data( $object, $key, $value, $unique = false ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::add_meta_data()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Data::add_meta_data()' );
 
 		$object->add_meta_data( $key, $value, $unique );
 		$object->save_meta_data();
@@ -138,7 +138,7 @@ abstract class SV_WC_Data_Compatibility {
 	 */
 	public static function update_meta_data( $object, $key, $value, $meta_id = '' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::update_meta_data()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Data::update_meta_data()' );
 
 		$object->update_meta_data( $key, $value, $meta_id );
 		$object->save_meta_data();
@@ -156,7 +156,7 @@ abstract class SV_WC_Data_Compatibility {
 	 */
 	public static function delete_meta_data( $object, $key ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data::delete_meta_data()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Data::delete_meta_data()' );
 
 		$object->delete_meta_data( $key );
 		$object->save_meta_data();

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -45,6 +45,8 @@ abstract class SV_WC_Data_Compatibility {
 	/**
 	 * Gets an object property.
 	 *
+	 * @see \WC_Data::get_prop()
+	 *
 	 * @since 4.6.0
 	 * @deprecated 5.5.0
 	 *
@@ -52,13 +54,13 @@ abstract class SV_WC_Data_Compatibility {
 	 * @param string $prop the property name
 	 * @param string $context if 'view' then the value will be filtered
 	 * @param array $compat_props compatibility properties unused since 5.5.0
-	 * @return mixed
+	 * @return null|mixed
 	 */
 	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = [] ) {
 
 		wc_deprecated_function( __METHOD__, '5.5.0', '\WC_Data methods' );
 
-		return $object->{"get_{$prop}"}( $context );
+		return is_callable( [ $object, "get_{$prop}" ] ) ? $object->{"get_{$prop}"}( $context ) : null;
 	}
 
 

--- a/woocommerce/compatibility/class-sv-wc-datetime.php
+++ b/woocommerce/compatibility/class-sv-wc-datetime.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_DateTime' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_DateTime' ) ) :
 
 /**
  * Backports the \WC_DateTime class to WooCommerce pre-3.0.0

--- a/woocommerce/compatibility/class-sv-wc-datetime.php
+++ b/woocommerce/compatibility/class-sv-wc-datetime.php
@@ -68,7 +68,7 @@ class SV_WC_DateTime extends \DateTime {
 	 */
 	public function __toString() {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\DateTime::format()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'DateTime::format( DATE_ATOM )' );
 
 		return $this->format( DATE_ATOM );
 	}
@@ -84,7 +84,7 @@ class SV_WC_DateTime extends \DateTime {
 	 */
 	public function getTimestamp() {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\DateTime::getTimestamp()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'DateTime::getTimestamp()' );
 
 		return parent::getTimestamp();
 	}
@@ -100,7 +100,7 @@ class SV_WC_DateTime extends \DateTime {
 	 */
 	public function getOffsetTimestamp() {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', \DateTime::class );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'DateTime::getOffset()' );
 
 		return $this->getTimestamp() + $this->getOffset();
 	}
@@ -117,7 +117,7 @@ class SV_WC_DateTime extends \DateTime {
 	 */
 	public function date( $format ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', 'gmdate() and \\DateTime' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'gmdate()' );
 
 		return gmdate( $format, $this->getOffsetTimestamp() );
 	}
@@ -134,7 +134,7 @@ class SV_WC_DateTime extends \DateTime {
 	 */
 	public function date_i18n( $format = 'Y-m-d' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', 'date_i18n() and \\DateTime' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'date_i18n()' );
 
 		return date_i18n( $format, $this->getOffsetTimestamp() );
 	}

--- a/woocommerce/compatibility/class-sv-wc-datetime.php
+++ b/woocommerce/compatibility/class-sv-wc-datetime.php
@@ -24,27 +24,51 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
+use DateTimeZone;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_DateTime' ) ) :
 
+
 /**
- * Backports the \WC_DateTime class to WooCommerce pre-3.0.0
- *
- * TODO: Remove this when WC 3.x can be required {CW 2017-03-16}
+ * Extends the DateTime object for backwards compatibility.
  *
  * @since 4.6.0
+ * @deprecated 5.5.0
  */
 class SV_WC_DateTime extends \DateTime {
+
+
+	/**
+	 * SV_WC_DateTime constructor.
+	 *
+	 * @since 5.5.0
+	 * @deprecated 5.5.0
+	 *
+	 * @param string $time
+	 * @param \DateTimeZone|null $timezone
+	 * @throws \Exception
+	 */
+	public function __construct( $time = 'now', \DateTimeZone $timezone = null ) {
+
+		wc_deprecated_function( 'SV_WC_DateTime', '5.5.0', \DateTime::class );
+
+		parent::__construct( $time, $timezone );
+	}
 
 
 	/**
 	 * Outputs an ISO 8601 date string in local timezone.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @return string
 	 */
 	public function __toString() {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\DateTime::format()' );
 
 		return $this->format( DATE_ATOM );
 	}
@@ -53,14 +77,16 @@ class SV_WC_DateTime extends \DateTime {
 	/**
 	 * Gets the UTC timestamp.
 	 *
-	 * Missing in PHP 5.2.
-	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @return int
 	 */
 	public function getTimestamp() {
 
-		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\DateTime::getTimestamp()' );
+
+		return parent::getTimestamp();
 	}
 
 
@@ -68,9 +94,13 @@ class SV_WC_DateTime extends \DateTime {
 	 * Gets the timestamp with the WordPress timezone offset added or subtracted.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @return int
 	 */
 	public function getOffsetTimestamp() {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', \DateTime::class );
 
 		return $this->getTimestamp() + $this->getOffset();
 	}
@@ -80,10 +110,14 @@ class SV_WC_DateTime extends \DateTime {
 	 * Gets a date based on the offset timestamp.
 	 *
 	 * @since 4.6.0
-	 * @param  string $format date format
+	 * @deprecated 5.5.0
+	 *
+	 * @param string $format date format
 	 * @return string
 	 */
 	public function date( $format ) {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', 'gmdate() and \\DateTime' );
 
 		return gmdate( $format, $this->getOffsetTimestamp() );
 	}
@@ -93,15 +127,20 @@ class SV_WC_DateTime extends \DateTime {
 	 * Gets a localised date based on offset timestamp.
 	 *
 	 * @since 4.6.0
-	 * @param  string $format date format
+	 * @deprecated 5.5.0
+	 *
+	 * @param string $format date format
 	 * @return string
 	 */
 	public function date_i18n( $format = 'Y-m-d' ) {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', 'date_i18n() and \\DateTime' );
 
 		return date_i18n( $format, $this->getOffsetTimestamp() );
 	}
 
 
 }
+
 
 endif;

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -50,7 +50,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_date_created( \WC_Order $order, $context = 'edit' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_created()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::get_date_created()' );
 
 		return self::get_date_prop( $order, 'created', $context );
 	}
@@ -69,7 +69,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_date_modified( \WC_Order $order, $context = 'edit' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_modified()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::get_date_modified()' );
 
 		return self::get_date_prop( $order, 'modified', $context );
 	}
@@ -88,7 +88,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_date_paid( \WC_Order $order, $context = 'edit' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_paid()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::get_date_paid()' );
 
 		return self::get_date_prop( $order, 'paid', $context );
 	}
@@ -107,7 +107,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_date_completed( \WC_Order $order, $context = 'edit' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_completed()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::get_date_completed()' );
 
 		return self::get_date_prop( $order, 'completed', $context );
 	}
@@ -129,7 +129,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_date_prop( \WC_Order $order, $type, $context = 'edit' ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order date methods' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order' );
 
 		$prop = "date_{$type}";
 		$date = is_callable( [ $order, "get_{$prop}" ] ) ? $order->{"get_{$prop}"}( $context ) : null;
@@ -152,7 +152,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = [] ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order property getter methods' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::get_prop()' );
 
 		return parent::get_prop( $object, $prop, $context, self::$compat_props );
 	}
@@ -192,7 +192,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_coupon( \WC_Order $order, $code = [], $discount = 0, $discount_tax = 0 ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Coupon();
 
@@ -225,7 +225,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_fee( \WC_Order $order, $fee ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Fee();
 
@@ -262,7 +262,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_shipping( \WC_Order $order, $shipping_rate ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Shipping();
 
@@ -304,7 +304,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_tax( \WC_Order $order, $tax_rate_id, $tax_amount = 0, $shipping_tax_amount = 0 ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Tax();
 
@@ -346,7 +346,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function update_coupon( \WC_Order $order, $item, $args ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order_Item_Coupon methods' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order_Item_Coupon' );
 
 		if ( is_numeric( $item ) ) {
 			$item = $order->get_item( $item );
@@ -391,7 +391,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function update_fee( \WC_Order $order, $item, $args ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order_Item_Fee methods' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order_Item_Fee' );
 
 		if ( is_numeric( $item ) ) {
 			$item = $order->get_item( $item );
@@ -452,7 +452,6 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
-	 *
 	 * @return bool
 	 */
 	public static function has_shipping_address( \WC_Order $order ) {
@@ -478,15 +477,23 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_item_formatted_meta_data( $item, $hide_prefix = '_', $include_all = false ) {
 
-		$meta_data = $item->get_formatted_meta_data( $hide_prefix, $include_all );
-		$item_meta = [];
+		if ( $item instanceof \WC_Order_Item && SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.1' ) ) {
 
-		foreach ( $meta_data as $meta ) {
+			$meta_data = $item->get_formatted_meta_data( $hide_prefix, $include_all );
+			$item_meta = [];
 
-			$item_meta[] = [
-				'label' => $meta->display_key,
-				'value' => $meta->value,
-			];
+			foreach ( $meta_data as $meta ) {
+
+				$item_meta[] = array(
+					'label' => $meta->display_key,
+					'value' => $meta->value,
+				);
+			}
+
+		} else {
+
+			$item_meta = new \WC_Order_Item_Meta( $item );
+			$item_meta = $item_meta->get_formatted( $hide_prefix );
 		}
 
 		return $item_meta;

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -276,6 +276,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 
 		foreach ( $shipping_rate->get_meta_data() as $key => $value ) {
 			$item->add_meta_data( $key, $value, true );
+			$item->save_meta_data();
 		}
 
 		$item->save();

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -164,6 +164,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * Note that this does not save any data to the database.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $object the order object
 	 * @param array $props the new properties as $key => $value

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Order_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Order_Compatibility' ) ) :
 
 /**
  * WooCommerce order compatibility class.

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -192,7 +192,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_coupon( \WC_Order $order, $code = [], $discount = 0, $discount_tax = 0 ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_coupon()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Coupon();
 
@@ -225,7 +225,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_fee( \WC_Order $order, $fee ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_fee()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Fee();
 
@@ -262,7 +262,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_shipping( \WC_Order $order, $shipping_rate ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_shipping()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Shipping();
 
@@ -304,7 +304,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_tax( \WC_Order $order, $tax_rate_id, $tax_amount = 0, $shipping_tax_amount = 0 ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_tax()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_item()' );
 
 		$item = new \WC_Order_Item_Tax();
 
@@ -346,7 +346,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function update_coupon( \WC_Order $order, $item, $args ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::update_coupon()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order_Item_Coupon methods' );
 
 		if ( is_numeric( $item ) ) {
 			$item = $order->get_item( $item );
@@ -391,7 +391,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function update_fee( \WC_Order $order, $item, $args ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::update_fee()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order_Item_Fee methods' );
 
 		if ( is_numeric( $item ) ) {
 			$item = $order->get_item( $item );

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Order_Compatibility' ) ) :
 
+
 /**
  * WooCommerce order compatibility class.
  *
@@ -36,26 +37,11 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Or
 class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 
 
-	/** @var array mapped compatibility properties, as `$new_prop => $old_prop` */
-	protected static $compat_props = array(
-		'date_completed' => 'completed_date',
-		'date_paid'      => 'paid_date',
-		'date_modified'  => 'modified_date',
-		'date_created'   => 'order_date',
-		'customer_id'    => 'customer_user',
-		'discount'       => 'cart_discount',
-		'discount_tax'   => 'cart_discount_tax',
-		'shipping_total' => 'total_shipping',
-		'type'           => 'order_type',
-		'currency'       => 'order_currency',
-		'version'        => 'order_version',
-	);
-
-
 	/**
 	 * Gets an order's created date.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 * @param string $context if 'view' then the value will be filtered
@@ -63,6 +49,8 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @return \WC_DateTime|null
 	 */
 	public static function get_date_created( \WC_Order $order, $context = 'edit' ) {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_created()' );
 
 		return self::get_date_prop( $order, 'created', $context );
 	}
@@ -72,6 +60,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * Gets an order's last modified date.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 * @param string $context if 'view' then the value will be filtered
@@ -79,6 +68,8 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @return \WC_DateTime|null
 	 */
 	public static function get_date_modified( \WC_Order $order, $context = 'edit' ) {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_modified()' );
 
 		return self::get_date_prop( $order, 'modified', $context );
 	}
@@ -88,6 +79,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * Gets an order's paid date.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 * @param string $context if 'view' then the value will be filtered
@@ -95,6 +87,8 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @return \WC_DateTime|null
 	 */
 	public static function get_date_paid( \WC_Order $order, $context = 'edit' ) {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_paid()' );
 
 		return self::get_date_prop( $order, 'paid', $context );
 	}
@@ -104,6 +98,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * Gets an order's completed date.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 * @param string $context if 'view' then the value will be filtered
@@ -111,6 +106,8 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @return \WC_DateTime|null
 	 */
 	public static function get_date_completed( \WC_Order $order, $context = 'edit' ) {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::get_date_completed()' );
 
 		return self::get_date_prop( $order, 'completed', $context );
 	}
@@ -122,6 +119,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * This should only be used to retrieve WC core date properties.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 * @param string $type type of date to get
@@ -131,33 +129,10 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_date_prop( \WC_Order $order, $type, $context = 'edit' ) {
 
-		$date = null;
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order date methods' );
+
 		$prop = "date_{$type}";
-
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-
-			$date = is_callable( array( $order, "get_{$prop}" ) ) ? $order->{"get_{$prop}"}( $context ) : null;
-
-		} else {
-
-			// backport the property name for WC < 3.0
-			if ( isset( self::$compat_props[ $prop ] ) ) {
-				$prop = self::$compat_props[ $prop ];
-			}
-
-			if ( $date = $order->$prop ) {
-
-				try {
-
-					$date = new SV_WC_DateTime( $date, new \DateTimeZone( wc_timezone_string() ) );
-					$date->setTimezone( new \DateTimeZone( wc_timezone_string() ) );
-
-				} catch ( \Exception $e ) {
-
-					$date = null;
-				}
-			}
-		}
+		$date = is_callable( [ $order, "get_{$prop}" ] ) ? $order->{"get_{$prop}"}( $context ) : null;
 
 		return $date;
 	}
@@ -167,27 +142,17 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * Gets an order property.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Order $object the order object
 	 * @param string $prop the property name
 	 * @param string $context if 'view' then the value will be filtered
+	 * @param array $compat_props compatibility arguments, unused since 5.5.0
 	 * @return mixed
 	 */
-	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = array() ) {
+	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = [] ) {
 
-		// backport a few specific properties to pre-3.0
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt_3_0() ) {
-
-			// convert the shipping_total prop for the edit context
-			if ( 'shipping_total' === $prop && 'view' !== $context ) {
-
-				$prop = 'order_shipping';
-
-			// get the post_parent and bail early
-			} elseif ( 'parent_id' === $prop ) {
-
-				return $object->post->post_parent;
-			}
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order property getter methods' );
 
 		return parent::get_prop( $object, $prop, $context, self::$compat_props );
 	}
@@ -199,94 +164,97 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * Note that this does not save any data to the database.
 	 *
 	 * @since 4.6.0
+	 *
 	 * @param \WC_Order $object the order object
 	 * @param array $props the new properties as $key => $value
-	 * @return \WC_Data|\WC_Order
+	 * @param array $compat_props compatibility arguments, unused since 5.5.0
+	 * @return bool|\WP_Error
 	 */
-	public static function set_props( $object, $props, $compat_props = array() ) {
+	public static function set_props( $object, $props, $compat_props = [] ) {
 
 		return parent::set_props( $object, $props, self::$compat_props );
 	}
 
 
 	/**
+	 * Adds a coupon to an order item.
+	 *
 	 * Order item CRUD compatibility method to add a coupon to an order.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Order $order the order object
 	 * @param array $code the coupon code
 	 * @param int $discount the discount amount.
 	 * @param int $discount_tax the discount tax amount.
 	 * @return int the order item ID
 	 */
-	public static function add_coupon( \WC_Order $order, $code = array(), $discount = 0, $discount_tax = 0 ) {
+	public static function add_coupon( \WC_Order $order, $code = [], $discount = 0, $discount_tax = 0 ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_coupon()' );
 
-			$item = new \WC_Order_Item_Coupon();
+		$item = new \WC_Order_Item_Coupon();
 
-			$item->set_props( array(
-				'code'         => $code,
-				'discount'     => $discount,
-				'discount_tax' => $discount_tax,
-				'order_id'     => $order->get_id(),
-			) );
+		$item->set_props( [
+			'code'         => $code,
+			'discount'     => $discount,
+			'discount_tax' => $discount_tax,
+			'order_id'     => $order->get_id(),
+		] );
 
-			$item->save();
+		$item->save();
 
-			$order->add_item( $item );
+		$order->add_item( $item );
 
-			return $item->get_id();
-
-		} else {
-
-			return $order->add_coupon( $code, $discount, $discount_tax );
-		}
+		return $item->get_id();
 	}
 
 
 	/**
+	 * Adds a fee to an order.
+	 *
 	 * Order item CRUD compatibility method to add a fee to an order.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Order $order the order object
 	 * @param object $fee the fee to add
 	 * @return int the order item ID
 	 */
 	public static function add_fee( \WC_Order $order, $fee ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_fee()' );
 
-			$item = new \WC_Order_Item_Fee();
+		$item = new \WC_Order_Item_Fee();
 
-			$item->set_props( array(
-				'name'      => $fee->name,
-				'tax_class' => $fee->taxable ? $fee->tax_class : 0,
-				'total'     => $fee->amount,
-				'total_tax' => $fee->tax,
-				'taxes'     => array(
-					'total' => $fee->tax_data,
-				),
-				'order_id'  => $order->get_id(),
-			) );
+		$item->set_props( [
+			'name'      => $fee->name,
+			'tax_class' => $fee->taxable ? $fee->tax_class : 0,
+			'total'     => $fee->amount,
+			'total_tax' => $fee->tax,
+			'taxes'     => [
+				'total' => $fee->tax_data,
+			],
+			'order_id'  => $order->get_id(),
+		] );
 
-			$item->save();
+		$item->save();
 
-			$order->add_item( $item );
+		$order->add_item( $item );
 
-			return $item->get_id();
-
-		} else {
-
-			return $order->add_fee( $fee );
-		}
+		return $item->get_id();
 	}
 
 
 	/**
+	 * Adds shipping line to order.
+	 *
 	 * Order item CRUD compatibility method to add a shipping line to an order.
 	 *
 	 * @since 4.7.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 * @param \WC_Shipping_Rate $shipping_rate shipping rate to add
@@ -294,77 +262,76 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function add_shipping( \WC_Order $order, $shipping_rate ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_shipping()' );
 
-			$item = new \WC_Order_Item_Shipping();
+		$item = new \WC_Order_Item_Shipping();
 
-			$item->set_props( array(
-				'method_title' => $shipping_rate->label,
-				'method_id'    => $shipping_rate->id,
-				'total'        => wc_format_decimal( $shipping_rate->cost ),
-				'taxes'        => $shipping_rate->taxes,
-				'order_id'     => $order->get_id(),
-			) );
+		$item->set_props( [
+			'method_title' => $shipping_rate->label,
+			'method_id'    => $shipping_rate->id,
+			'total'        => wc_format_decimal( $shipping_rate->cost ),
+			'taxes'        => $shipping_rate->taxes,
+			'order_id'     => $order->get_id(),
+		] );
 
-			foreach ( $shipping_rate->get_meta_data() as $key => $value ) {
-				$item->add_meta_data( $key, $value, true );
-			}
-
-			$item->save();
-
-			$order->add_item( $item );
-
-			return $item->get_id();
-
-		} else {
-
-			return $order->add_shipping( $shipping_rate );
+		foreach ( $shipping_rate->get_meta_data() as $key => $value ) {
+			$item->add_meta_data( $key, $value, true );
 		}
+
+		$item->save();
+
+		$order->add_item( $item );
+
+		return $item->get_id();
 	}
 
 
 	/**
+	 * Adds tax line to an order.
+	 *
 	 * Order item CRUD compatibility method to add a tax line to an order.
 	 *
 	 * @since 4.7.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 * @param int $tax_rate_id tax rate ID
-	 * @param float $tax_amount cart tax amount
-	 * @param float $shipping_tax_amount shipping tax amount
+	 * @param int|float $tax_amount cart tax amount
+	 * @param int|float $shipping_tax_amount shipping tax amount
 	 * @return int order item ID
+	 * @throws \WC_Data_Exception
+	 *
 	 */
 	public static function add_tax( \WC_Order $order, $tax_rate_id, $tax_amount = 0, $shipping_tax_amount = 0 ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::add_tax()' );
 
-			$item = new \WC_Order_Item_Tax();
+		$item = new \WC_Order_Item_Tax();
 
-			$item->set_props( array(
-				'rate_id'            => $tax_rate_id,
-				'tax_total'          => $tax_amount,
-				'shipping_tax_total' => $shipping_tax_amount,
-			) );
+		$item->set_props( [
+			'rate_id'            => $tax_rate_id,
+			'tax_total'          => $tax_amount,
+			'shipping_tax_total' => $shipping_tax_amount,
+		] );
 
-			$item->set_rate( $tax_rate_id );
-			$item->set_order_id( $order->get_id() );
-			$item->save();
+		$item->set_rate( $tax_rate_id );
+		$item->set_order_id( $order->get_id() );
+		$item->save();
 
-			$order->add_item( $item );
+		$order->add_item( $item );
 
-			return $item->get_id();
-
-		} else {
-
-			return $order->add_tax( $tax_rate_id, $tax_amount, $shipping_tax_amount );
-		}
+		return $item->get_id();
 	}
 
 
 	/**
+	 * Updates an order coupon.
+	 *
 	 * Order item CRUD compatibility method to update an order coupon.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Order $order the order object
 	 * @param int|\WC_Order_Item $item the order item ID
 	 * @param array $args {
@@ -375,48 +342,40 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 *     @type float  $discount_tax the coupon discount tax amount
 	 * }
 	 * @return int|bool the order item ID or false on failure
+	 * @throws \WC_Data_Exception
 	 */
 	public static function update_coupon( \WC_Order $order, $item, $args ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::update_coupon()' );
 
-			if ( is_numeric( $item ) ) {
-				$item = $order->get_item( $item );
-			}
-
-			if ( ! is_object( $item ) || ! $item->is_type( 'coupon' ) ) {
-				return false;
-			}
-
-			if ( ! $order->get_id() ) {
-				$order->save();
-			}
-
-			$item->set_order_id( $order->get_id() );
-			$item->set_props( $args );
-			$item->save();
-
-			return $item->get_id();
-
-		} else {
-
-			// convert WC 3.0+ args for backwards compatibility
-			if ( isset( $args['discount'] ) ) {
-				$args['discount_amount'] = $args['discount'];
-			}
-			if ( isset( $args['discount_tax'] ) ) {
-				$args['discount_amount_tax'] = $args['discount_tax'];
-			}
-
-			return $order->update_coupon( $item, $args );
+		if ( is_numeric( $item ) ) {
+			$item = $order->get_item( $item );
 		}
+
+		if ( ! is_object( $item ) || ! $item->is_type( 'coupon' ) ) {
+			return false;
+		}
+
+		if ( ! $order->get_id() ) {
+			$order->save();
+		}
+
+		$item->set_order_id( $order->get_id() );
+		$item->set_props( $args );
+		$item->save();
+
+		return $item->get_id();
 	}
 
 
 	/**
+	 * Updates an order fee.
+	 *
 	 * Order item CRUD compatibility method to update an order fee.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Order $order the order object
 	 * @param int|\WC_Order_Item $item the order item ID
 	 * @param array $args {
@@ -428,79 +387,69 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 *     @type float  $line_tax   the fee tax amount
 	 * }
 	 * @return int|bool the order item ID or false on failure
+	 * @throws \WC_Data_Exception
 	 */
 	public static function update_fee( \WC_Order $order, $item, $args ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Order::update_fee()' );
 
-			if ( is_numeric( $item ) ) {
-				$item = $order->get_item( $item );
-			}
-
-			if ( ! is_object( $item ) || ! $item->is_type( 'fee' ) ) {
-				return false;
-			}
-
-			if ( ! $order->get_id() ) {
-				$order->save();
-			}
-
-			$item->set_order_id( $order->get_id() );
-			$item->set_props( $args );
-			$item->save();
-
-			return $item->get_id();
-
-		} else {
-
-			return $order->update_fee( $item, $args );
+		if ( is_numeric( $item ) ) {
+			$item = $order->get_item( $item );
 		}
+
+		if ( ! is_object( $item ) || ! $item->is_type( 'fee' ) ) {
+			return false;
+		}
+
+		if ( ! $order->get_id() ) {
+			$order->save();
+		}
+
+		$item->set_order_id( $order->get_id() );
+		$item->set_props( $args );
+		$item->save();
+
+		return $item->get_id();
 	}
 
 
 	/**
-	 * Backports wc_reduce_stock_levels() to pre-3.0.
+	 * Reduces stock levels for products in order.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Order $order the order object
 	 */
 	public static function reduce_stock_levels( \WC_Order $order ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-			wc_reduce_stock_levels( $order->get_id() );
-		} else {
-			$order->reduce_order_stock();
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_reduce_stock_levels()' );
+
+		wc_reduce_stock_levels( $order->get_id() );
 	}
 
 
 	/**
-	 * Backports wc_update_total_sales_counts() to pre-3.0.
+	 * Updates total product sales count for a given order.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param \WC_Order $order the order object
 	 */
 	public static function update_total_sales_counts( \WC_Order $order ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-			wc_update_total_sales_counts( $order->get_id() );
-		} else {
-			$order->record_product_sales();
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_update_total_sales_counts()' );
+
+		wc_update_total_sales_counts( $order->get_id() );
 	}
 
 
 	/**
 	 * Determines if an order has an available shipping address.
 	 *
-	 * WooCommerce 3.0+ no longer fills the shipping address with the billing if
-	 * a shipping address was never set by the customer at checkout, as is the
-	 * case with virtual orders. This method is helpful for gateways that may
-	 * reject such transactions with blank shipping information.
-	 *
-	 * TODO: Remove when WC 3.0.4 can be required {CW 2017-04-17}
-	 *
 	 * @since 4.6.1
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Order $order order object
 	 *
@@ -508,7 +457,9 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function has_shipping_address( \WC_Order $order ) {
 
-		return self::get_prop( $order, 'shipping_address_1' ) || self::get_prop( $order, 'shipping_address_2' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Order::has_shipping_address()' );
+
+		return $order->has_shipping_address();
 	}
 
 
@@ -517,33 +468,25 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 *
 	 * @since 4.6.5
 	 *
-	 * @param \WC_Order_Item|array $item order item object or array
-	 * @param string $hideprefix prefix for meta that is considered hidden
+	 * @param \WC_Order_Item $item order item object
+	 * @param string $hide_prefix prefix for meta that is considered hidden
 	 * @param bool $include_all whether to include all meta (attributes, etc...), or just custom fields
 	 * @return array $item_meta {
 	 *     @type string $label meta field label
-	 *     @type mixed  $value meta value
+	 *     @type mixed $value meta value
  	 * }
 	 */
-	public static function get_item_formatted_meta_data( $item, $hideprefix = '_', $include_all = false ) {
+	public static function get_item_formatted_meta_data( $item, $hide_prefix = '_', $include_all = false ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_1() && $item instanceof \WC_Order_Item ) {
+		$meta_data = $item->get_formatted_meta_data( $hide_prefix, $include_all );
+		$item_meta = [];
 
-			$meta_data = $item->get_formatted_meta_data( $hideprefix, $include_all );
-			$item_meta = array();
+		foreach ( $meta_data as $meta ) {
 
-			foreach ( $meta_data as $meta ) {
-
-				$item_meta[] = array(
-					'label' => $meta->display_key,
-					'value' => $meta->value,
-				);
-			}
-
-		} else {
-
-			$item_meta = new \WC_Order_Item_Meta( $item );
-			$item_meta = $item_meta->get_formatted( $hideprefix );
+			$item_meta[] = [
+				'label' => $meta->display_key,
+				'value' => $meta->value,
+			];
 		}
 
 		return $item_meta;
@@ -560,15 +503,17 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_edit_order_url( \WC_Order $order ) {
 
-		if ( self::is_wc_version_gte( '3.3' ) ) {
-			return $order->get_edit_order_url();
+		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.3' ) ) {
+			$order_url = $order->get_edit_order_url();
 		} else {
-			return apply_filters( 'woocommerce_get_edit_order_url', get_admin_url( null, 'post.php?post=' . self::get_prop( $order, 'id' ) . '&action=edit' ), $order );
+			$order_url = apply_filters( 'woocommerce_get_edit_order_url', get_admin_url( null, 'post.php?post=' . self::get_prop( $order, 'id' ) . '&action=edit' ), $order );
 		}
+
+		return $order_url;
 	}
 
 
 }
 
 
-endif; // Class exists check
+endif;

--- a/woocommerce/compatibility/class-sv-wc-product-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-product-compatibility.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Product_Compatibility' ) ) :
 
+
 /**
  * WooCommerce product compatibility class.
  *
@@ -36,33 +37,21 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Pr
 class SV_WC_Product_Compatibility extends SV_WC_Data_Compatibility {
 
 
-	/** @var array mapped compatibility properties, as `$new_prop => $old_prop` */
-	protected static $compat_props = array(
-		'catalog_visibility' => 'visibility',
-		'date_on_sale_from'  => 'sale_price_dates_from',
-		'date_on_sale_to'    => 'sale_price_dates_to',
-		'gallery_image_ids'  => 'product_image_gallery',
-		'cross_sell_ids'     => 'crosssell_ids',
-	);
-
-
 	/**
 	 * Gets a product property.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $object the product object
 	 * @param string $prop the property name
 	 * @param string $context if 'view' then the value will be filtered
+	 * @param array $compat_props compatibility arguments, unused since 5.5.0
 	 * @return mixed
 	 */
-	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = array() ) {
+	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = [] ) {
 
-		// backport 'WC_Product::get_parent_id()' to pre-3.0
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt_3_0() && 'parent_id' === $prop ) {
-			$prop    = 'id';
-			$context = $object->is_type( 'variation' ) ? 'raw' : $context;
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Product property getter methods' );
 
 		return parent::get_prop( $object, $prop, $context, self::$compat_props );
 	}
@@ -74,12 +63,16 @@ class SV_WC_Product_Compatibility extends SV_WC_Data_Compatibility {
 	 * Note that this does not save any data to the database.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $object the product object
 	 * @param array $props the new properties as $key => $value
-	 * @return \WC_Data|\WC_Product
+	 * @param array $compat_props compatibility arguments, unused since 5.5.0
+	 * @return bool|\WP_Error
 	 */
-	public static function set_props( $object, $props, $compat_props = array() ) {
+	public static function set_props( $object, $props, $compat_props = [] ) {
+
+		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Product::set_props()' );
 
 		return parent::set_props( $object, $props, self::$compat_props );
 	}
@@ -89,184 +82,161 @@ class SV_WC_Product_Compatibility extends SV_WC_Data_Compatibility {
 	 * Gets a product's parent product.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $product the product object
 	 * @return \WC_Product|bool
 	 */
 	public static function get_parent( \WC_Product $product ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-			$parent = wc_get_product( $product->get_parent_id() );
-		} else {
-			$parent = $product->is_type( 'variation' ) ? wc_get_product( $product->id ) : false;
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_product( \WC_Product::get_parent_id() )' );
 
-		return $parent;
+		return wc_get_product( $product->get_parent_id() );
 	}
 
 
 	/**
-	 * Backports wc_update_product_stock() to pre-3.0.
+	 * Updates product stock.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param int $amount Optional. The new stock quantity
-	 * @param string $mode Optional. Can be set, add, or subtract
+	 * @param null|int $amount optional: the new stock quantity
+	 * @param string $mode optional: can be set (default), add, or subtract
 	 * @return int
 	 */
 	public static function wc_update_product_stock( \WC_Product $product, $amount = null, $mode = 'set' ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-			return wc_update_product_stock( $product, $amount, $mode );
-		} else {
-			return $product->set_stock( $amount, $mode );
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_update_product_stock()' );
+
+		return wc_update_product_stock( $product, $amount, $mode );
 	}
 
 
 	/**
-	 * Backports wc_get_price_html_from_text() to pre-3.0.
+	 * Gets the product price HTML from text.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $product the product object
 	 * @return string
 	 */
 	public static function wc_get_price_html_from_text( \WC_Product $product ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-			return wc_get_price_html_from_text();
-		} else {
-			return $product->get_price_html_from_text();
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_price_html_from_text()' );
+
+		return wc_get_price_html_from_text();
 	}
 
 
 	/**
-	 * Backports wc_get_price_including_tax() to pre-3.0.
+	 * Gets the product price including tax.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param int $qty Optional. The quantity
-	 * @param string $price Optional. The product price
+	 * @param int $qty optional: the quantity
+	 * @param string $price optional: the product price
 	 * @return string
 	 */
 	public static function wc_get_price_including_tax( \WC_Product $product, $qty = 1, $price = '' ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_price_including_tax()' );
 
-			return wc_get_price_including_tax( $product, array(
-				'qty'   => $qty,
-				'price' => $price,
-			) );
-
-		} else {
-
-			return $product->get_price_including_tax( $qty, $price );
-		}
+		return wc_get_price_including_tax( $product, [
+			'qty'   => $qty,
+			'price' => $price,
+		] );
 	}
 
 
 	/**
-	 * Backports wc_get_price_excluding_tax() to pre-3.0.
+	 * Gets the product price excluding tax.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param int $qty Optional. The quantity
-	 * @param string $price Optional. The product price
+	 * @param int $qty optional: The quantity
+	 * @param string $price optional: the product price
 	 * @return string
 	 */
 	public static function wc_get_price_excluding_tax( \WC_Product $product, $qty = 1, $price = '' ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_price_excluding_tax()' );
 
-			return wc_get_price_excluding_tax( $product, array(
-				'qty'   => $qty,
-				'price' => $price,
-			) );
-
-		} else {
-
-			return $product->get_price_excluding_tax( $qty, $price );
-		}
+		return wc_get_price_excluding_tax( $product, [
+			'qty'   => $qty,
+			'price' => $price,
+		] );
 	}
 
 
 	/**
-	 * Backports wc_get_price_to_display() to pre-3.0.
+	 * Gets the product price to display.
 	 *
 	 * @since 4.6.0
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param string $price Optional. The product price
-	 * @param int $qty Optional. The quantity
+	 * @param string $price optional: the product price
+	 * @param int $qty optional: the quantity
 	 * @return string
 	 */
 	public static function wc_get_price_to_display( \WC_Product $product, $price = '', $qty = 1 ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_price_to_display()' );
 
-			return wc_get_price_to_display( $product, array(
-				'qty'   => $qty,
-				'price' => $price,
-			) );
-
-		} else {
-
-			return $product->get_display_price( $price, $qty );
-		}
+		return wc_get_price_to_display( $product, [
+			'qty'   => $qty,
+			'price' => $price,
+		] );
 	}
 
 
 	/**
-	 * Backports wc_get_product_category_list() to pre-3.0.
+	 * Gets the product category list.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
 	 * @param \WC_Product $product the product object
-	 * @param string $sep Optional. The list separator
-	 * @param string $before Optional. To display before the list
-	 * @param string $after Optional. To display after the list
+	 * @param string $sep optional: the list separator
+	 * @param string $before optional: to display before the list
+	 * @param string $after optional: to display after the list
 	 * @return string
 	 */
 	public static function wc_get_product_category_list( \WC_Product $product, $sep = ', ', $before = '', $after = '' ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_product_category_list()' );
 
-			$id = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
+		$id = $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
 
-			return wc_get_product_category_list( $id, $sep, $before, $after );
-
-		} else {
-
-			return $product->get_categories( $sep, $before, $after );
-		}
+		return wc_get_product_category_list( $id, $sep, $before, $after );
 	}
 
 
 	/**
-	 * Backports wc_get_rating_html() to pre-3.0.
+	 * Formats the product rating HTML.
 	 *
 	 * @since 4.6.0
+	 * @deprecated 5.5.0
 	 *
-	 * @param \WC_Product $product the product object
-	 * @param string $rating Optional. The product rating
+	 * @param \WC_Product $product the product object, unused since 5.5.0
+	 * @param null|string $rating optional: the product rating
 	 * @return string
 	 */
 	public static function wc_get_rating_html( \WC_Product $product, $rating = null ) {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-			return wc_get_rating_html( $rating );
-		} else {
-			return $product->get_rating_html( $rating );
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', 'wc_get_rating_html()' );
+
+		return wc_get_rating_html( $rating );
 	}
 
 
 }
 
 
-endif; // Class exists check
+endif;

--- a/woocommerce/compatibility/class-sv-wc-product-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-product-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Product_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Product_Compatibility' ) ) :
 
 /**
  * WooCommerce product compatibility class.

--- a/woocommerce/compatibility/class-sv-wc-product-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-product-compatibility.php
@@ -51,7 +51,7 @@ class SV_WC_Product_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_prop( $object, $prop, $context = 'edit', $compat_props = [] ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Product property getter methods' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Product::get_prop()' );
 
 		return parent::get_prop( $object, $prop, $context, self::$compat_props );
 	}
@@ -72,7 +72,7 @@ class SV_WC_Product_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function set_props( $object, $props, $compat_props = [] ) {
 
-		wc_deprecated_function( __METHOD__, '5.5.0', '\\WC_Product::set_props()' );
+		wc_deprecated_function( __METHOD__, '5.5.0', 'WC_Product::set_props()' );
 
 		return parent::set_props( $object, $props, self::$compat_props );
 	}

--- a/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
@@ -28,6 +28,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as FrameworkBase;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
 
+
 /**
  * The base hosted payment handler.
  *
@@ -383,5 +384,6 @@ abstract class Abstract_Hosted_Payment_Handler extends Abstract_Payment_Handler 
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as FrameworkBase;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as FrameworkBase;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
 
 /**
  * The base hosted payment handler.

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -28,6 +28,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as FrameworkBase;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
 
+
 /**
  * The base payment handler class.
  *
@@ -300,7 +301,7 @@ abstract class Abstract_Payment_Handler {
 	 * @since 5.4.0
 	 *
 	 * @param \WC_Order $order order object
-	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response API response object
+	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Customer_Response|FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response API response object
 	 */
 	public function mark_order_as_paid( \WC_Order $order, FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
@@ -310,9 +311,11 @@ abstract class Abstract_Payment_Handler {
 		$this->get_gateway()->add_payment_gateway_transaction_data( $order, $response );
 
 		if ( $order->has_status( $this->get_held_order_status( $order, $response ) ) ) {
-			FrameworkBase\SV_WC_Order_Compatibility::reduce_stock_levels( $order ); // reduce stock for held orders, but don't complete payment
+			// reduce stock for held orders, but don't complete payment
+			wc_reduce_stock_levels( $order );
 		} else {
-			$order->payment_complete(); // mark order as having received payment
+			// mark order as having received payment
+			$order->payment_complete();
 		}
 
 		/**
@@ -497,5 +500,6 @@ abstract class Abstract_Payment_Handler {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as FrameworkBase;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as FrameworkBase;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
 
 /**
  * The base payment handler class.

--- a/woocommerce/payment-gateway/Handlers/Capture.php
+++ b/woocommerce/payment-gateway/Handlers/Capture.php
@@ -189,7 +189,7 @@ class Capture {
 				__( '%1$s Capture of %2$s Approved', 'woocommerce-plugin-framework' ),
 				$this->get_gateway()->get_method_title(),
 				wc_price( $order->capture->amount, [
-					'currency' => $order->get_currency( 'edit' )
+					'currency' => $order->get_currency()
 				] )
 			);
 

--- a/woocommerce/payment-gateway/Handlers/Capture.php
+++ b/woocommerce/payment-gateway/Handlers/Capture.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Handlers\\Capture' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Handlers\\Capture' ) ) :
 
 /**
  * The transaction capture handler.

--- a/woocommerce/payment-gateway/Handlers/Capture.php
+++ b/woocommerce/payment-gateway/Handlers/Capture.php
@@ -30,6 +30,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Handlers\\Capture' ) ) :
 
+
 /**
  * The transaction capture handler.
  *
@@ -73,7 +74,7 @@ class Capture {
 	 */
 	public function maybe_capture_paid_order( $order_id, $old_status, $new_status ) {
 
-		$paid_statuses = Framework\SV_WC_Plugin_Compatibility::wc_get_is_paid_statuses();
+		$paid_statuses = (array) wc_get_is_paid_statuses();
 
 		// bail if changing to a non-paid status or from a paid status
 		if ( ! in_array( $new_status, $paid_statuses, true ) || in_array( $old_status, $paid_statuses, true ) ) {
@@ -86,7 +87,7 @@ class Capture {
 			return;
 		}
 
-		$payment_method = Framework\SV_WC_Order_Compatibility::get_prop( $order, 'payment_method' );
+		$payment_method = $order->get_payment_method( 'edit' );
 
 		if ( $payment_method !== $this->get_gateway()->get_id() ) {
 			return;
@@ -147,7 +148,7 @@ class Capture {
 
 				$message = "{$this->get_gateway()->get_method_title()} does not support payment captures";
 
-				Framework\SV_WC_Plugin_Compatibility::wc_doing_it_wrong( __METHOD__, $message, '5.3.0' );
+				wc_doing_it_wrong( __METHOD__, $message, '5.3.0' );
 
 				throw new Framework\SV_WC_Payment_Gateway_Exception( $message, 500 );
 			}
@@ -187,7 +188,9 @@ class Capture {
 				/* translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - transaction amount. Definitions: Capture, as in capture funds from a credit card. */
 				__( '%1$s Capture of %2$s Approved', 'woocommerce-plugin-framework' ),
 				$this->get_gateway()->get_method_title(),
-				wc_price( $order->capture->amount, array( 'currency' => Framework\SV_WC_Order_Compatibility::get_prop( $order, 'currency', 'view' ) ) )
+				wc_price( $order->capture->amount, [
+					'currency' => $order->get_currency( 'edit' )
+				] )
 			);
 
 			// adds the transaction id (if any) to the order note
@@ -347,8 +350,7 @@ class Capture {
 	 */
 	public function has_order_authorization_expired( \WC_Order $order ) {
 
-		$transaction_date = $this->get_gateway()->get_order_meta( Framework\SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'trans_date' );
-
+		$transaction_date = $this->get_gateway()->get_order_meta( $order, 'trans_date' );
 		$transaction_time = strtotime( $transaction_date );
 
 		return $transaction_date && floor( ( time() - $transaction_time ) / 3600 ) > $this->get_gateway()->get_authorization_time_window();
@@ -422,5 +424,6 @@ class Capture {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
+++ b/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
@@ -21,13 +21,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway\Admin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Payment_Gateway\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
 
 /**
  * The payment gateway plugin Setup Wizard class.

--- a/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
+++ b/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
@@ -29,6 +29,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_0 as Framework;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
 
+
 /**
  * The payment gateway plugin Setup Wizard class.
  *
@@ -63,5 +64,6 @@ abstract class Setup_Wizard extends Framework\Admin\Setup_Wizard {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Admin_Order' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Admin_Order' ) ) :
 
 /**
  * Handle the admin order screens.

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Admin_Order' ) ) :
 
+
 /**
  * Handle the admin order screens.
  *
@@ -114,8 +115,8 @@ class SV_WC_Payment_Gateway_Admin_Order {
 
 		wp_localize_script( 'sv-wc-payment-gateway-admin-order', 'sv_wc_payment_gateway_admin_order', array(
 			'ajax_url'       => admin_url( 'admin-ajax.php' ),
-			'gateway_id'     => SV_WC_Order_Compatibility::get_prop( $order, 'payment_method' ),
-			'order_id'       => SV_WC_Order_Compatibility::get_prop( $order, 'id' ),
+			'gateway_id'     => $order->get_payment_method( 'edit' ),
+			'order_id'       => $order->get_id(),
 			'capture_ays'    => __( 'Are you sure you wish to process this capture? The action cannot be undone.', 'woocommerce-plugin-framework' ),
 			'capture_action' => 'wc_' . $this->get_plugin()->get_id() . '_capture_charge',
 			'capture_nonce'  => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_capture_charge' ),
@@ -256,7 +257,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	public function add_capture_button( $order ) {
 
 		// only display the button for core orders
-		if ( ! $order instanceof \WC_Order || 'shop_order' !== get_post_type( SV_WC_Order_Compatibility::get_prop( $order, 'id' ) ) ) {
+		if ( ! $order instanceof \WC_Order || 'shop_order' !== get_post_type( $order->get_id() ) ) {
 			return;
 		}
 
@@ -362,7 +363,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 				throw new SV_WC_Payment_Gateway_Exception( 'Invalid permissions' );
 			}
 
-			if ( SV_WC_Order_Compatibility::get_prop( $order, 'payment_method' ) !== $gateway->get_id() ) {
+			if ( $order->get_payment_method( 'edit' ) !== $gateway->get_id() ) {
 				throw new SV_WC_Payment_Gateway_Exception( 'Invalid payment method' );
 			}
 
@@ -380,15 +381,15 @@ class SV_WC_Payment_Gateway_Admin_Order {
 				throw new SV_WC_Payment_Gateway_Exception( $result['message'] );
 			}
 
-			wp_send_json_success( array(
+			wp_send_json_success( [
 				'message' => html_entity_decode( wp_strip_all_tags( $result['message'] ) ), // ensure any HTML tags are removed and the currency symbol entity is decoded
-			) );
+			] );
 
 		} catch ( SV_WC_Payment_Gateway_Exception $e ) {
 
-			wp_send_json_error( array(
+			wp_send_json_error( [
 				'message' => $e->getMessage(),
-			) );
+			] );
 		}
 	}
 
@@ -404,8 +405,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	protected function get_order_gateway( \WC_Order $order ) {
 
 		$capture_gateway = null;
-
-		$payment_method = SV_WC_Order_Compatibility::get_prop( $order, 'payment_method' );
+		$payment_method  = $order->get_payment_method( 'edit' );
 
 		if ( $this->get_plugin()->has_gateway( $payment_method ) ) {
 
@@ -450,7 +450,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 */
 	protected function maybe_capture_charge( $order, $amount = null ) {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.3.0' );
+		wc_deprecated_function( __METHOD__, '5.3.0' );
 
 		if ( ! is_object( $order ) ) {
 			$order = wc_get_order( $order );
@@ -491,7 +491,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 */
 	public function maybe_capture_paid_order( $order_id, $old_status, $new_status ) {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.3.0' );
+		wc_deprecated_function( __METHOD__, '5.3.0' );
 	}
 
 
@@ -506,18 +506,15 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 */
 	protected function is_order_ready_for_capture( \WC_Order $order ) {
 
-		SV_WC_Plugin_Compatibility::wc_deprecated_function( __METHOD__, '5.3.0' );
+		wc_deprecated_function( __METHOD__, '5.3.0' );
 
 		$gateway = $this->get_order_gateway( $order );
 
-		if ( ! $gateway ) {
-			return false;
-		}
-
-		return $gateway->get_capture_handler()->is_order_ready_for_capture( $order );
+		return $gateway && $gateway->get_capture_handler()->is_order_ready_for_capture( $order );
 	}
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -85,7 +85,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 			// Edit Order screen assets
 			if ( 'post.php' === $hook_suffix ) {
 
-				$order = wc_get_order( SV_WC_Helper::get_request( 'post' ) );
+				$order = wc_get_order( SV_WC_Helper::get_requested_value( 'post' ) );
 
 				if ( ! $order ) {
 					return;
@@ -342,7 +342,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 
 		check_ajax_referer( 'wc_' . $this->get_plugin()->get_id() . '_capture_charge', 'nonce' );
 
-		$gateway_id = SV_WC_Helper::get_request( 'gateway_id' );
+		$gateway_id = SV_WC_Helper::get_requested_value( 'gateway_id' );
 
 		if ( ! $this->get_plugin()->has_gateway( $gateway_id ) ) {
 			die();
@@ -352,7 +352,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 
 		try {
 
-			$order_id = SV_WC_Helper::get_request( 'order_id' );
+			$order_id = SV_WC_Helper::get_requested_value( 'order_id' );
 			$order    = wc_get_order( $order_id );
 
 			if ( ! $order ) {
@@ -369,8 +369,8 @@ class SV_WC_Payment_Gateway_Admin_Order {
 
 			$amount_captured = (float) $gateway->get_order_meta( $order, 'capture_total' );
 
-			if ( SV_WC_Helper::get_request( 'amount' ) ) {
-				$amount = (float) SV_WC_Helper::get_request( 'amount' );
+			if ( $request_amount = SV_WC_Helper::get_requested_value( 'amount' ) ) {
+				$amount = (float) $request_amount;
 			} else {
 				$amount = $order->get_total();
 			}

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 /**
  * The token editor.

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
+
 /**
  * The token editor.
  *
@@ -716,5 +717,6 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -178,7 +178,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 			}
 
 			// Set the default method
-			$data['default'] = $token_id === SV_WC_Helper::get_post( $this->get_input_name() . '_default' );
+			$data['default'] = $token_id === SV_WC_Helper::get_posted_value( $this->get_input_name() . '_default' );
 
 			if ( $data = $this->validate_token_data( $token_id, $data ) ) {
 				$built_tokens[ $token_id ] = $this->build_token( $user_id, $token_id, $data );
@@ -198,7 +198,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 		check_ajax_referer( 'wc_payment_gateway_admin_get_blank_payment_token', 'security' );
 
-		$index = SV_WC_Helper::get_request( 'index' );
+		$index = SV_WC_Helper::get_requested_value( 'index' );
 
 		if ( $index ) {
 
@@ -241,8 +241,8 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 				throw new SV_WC_Payment_Gateway_Exception( 'Invalid nonce' );
 			}
 
-			$user_id  = SV_WC_Helper::get_request( 'user_id' );
-			$token_id = SV_WC_Helper::get_request( 'token_id' );
+			$user_id  = SV_WC_Helper::get_requested_value( 'user_id' );
+			$token_id = SV_WC_Helper::get_requested_value( 'token_id' );
 
 			if ( ! $user_id ) {
 				throw new SV_WC_Payment_Gateway_Exception( 'User ID is missing' );
@@ -278,7 +278,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 				throw new SV_WC_Payment_Gateway_Exception( 'Invalid nonce' );
 			}
 
-			$user_id = SV_WC_Helper::get_request( 'user_id' );
+			$user_id = SV_WC_Helper::get_requested_value( 'user_id' );
 
 			if ( ! $user_id ) {
 				throw new SV_WC_Payment_Gateway_Exception( 'User ID is missing' );

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Admin_User_Handler' ) ) :
 
+
 /**
  * Handle the admin user profile settings.
  *
@@ -35,11 +36,13 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Pa
  */
 class SV_WC_Payment_Gateway_Admin_User_Handler {
 
+
 	/** @var \SV_WC_Payment_Gateway_Plugin the plugin instance **/
 	protected $plugin;
 
 	/** @var array the token editor for each gateway **/
 	protected $token_editors = array();
+
 
 	/**
 	 * Construct the user handler.
@@ -401,6 +404,9 @@ class SV_WC_Payment_Gateway_Admin_User_Handler {
 	protected function get_plugin() {
 		return $this->plugin;
 	}
+
+
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Admin_User_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Admin_User_Handler' ) ) :
 
 /**
  * Handle the admin user profile settings.

--- a/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
+++ b/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Response_Message_Helper' ) ) :
 
+
 /**
  * WooCommerce Payment Gateway API Response Message Helper
  *
@@ -153,5 +154,6 @@ class SV_WC_Payment_Gateway_API_Response_Message_Helper {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
+++ b/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Response_Message_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Response_Message_Helper' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Response Message Helper

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Authorization_Response' ) ) :
 
+
 /**
  * WooCommerce Direct Payment Gateway API Authorization Response
  *
@@ -79,6 +80,7 @@ interface SV_WC_Payment_Gateway_API_Authorization_Response extends SV_WC_Payment
 	public function csc_match();
 
 
-} // SV_WC_Payment_Gateway_API_Authorization_Response
+}
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Authorization_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Authorization_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Authorization Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Create_Payment_Token_Response' ) ) :
 
+
 /**
  * WooCommerce Direct Payment Gateway API Create Payment Token Response
  */
@@ -46,4 +47,5 @@ interface SV_WC_Payment_Gateway_API_Create_Payment_Token_Response extends SV_WC_
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Create_Payment_Token_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Create_Payment_Token_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Create Payment Token Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
@@ -28,22 +28,24 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Customer_Response' ) ) :
 
+
+/**
+ * WooCommerce Direct Payment Gateway API Customer Response
+ */
+interface SV_WC_Payment_Gateway_API_Customer_Response extends SV_WC_Payment_Gateway_API_Response {
+
+
 	/**
-	 * WooCommerce Direct Payment Gateway API Customer Response
+	 * Returns the customer ID.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return string customer ID returned by the gateway
 	 */
-	interface SV_WC_Payment_Gateway_API_Customer_Response extends SV_WC_Payment_Gateway_API_Response {
+	public function get_customer_id();
 
 
-		/**
-		 * Returns the customer ID.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @return string customer ID returned by the gateway
-		 */
-		public function get_customer_id();
+}
 
 
-	}
-
-endif;  // interface exists check
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Customer_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Customer_Response' ) ) :
 
 	/**
 	 * WooCommerce Direct Payment Gateway API Customer Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Get_Tokenized_Payment_Methods_Response' ) ) :
 
+
 /**
  * WooCommerce Direct Payment Gateway API Create Payment Token Response
  */
@@ -46,4 +47,5 @@ interface SV_WC_Payment_Gateway_API_Get_Tokenized_Payment_Methods_Response exten
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_API_Get_Tokenized_Payment_Methods_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_API_Get_Tokenized_Payment_Methods_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Create Payment Token Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment Credit Card Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response' ) ) :
 
+
 /**
  * WooCommerce Payment Gateway API Payment Credit Card Notification Response
  *
@@ -72,4 +73,5 @@ interface SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response ex
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment eCheck Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response' ) ) :
 
+
 /**
  * WooCommerce Payment Gateway API Payment eCheck Notification Response
  *
@@ -61,4 +62,5 @@ interface SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response extends
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Payment_Notification_Response' ) ) :
 
+
 /**
  * WooCommerce Payment Gateway API Payment Notification Response
  *
@@ -83,4 +84,5 @@ interface SV_WC_Payment_Gateway_API_Payment_Notification_Response extends SV_WC_
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Payment_Notification_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Payment_Notification_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response' ) ) :
 
 /**
  * WooCommerce Payment Gateway API Payment Credit Card Notification Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response' ) ) :
 
+
 /**
  * WooCommerce Payment Gateway API Payment Credit Card Notification Response
  *
@@ -170,4 +171,5 @@ interface SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response exten
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
@@ -28,9 +28,11 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Request' ) ) :
 
+
 /**
  * WooCommerce Direct Payment Gateway API Request
  */
 interface SV_WC_Payment_Gateway_API_Request extends SV_WC_API_Request { }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Request' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Request' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Request

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Response' ) ) :
 
+
 /**
  * WooCommerce Direct Payment Gateway API Response
  */
@@ -116,4 +117,5 @@ interface SV_WC_Payment_Gateway_API_Response extends SV_WC_API_Response {
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API_Response' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API Response

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_API' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API' ) ) :
 
 /**
  * WooCommerce Direct Payment Gateway API

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_API' ) ) :
 
+
 /**
  * WooCommerce Direct Payment Gateway API
  */
@@ -245,4 +246,5 @@ interface SV_WC_Payment_Gateway_API {
 
 }
 
-endif;  // interface exists check
+
+endif;

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Request' ) ) :
 
 /**
  * The Apple Pay API request object.

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Request' ) ) :
 
+
 /**
  * The Apple Pay API request object.
  *
@@ -107,5 +108,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_API_Request extends SV_WC_API_JSON_Request
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' ) ) :
 
+
 /**
  * The Apple Pay API response object.
  *
@@ -106,5 +107,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_API_Response extends SV_WC_API_JSON_Respon
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' ) ) :
 
 /**
  * The Apple Pay API response object.

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_API' ) ) :
 
 /**
  * Sets up the Apple Pay API.
@@ -56,7 +56,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 		$this->set_request_content_type_header( 'application/json' );
 		$this->set_request_accept_header( 'application/json' );
 
-		$this->set_response_handler( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' );
+		$this->set_response_handler( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' );
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_API' ) ) :
 
+
 /**
  * Sets up the Apple Pay API.
  *
@@ -189,5 +190,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Payment_Response' ) ) :
 
+
 /**
  * The Apple Pay payment response object.
  *
@@ -201,5 +202,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Payment_Response extends SV_WC_API_JSON_Re
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Payment_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Payment_Response' ) ) :
 
 /**
  * The Apple Pay payment response object.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -364,7 +364,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 	 */
 	protected function is_settings_screen() {
 
-		return 'wc-settings' === SV_WC_Helper::get_request( 'page' ) && 'apple-pay' === SV_WC_Helper::get_request( 'section' );
+		return 'wc-settings' === SV_WC_Helper::get_requested_value( 'page' ) && 'apple-pay' === SV_WC_Helper::get_requested_value( 'section' );
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Admin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Admin' ) ) :
 
 /**
  * Sets up the Apple Pay settings screen.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Admin' ) ) :
 
+
 /**
  * Sets up the Apple Pay settings screen.
  *
@@ -404,5 +405,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -116,8 +116,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 
 		check_ajax_referer( 'sv_wc_apple_pay_validate_merchant', 'nonce' );
 
-		$merchant_id = SV_WC_Helper::get_post( 'merchant_id' );
-		$url         = SV_WC_Helper::get_post( 'url' );
+		$merchant_id = SV_WC_Helper::get_posted_value( 'merchant_id' );
+		$url         = SV_WC_Helper::get_posted_value( 'url' );
 
 		try {
 
@@ -178,7 +178,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 				}
 			}
 
-			$chosen_shipping_methods = ( $method = SV_WC_Helper::get_request( 'method' ) ) ? array( wc_clean( $method ) ) : array();
+			$chosen_shipping_methods = ( $method = SV_WC_Helper::get_requested_value( 'method' ) ) ? array( wc_clean( $method ) ) : array();
 
 			WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
 
@@ -217,8 +217,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 
 		$this->get_handler()->log( 'Processing payment' );
 
-		$type     = SV_WC_Helper::get_post( 'type' );
-		$response = stripslashes( SV_WC_Helper::get_post( 'payment' ) );
+		$type     = SV_WC_Helper::get_posted_value( 'type' );
+		$response = stripslashes( SV_WC_Helper::get_posted_value( 'payment' ) );
 
 		$this->get_handler()->store_payment_response( $response );
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_AJAX' ) ) :
 
+
 /**
  * The Apple Pay AJAX handler.
  *
@@ -173,11 +174,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 
 				if ( $country ) {
 
-					if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-						WC()->customer->set_calculated_shipping( true );
-					} else {
-						WC()->customer->calculated_shipping( true );
-					}
+					WC()->customer->set_calculated_shipping( true );
 				}
 			}
 
@@ -257,5 +254,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_AJAX' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_AJAX' ) ) :
 
 /**
  * The Apple Pay AJAX handler.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Frontend' ) ) :
 
+
 /**
  * Sets up the Apple Pay front-end functionality.
  *
@@ -353,5 +354,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Frontend' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Frontend' ) ) :
 
 /**
  * Sets up the Apple Pay front-end functionality.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -92,20 +92,20 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 				try {
 
-					$item = new \WC_Order_Item_Coupon();
+					$coupon_item = new \WC_Order_Item_Coupon();
 
-					$item->set_props( [
+					$coupon_item->set_props( [
 						'code'         => $code,
 						'discount'     => $cart->get_coupon_discount_amount( $code ),
 						'discount_tax' => $cart->get_coupon_discount_tax_amount( $code ),
 						'order_id'     => $order->get_id(),
 					] );
 
-					$item->save();
+					$coupon_item->save();
 
-					$order->add_item( $item );
+					$order->add_item( $coupon_item );
 
-					$added_coupon = (bool) $item->get_id();
+					$added_coupon = (bool) $coupon_item->get_id();
 
 				} catch ( \Exception $e ) {
 
@@ -198,22 +198,21 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 					try {
 
+						$tax_item = new \WC_Order_Item_Tax();
 
-						$item = new \WC_Order_Item_Tax();
-
-						$item->set_props( [
+						$tax_item->set_props( [
 							'rate_id'            => $rate_id,
 							'tax_total'          => $cart->get_tax_amount( $rate_id ),
 							'shipping_tax_total' => $cart->get_shipping_tax_amount( $rate_id ),
 						] );
 
-						$item->set_rate( $rate_id );
-						$item->set_order_id( $order->get_id() );
-						$item->save();
+						$tax_item->set_rate( $rate_id );
+						$tax_item->set_order_id( $order->get_id() );
+						$tax_item->save();
 
-						$order->add_item( $item );
+						$order->add_item( $tax_item );
 
-						$added_tax = (bool) $item->get_id();
+						$added_tax = (bool) $tax_item->get_id();
 
 					} catch ( \Exception $e ) {
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay_Orders' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Orders' ) ) :
 
 /**
  * The Apple Pay order handler.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay_Orders' ) ) :
 
+
 /**
  * The Apple Pay order handler.
  *
@@ -50,7 +51,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 		// ensure totals are fully calculated by simulating checkout in WC 3.1 or lower
 		// TODO: remove this when WC 3.2+ can be required {CW 2017-11-17}
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) && ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) && SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) ) {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
 		}
 
@@ -60,27 +61,27 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			wc_transaction_query( 'start' );
 
-			$order_data = array(
+			$order_data = [
 				'status'      => apply_filters( 'woocommerce_default_order_status', 'pending' ),
 				'customer_id' => get_current_user_id(),
 				'cart_hash'   => md5( json_encode( wc_clean( $cart->get_cart_for_session() ) ) . $cart->total ),
 				'created_via' => 'apple_pay',
-			);
+			];
 
 			$order = self::get_order_object( $order_data );
 
 			foreach ( $cart->get_cart() as $cart_item_key => $item ) {
 
-				$args = array(
+				$args = [
 					'variation' => $item['variation'],
-					'totals'    => array(
+					'totals'    => [
 						'subtotal'     => $item['line_subtotal'],
 						'subtotal_tax' => $item['line_subtotal_tax'],
 						'total'        => $item['line_total'],
 						'tax'          => $item['line_tax'],
 						'tax_data'     => $item['line_tax_data']
-					),
-				);
+					],
+				];
 
 				if ( ! $order->add_product( $item['data'], $item['quantity'], $args ) ) {
 					throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 525 ) );
@@ -89,20 +90,66 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			foreach ( $cart->get_coupons() as $code => $coupon ) {
 
-				if ( ! SV_WC_Order_Compatibility::add_coupon( $order, $code, $cart->get_coupon_discount_amount( $code ), $cart->get_coupon_discount_tax_amount( $code ) ) ) {
+				try {
+
+					$item = new \WC_Order_Item_Coupon();
+
+					$item->set_props( [
+						'code'         => $code,
+						'discount'     => $cart->get_coupon_discount_amount( $code ),
+						'discount_tax' => $cart->get_coupon_discount_tax_amount( $code ),
+						'order_id'     => $order->get_id(),
+					] );
+
+					$item->save();
+
+					$order->add_item( $item );
+
+					$added_coupon = (bool) $item->get_id();
+
+				} catch ( \Exception $e ) {
+
+					$added_coupon = false;
+				}
+
+				if ( ! $added_coupon ) {
 					throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 529 ) );
 				}
 			}
 
-			$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+			$chosen_methods = WC()->session->get( 'chosen_shipping_methods', [] );
 
 			foreach ( WC()->shipping->get_packages() as $key => $package ) {
 
 				if ( isset( $package['rates'][ $chosen_methods[ $key ] ] ) ) {
 
-					$method = $package['rates'][ $chosen_methods[ $key ] ];
+					/** @var \WC_Shipping_Rate $shipping_rate */
+					$shipping_rate = $package['rates'][ $chosen_methods[ $key ] ];
 
-					if ( ! SV_WC_Order_Compatibility::add_shipping( $order, $method ) ) {
+					try {
+
+						$shipping_item = new \WC_Order_Item_Shipping();
+
+						$shipping_item->set_props( [
+							'method_title' => $shipping_rate->label,
+							'method_id'    => $shipping_rate->id,
+							'total'        => wc_format_decimal( $shipping_rate->cost ),
+							'taxes'        => $shipping_rate->taxes,
+							'order_id'     => $order->get_id(),
+						] );
+
+						$shipping_item->save();
+
+						$order->add_item( $shipping_item );
+
+						$added_shipping = (bool) $shipping_item->get_id();
+
+					} catch ( \Exception $e ) {
+
+						$added_shipping = false;
+					}
+
+					if ( ! $added_shipping ) {
 						throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 527 ) );
 					}
 				}
@@ -111,19 +158,69 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 			// add fees
 			foreach ( $cart->get_fees() as $key => $fee ) {
 
-				if ( ! SV_WC_Order_Compatibility::add_fee( $order, $fee ) ) {
+				try {
+
+					$fee_item = new \WC_Order_Item_Fee();
+
+					$fee_item->set_props( [
+						'name'      => $fee->name,
+						'tax_class' => $fee->taxable ? $fee->tax_class : 0,
+						'total'     => $fee->amount,
+						'total_tax' => $fee->tax,
+						'taxes'     => [
+							'total' => $fee->tax_data,
+						],
+						'order_id'  => $order->get_id(),
+					] );
+
+					$fee_item->save();
+
+					$order->add_item( $fee_item );
+
+					$added_fee = (bool) $fee_item->get_id();
+
+				} catch ( \Exception $e ) {
+
+					$added_fee = false;
+				}
+
+				if ( ! $added_fee ) {
 					throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 526 ) );
 				}
 			}
 
 			$cart_taxes     = SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.2' ) ? $cart->get_cart_contents_taxes() : $cart->taxes;
-			$shipping_taxes = SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.2' ) ? $cart->get_shipping_taxes() : $cart->shipping_taxes;
+			$shipping_taxes = SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.2' ) ? $cart->get_shipping_taxes()      : $cart->shipping_taxes;
 
 			foreach ( array_keys( $cart_taxes + $shipping_taxes ) as $rate_id ) {
 
 				if ( $rate_id && apply_filters( 'woocommerce_cart_remove_taxes_zero_rate_id', 'zero-rated' ) !== $rate_id ) {
 
-					if ( ! SV_WC_Order_Compatibility::add_tax( $order, $rate_id, $cart->get_tax_amount( $rate_id ), $cart->get_shipping_tax_amount( $rate_id ) ) ) {
+					try {
+
+
+						$item = new \WC_Order_Item_Tax();
+
+						$item->set_props( [
+							'rate_id'            => $rate_id,
+							'tax_total'          => $cart->get_tax_amount( $rate_id ),
+							'shipping_tax_total' => $cart->get_shipping_tax_amount( $rate_id ),
+						] );
+
+						$item->set_rate( $rate_id );
+						$item->set_order_id( $order->get_id() );
+						$item->save();
+
+						$order->add_item( $item );
+
+						$added_tax = (bool) $item->get_id();
+
+					} catch ( \Exception $e ) {
+
+						$added_tax = false;
+					}
+
+					if ( ! $added_tax ) {
 						throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 526 ) );
 					}
 				}
@@ -135,7 +232,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			$order->calculate_totals( false ); // false to skip recalculating taxes
 
-			do_action( 'woocommerce_checkout_update_order_meta', SV_WC_Order_Compatibility::get_prop( $order, 'id' ), array() );
+			do_action( 'woocommerce_checkout_update_order_meta', $order->get_id(), [] );
 
 			return $order;
 
@@ -169,9 +266,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			if ( is_wp_error( $order ) ) {
 				throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 522 ) );
-			} else {
-				$order->remove_order_items();
 			}
+
+			$order->remove_order_items();
 
 		} else {
 
@@ -179,12 +276,14 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			if ( is_wp_error( $order ) ) {
 				throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 520 ) );
-			} elseif ( false === $order ) {
+			}
+
+			if ( false === $order ) {
 				throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 521 ) );
 			}
 
 			// set the new order ID so it can be resumed in case of failure
-			WC()->session->set( 'order_awaiting_payment', SV_WC_Order_Compatibility::get_prop( $order, 'id' ) );
+			WC()->session->set( 'order_awaiting_payment', $order->get_id() );
 		}
 
 		return $order;
@@ -192,5 +291,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay' ) ) :
 
+
 /**
  * Sets up Apple Pay support.
  *
@@ -122,17 +123,15 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 			$order->set_address( $payment_response->get_billing_address(),  'billing' );
 			$order->set_address( $payment_response->get_shipping_address(), 'shipping' );
 
-			if ( SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ) {
-				$order->save();
-			}
+			$order->save();
 
 			// add Apple Pay response data to the order
-			add_filter( 'wc_payment_gateway_' . $this->get_processing_gateway()->get_id() . '_get_order', array( $this, 'add_order_data' ) );
+			add_filter( 'wc_payment_gateway_' . $this->get_processing_gateway()->get_id() . '_get_order', [ $this, 'add_order_data' ] );
 
 			if ( $this->is_test_mode() ) {
 				$result = $this->process_test_payment( $order );
 			} else {
-				$result = $this->get_processing_gateway()->process_payment( SV_WC_Order_Compatibility::get_prop( $order, 'id' ) );
+				$result = $this->get_processing_gateway()->process_payment( $order->get_id() );
 			}
 
 			if ( isset( $result['result'] ) && 'success' !== $result['result'] ) {
@@ -693,20 +692,20 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 */
 	public function set_customer_taxable_address( $address ) {
 
-		$billing_country = SV_WC_Plugin_Compatibility::is_wc_version_gte_3_0() ? WC()->customer->get_billing_country() : WC()->customer->get_country();
+		$billing_country = WC()->customer->get_billing_country();
 
 		// set to the shipping address provided by Apple Pay if:
-		// 1. shipping is available
-		// 2. billing is not available
+		// 1. billing is not available
+		// 2. shipping is available
 		// 3. taxes aren't configured to use the shop base
-		if ( WC()->customer->get_shipping_country() && ! $billing_country && $address[0] !== WC()->countries->get_base_country() ) {
+		if ( ! $billing_country && WC()->customer->get_shipping_country() && $address[0] !== WC()->countries->get_base_country() ) {
 
-			$address = array(
+			$address = [
 				WC()->customer->get_shipping_country(),
 				WC()->customer->get_shipping_state(),
 				WC()->customer->get_shipping_postcode(),
 				WC()->customer->get_shipping_city(),
-			);
+			];
 		}
 
 		return $address;
@@ -1043,5 +1042,6 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Apple_Pay' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Apple_Pay' ) ) :
 
 /**
  * Sets up Apple Pay support.
@@ -952,7 +952,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 
 		$accepted_card_types = ( $this->get_processing_gateway() ) ? $this->get_processing_gateway()->get_card_types() : array();
 
-		$accepted_card_types = array_map( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Helper::normalize_card_type', $accepted_card_types );
+		$accepted_card_types = array_map( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Helper::normalize_card_type', $accepted_card_types );
 
 		$valid_networks = array(
 			SV_WC_Payment_Gateway_Helper::CARD_TYPE_AMEX       => 'amex',

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Direct' ) ) :
 
+
 /**
  * # WooCommerce Payment Gateway Framework Direct Gateway
  *
@@ -400,9 +401,11 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 				$held_order_status = apply_filters( 'wc_' . $this->get_id() . '_held_order_status', 'on-hold', $order, null );
 
 				if ( $order->has_status( $held_order_status ) ) {
-					SV_WC_Order_Compatibility::reduce_stock_levels( $order ); // reduce stock for held orders, but don't complete payment
+					// reduce stock for held orders, but don't complete payment
+					wc_reduce_stock_levels( $order );
 				} else {
-					$order->payment_complete(); // mark order as having received payment
+					// mark order as having received payment
+					$order->payment_complete();
 				}
 
 				// process_payment() can sometimes be called in an admin-context
@@ -1002,11 +1005,12 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 
 
 	/**
-	 * Creates the order required for adding a new payment method. Note that
-	 * a mock order is generated as there is no actual order associated with the
-	 * request.
+	 * Creates the order required for adding a new payment method.
+	 *
+	 * Note that a mock order is generated as there is no actual order associated with the request.
 	 *
 	 * @since 4.0.0
+	 *
 	 * @return \WC_Order generated order object
 	 */
 	protected function get_order_for_add_payment_method() {
@@ -1017,12 +1021,13 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 
 		$user = get_userdata( get_current_user_id() );
 
-		$properties = array(
+		$properties = [
 			'currency'    => get_woocommerce_currency(), // default to base store currency
 			'customer_id' => $user->ID,
-		);
+		];
 
-		$defaults = array(
+		$defaults = [
+
 			// billing
 			'billing_first_name' => '',
 			'billing_last_name'  => '',
@@ -1046,7 +1051,8 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 			'shipping_postcode'   => '',
 			'shipping_state'      => '',
 			'shipping_country'    => '',
-		);
+
+		];
 
 		foreach ( $defaults as $prop => $value ) {
 
@@ -1057,7 +1063,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 			}
 		}
 
-		$order = SV_WC_Order_Compatibility::set_props( $order, $properties );
+		$order->set_props( $properties );
 
 		// other default info
 		$order->customer_id = $this->get_customer_id( $order->get_user_id() );
@@ -1071,10 +1077,10 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		/**
 		 * Direct Gateway Get Order for Add Payment Method Filter.
 		 *
-		 * Allow actors to modify the order object used for an add payment method
-		 * transaction.
+		 * Allow actors to modify the order object used for an add payment method transaction.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param \WC_Order $order order object
 		 * @param SV_WC_Payment_Gateway_Direct $this instance
 		 */
@@ -1187,6 +1193,8 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		return false;
 	}
 
+
 }
 
-endif;  // class exists check
+
+endif;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -54,17 +54,17 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		if ( $this->supports_tokenization() ) {
 
 			// tokenized transaction?
-			if ( SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
+			if ( SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
 
 				// unknown token?
-				if ( ! $this->get_payment_tokens_handler()->user_has_token( get_current_user_id(), SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) ) {
+				if ( ! $this->get_payment_tokens_handler()->user_has_token( get_current_user_id(), SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) ) {
 					SV_WC_Helper::wc_add_notice( esc_html__( 'Payment error, please try another payment method or contact us to complete your transaction.', 'woocommerce-plugin-framework' ), 'error' );
 					$is_valid = false;
 				}
 
 				// Check the CSC if enabled
 				if ( $this->is_credit_card_gateway() && $this->csc_enabled_for_tokens() ) {
-					$is_valid = $this->validate_csc( SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-csc' ) ) && $is_valid;
+					$is_valid = $this->validate_csc( SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-csc' ) ) && $is_valid;
 				}
 
 				// no more validation to perform
@@ -98,11 +98,11 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 */
 	protected function validate_credit_card_fields( $is_valid ) {
 
-		$account_number   = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-account-number' );
-		$expiration_month = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-exp-month' );
-		$expiration_year  = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-exp-year' );
-		$expiry           = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-expiry' );
-		$csc              = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-csc' );
+		$account_number   = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-account-number' );
+		$expiration_month = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-exp-month' );
+		$expiration_year  = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-exp-year' );
+		$expiry           = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-expiry' );
+		$csc              = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-csc' );
 
 		// handle single expiry field formatted like "MM / YY" or "MM / YYYY"
 		if ( ! $expiration_month & ! $expiration_year && $expiry ) {
@@ -254,12 +254,12 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 */
 	protected function validate_check_fields( $is_valid ) {
 
-		$account_number         = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-account-number' );
-		$routing_number         = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-routing-number' );
+		$account_number         = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-account-number' );
+		$routing_number         = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-routing-number' );
 
 		// optional fields (excluding account type for now)
-		$drivers_license_number = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-drivers-license-number' );
-		$check_number           = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-check-number' );
+		$drivers_license_number = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-drivers-license-number' );
+		$check_number           = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-check-number' );
 
 		// routing number exists?
 		if ( empty( $routing_number ) ) {
@@ -553,18 +553,18 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 		$order = parent::get_order( $order_id );
 
 		// payment info
-		if ( SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-account-number' ) && ! SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
+		if ( SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-account-number' ) && ! SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
 
 			// common attributes
-			$order->payment->account_number = str_replace( array( ' ', '-' ), '', SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-account-number' ) );
+			$order->payment->account_number = str_replace( array( ' ', '-' ), '', SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-account-number' ) );
 			$order->payment->last_four = substr( $order->payment->account_number, -4 );
 
 			if ( $this->is_credit_card_gateway() ) {
 
 				// credit card specific attributes
-				$order->payment->card_type      = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-card-type' );
-				$order->payment->exp_month      = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-exp-month' );
-				$order->payment->exp_year       = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-exp-year' );
+				$order->payment->card_type      = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-card-type' );
+				$order->payment->exp_month      = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-exp-month' );
+				$order->payment->exp_year       = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-exp-year' );
 
 				// add card type for gateways that don't require it displayed at checkout
 				if ( empty( $order->payment->card_type ) ) {
@@ -572,30 +572,30 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 				}
 
 				// handle single expiry field formatted like "MM / YY" or "MM / YYYY"
-				if ( SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-expiry' ) ) {
-					list( $order->payment->exp_month, $order->payment->exp_year ) = array_map( 'trim', explode( '/', SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-expiry' ) ) );
+				if ( SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-expiry' ) ) {
+					list( $order->payment->exp_month, $order->payment->exp_year ) = array_map( 'trim', explode( '/', SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-expiry' ) ) );
 				}
 
 				// add CSC if enabled
 				if ( $this->csc_enabled() ) {
-					$order->payment->csc = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-csc' );
+					$order->payment->csc = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-csc' );
 				}
 
 			} elseif ( $this->is_echeck_gateway() ) {
 
 				// echeck specific attributes
-				$order->payment->routing_number         = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-routing-number' );
-				$order->payment->account_type           = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-account-type' );
-				$order->payment->check_number           = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-check-number' );
-				$order->payment->drivers_license_number = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-drivers-license-number' );
-				$order->payment->drivers_license_state  = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-drivers-license-state' );
+				$order->payment->routing_number         = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-routing-number' );
+				$order->payment->account_type           = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-account-type' );
+				$order->payment->check_number           = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-check-number' );
+				$order->payment->drivers_license_number = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-drivers-license-number' );
+				$order->payment->drivers_license_state  = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-drivers-license-state' );
 
 			}
 
-		} elseif ( SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
+		} elseif ( SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
 
 			// paying with tokenized payment method (we've already verified that this token exists in the validate_fields method)
-			$token = $this->get_payment_tokens_handler()->get_token( $order->get_user_id(), SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) );
+			$token = $this->get_payment_tokens_handler()->get_token( $order->get_user_id(), SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) );
 
 			$order->payment->token          = $token->get_id();
 			$order->payment->account_number = $token->get_last_four();
@@ -609,7 +609,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 				$order->payment->exp_year  = $token->get_exp_year();
 
 				if ( $this->csc_enabled_for_tokens() ) {
-					$order->payment->csc = SV_WC_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-csc' );
+					$order->payment->csc = SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-csc' );
 				}
 
 			} elseif ( $this->is_echeck_gateway() ) {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Direct' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Direct' ) ) :
 
 /**
  * # WooCommerce Payment Gateway Framework Direct Gateway

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Helper' ) ) :
 
+
 /**
  * SkyVerge Payment Gateway Helper Class
  *
@@ -266,4 +267,5 @@ class SV_WC_Payment_Gateway_Helper {
 
 }
 
-endif; // Class exists check
+
+endif;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -128,10 +128,10 @@ class SV_WC_Payment_Gateway_Helper {
 
 
 	/**
-	 * Determine the credit card type from a given account number (only first 4
-	 * required)
+	 * Determines the credit card type from a given account number (only first 4 required).
 	 *
 	 * @since 4.0.0
+	 *
 	 * @param string $account_number the credit card account number
 	 * @return string the credit card type
 	 */

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Helper' ) ) :
 
 /**
  * SkyVerge Payment Gateway Helper Class

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Hosted' ) ) :
 
+
 /**
  * # WooCommerce Payment Gateway Framework Hosted Gateway
  *
@@ -928,6 +929,8 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 		return $this->use_form_post() && true;
 	}
 
+
 }
 
-endif;  // class exists check
+
+endif;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Hosted' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Hosted' ) ) :
 
 /**
  * # WooCommerce Payment Gateway Framework Hosted Gateway

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_My_Payment_Methods' ) ) :
 
+
 /**
  * My Payment Methods Class
  *
@@ -155,7 +156,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 					$this->credit_card_tokens[ $token->get_id() ] = $token;
 
-				} elseif ( $token->is_check() ) {
+				} elseif ( $token->is_echeck() ) {
 
 					$this->echeck_tokens[ $token->get_id() ] = $token;
 				}
@@ -1098,4 +1099,5 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 }
 
-endif;  // class exists check
+
+endif;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_My_Payment_Methods' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_My_Payment_Methods' ) ) :
 
 /**
  * My Payment Methods Class

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -873,7 +873,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 			$this->load_tokens();
 
-			$token_id = SV_WC_Helper::get_post( 'token_id' );
+			$token_id = SV_WC_Helper::get_posted_value( 'token_id' );
 
 			if ( empty( $this->tokens[ $token_id ] ) || ! $this->tokens[ $token_id ] instanceof SV_WC_Payment_Gateway_Payment_Token ) {
 				throw new SV_WC_Payment_Gateway_Exception( 'Invalid token ID' );
@@ -890,7 +890,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 			$data = array();
 
-			parse_str( SV_WC_Helper::get_post( 'data' ), $data );
+			parse_str( SV_WC_Helper::get_posted_value( 'data' ), $data );
 
 			// set the data
 			$token = $this->save_token_data( $token, $data );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Form' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Form' ) ) :
 
 /**
  * Payment Form Class
@@ -987,7 +987,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 		);
 
 		if ( $this->get_gateway()->supports_card_types() ) {
-			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_4_3\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
+			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
 		}
 
 		/**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Form' ) ) :
 
+
 /**
  * Payment Form Class
  *
@@ -120,7 +121,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 			foreach ( $this->get_gateway()->get_payment_tokens_handler()->get_tokens( get_current_user_id() ) as $token ) {
 
 				// some gateways return all tokens for each gateway, so ensure the token type matches the gateway type
-				if ( ( $this->get_gateway()->is_credit_card_gateway() && $token->is_check() ) || ( $this->get_gateway()->is_echeck_gateway() && $token->is_credit_card() ) ) {
+				if ( ( $this->get_gateway()->is_credit_card_gateway() && $token->is_echeck() ) || ( $this->get_gateway()->is_echeck_gateway() && $token->is_credit_card() ) ) {
 					continue;
 				}
 
@@ -1013,4 +1014,5 @@ class SV_WC_Payment_Gateway_Payment_Form {
 
 }
 
-endif;  // class exists check
+
+endif;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -1037,8 +1037,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	/**
 	 * Get a gateway's settings screen section ID.
 	 *
-	 * This was used as a helper method for WC 2.5 compatibility, but is no
-	 * longer needed and now deprecated.
+	 * This was used as a helper method for WC 2.5 compatibility, but is no longer needed and now deprecated.
 	 *
 	 * @since 4.4.0
 	 * @deprecated 5.0.1
@@ -1048,7 +1047,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	public function get_payment_gateway_configuration_section( $gateway_id ) {
 
-		wc_doing_it_wrong( 'SV_WC_Payment_Gateway_Plugin::get_payment_gateway_configuration_section()', 'Deprecated! Use the plain gateway ID instead.', '5.0.1' );
+		wc_deprecated_function( __METHOD__, '5.0.1', 'strtolower( $gateway_id )' );
 
 		return strtolower( $gateway_id );
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Plugin' ) ) :
 
+
 /**
  * # WooCommerce Payment Gateway Plugin Framework
  *
@@ -1047,7 +1048,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	public function get_payment_gateway_configuration_section( $gateway_id ) {
 
-		SV_WC_Plugin_Compatibility::wc_doing_it_wrong( 'SV_WC_Payment_Gateway_Plugin::get_payment_gateway_configuration_section()', 'Deprecated! Use the plain gateway ID instead.', '5.0.1' );
+		wc_doing_it_wrong( 'SV_WC_Payment_Gateway_Plugin::get_payment_gateway_configuration_section()', 'Deprecated! Use the plain gateway ID instead.', '5.0.1' );
 
 		return strtolower( $gateway_id );
 	}
@@ -1335,5 +1336,6 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Plugin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Plugin' ) ) :
 
 /**
  * # WooCommerce Payment Gateway Plugin Framework

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Privacy' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Privacy' ) ) :
 
 /**
  * The payment gateway privacy handler class.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Privacy' ) ) :
 
+
 /**
  * The payment gateway privacy handler class.
  *
@@ -385,5 +386,6 @@ class SV_WC_Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -3575,6 +3575,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		if ( $order instanceof \WC_Order ) {
 			$order->add_meta_data( $this->get_order_meta_prefix() . $key, $value, $unique );
+			$order->save_meta_data();
 		}
 
 		return $order instanceof \WC_Order;
@@ -3624,6 +3625,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		if ( $order instanceof \WC_Order ) {
 			$order->update_meta_data( $this->get_order_meta_prefix() . $key, $value );
+			$order->save_meta_data();
 		}
 
 		return $order instanceof \WC_Order;
@@ -3646,6 +3648,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		if ( $order instanceof \WC_Order ) {
 			$order->delete_meta_data( $this->get_order_meta_prefix() . $key );
+			$order->save_meta_data();
 		}
 
 		return $order instanceof \WC_Order ;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -2833,7 +2833,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		if ( ! $customer_id && $args['autocreate'] ) {
 
 			/** @var \WC_Order|null $order */
-			$order         = isset( $args['order'] ) && $args['order'] instanceof \WC_Order ? $args['order'] : null;
+			$order         = $args['order'] instanceof \WC_Order ? $args['order'] : null;
 			$billing_email = $order ? $order->get_billing_email() : '';
 
 			// Generate a new customer id.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -3365,37 +3365,36 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Safely get and trim data from $_POST
+	 * Safely gets and trims data from $_POST
 	 *
-	 * @deprecated use SV_WC_Helper::get_post()
 	 * @since 1.0.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param string $key array key to get from $_POST array
 	 * @return string value from $_POST or blank string if $_POST[ $key ] is not set
 	 */
 	protected function get_post( $key ) {
 
-		if ( isset( $_POST[ $key ] ) ) {
-			return trim( $_POST[ $key ] );
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', SV_WC_Helper::class . '::get_posted_value()' );
 
-		return '';
+		return SV_WC_Helper::get_posted_value( $key );
 	}
 
 
 	/**
-	 * Safely get and trim data from $_REQUEST
+	 * Safely gets and trims data from $_REQUEST.
 	 *
 	 * @since 1.0.0
+	 * @deprecated 5.5.0
+	 *
 	 * @param string $key array key to get from $_REQUEST array
 	 * @return string value from $_REQUEST or blank string if $_REQUEST[ $key ] is not set
 	 */
 	protected function get_request( $key ) {
 
-		if ( isset( $_REQUEST[ $key ] ) ) {
-			return trim( $_REQUEST[ $key ] );
-		}
+		wc_deprecated_function( __METHOD__, '5.5.0', SV_WC_Helper::class . '::get_requested_value()' );
 
-		return '';
+		return SV_WC_Helper::get_requested_value( $key );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -3599,7 +3599,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		if ( ! $order instanceof \WC_Order ) {
 			$meta = false;
 		} else {
-			$meta = $order->get_meta( $this->get_order_meta_prefix() . $key, true );
+			$meta = $order->get_meta( $this->get_order_meta_prefix() . $key, true, 'edit' );
 		}
 
 		return $meta;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway' ) ) :
 
 /**
  * WooCommerce Payment Gateway Framework

--- a/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
+++ b/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
@@ -28,9 +28,11 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Exception' ) ) :
 
+
 /**
  * Payment Gateway Exception - generic payment failure Exception
  */
 class SV_WC_Payment_Gateway_Exception extends SV_WC_Plugin_Exception { }
 
-endif;  // class exists check
+
+endif;

--- a/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
+++ b/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Exception' ) ) :
 
 /**
  * Payment Gateway Exception - generic payment failure Exception

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Integration' ) ) :
 
+
 /**
  * Abstract Integration
  *
@@ -68,4 +69,4 @@ abstract class SV_WC_Payment_Gateway_Integration {
 }
 
 
-endif;  // class exists check
+endif;

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Integration' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Integration' ) ) :
 
 /**
  * Abstract Integration

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
 
 /**
  * Pre-Orders Integration

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
 
+
 /**
  * Pre-Orders Integration
  *
@@ -144,10 +145,10 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 			// if this is a pre-order release payment with a tokenized payment method, get the payment token to complete the order
 
 			// retrieve the payment token
-			$order->payment->token = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'payment_token' );
+			$order->payment->token = $this->get_gateway()->get_order_meta( $order, 'payment_token' );
 
 			// retrieve the optional customer id
-			$order->customer_id = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'customer_id' );
+			$order->customer_id = $this->get_gateway()->get_order_meta( $order, 'customer_id' );
 
 			// set token data on order
 			if ( $this->get_gateway()->get_payment_tokens_handler()->user_has_token( $order->get_user_id(), $order->payment->token ) ) {
@@ -178,16 +179,18 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 				// a guest user means that token data must be set from the original order
 
 				// account number
-				$order->payment->account_number = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'account_four' );
+				$order->payment->account_number = $this->get_gateway()->get_order_meta( $order, 'account_four' );
 
 				if ( $this->get_gateway()->is_credit_card_gateway() ) {
 
 					// card type
-					$order->payment->card_type = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'card_type' );
+					$order->payment->card_type = $this->get_gateway()->get_order_meta( $order, 'card_type' );
 
 					// expiry date
-					if ( $expiry_date = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'card_expiry_date' ) ) {
+					if ( $expiry_date = $this->get_gateway()->get_order_meta( $order, 'card_expiry_date' ) ) {
+
 						list( $exp_year, $exp_month ) = explode( '-', $expiry_date );
+
 						$order->payment->exp_month  = $exp_month;
 						$order->payment->exp_year   = $exp_year;
 					}
@@ -195,7 +198,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
 
 					// account type
-					$order->payment->account_type = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'account_type' );
+					$order->payment->account_type = $this->get_gateway()->get_order_meta( $order, 'account_type' );
 				}
 			}
 		}
@@ -294,7 +297,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 		try {
 
 			// set order defaults
-			$order = $this->get_gateway()->get_order( SV_WC_Order_Compatibility::get_prop( $order, 'id' ) );
+			$order = $this->get_gateway()->get_order( $order );
 
 			// order description
 			$order->description = sprintf( __( '%s - Pre-Order Release Payment for Order %s', 'woocommerce-plugin-framework' ), esc_html( SV_WC_Helper::get_site_name() ), $order->get_order_number() );
@@ -362,9 +365,11 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 					$this->get_gateway()->mark_order_as_held( $order, $this->get_gateway()->supports( SV_WC_Payment_Gateway::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->get_gateway()->perform_credit_card_authorization( $order ) ? __( 'Authorization only transaction', 'woocommerce-plugin-framework' ) : $response->get_status_message(), $response );
 
-					SV_WC_Order_Compatibility::reduce_stock_levels( $order ); // reduce stock for held orders, but don't complete payment
+					// reduce stock for held orders, but don't complete payment
+					wc_reduce_stock_levels( $order );
 
 				} else {
+
 					// otherwise complete the order
 					$order->payment_complete();
 				}
@@ -383,7 +388,9 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 		}
 	}
+
+
 }
 
 
-endif;  // class exists check
+endif;

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
 
+
 /**
  * Subscriptions Integration
  *
@@ -177,20 +178,20 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	public function save_payment_meta( $order ) {
 
 		// a single order can contain multiple subscriptions
-		$subscriptions = wcs_get_subscriptions_for_order( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), array(
-			'order_type' => array( 'any' ),
-		) );
+		$subscriptions = wcs_get_subscriptions_for_order( $order, [
+			'order_type' => [ 'any' ],
+		] );
 
 		foreach ( $subscriptions as $subscription ) {
 
 			// payment token
 			if ( ! empty( $order->payment->token ) ) {
-				update_post_meta( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ), $this->get_gateway()->get_order_meta_prefix() . 'payment_token', $order->payment->token );
+				update_post_meta( $subscription->get_id(), $this->get_gateway()->get_order_meta_prefix() . 'payment_token', $order->payment->token );
 			}
 
 			// customer ID
 			if ( ! empty( $order->customer_id ) ) {
-				update_post_meta( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ), $this->get_gateway()->get_order_meta_prefix() . 'customer_id', $order->customer_id );
+				update_post_meta( $subscription->get_id(), $this->get_gateway()->get_order_meta_prefix() . 'customer_id', $order->customer_id );
 			}
 		}
 	}
@@ -282,7 +283,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 		$details = new \stdClass;
 
-		$details->id             = max( 0, (int) SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ) );
+		$details->id             = max( 0, (int) $subscription->get_id() );
 		$details->is_renewal     = (bool) $renewal;
 		$details->is_installment = (bool) $subscription->get_date( 'end' );
 
@@ -317,7 +318,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		// set payment total so it can override the default in get_order()
 		$this->renewal_payment_total = SV_WC_Helper::number_format( $amount_to_charge );
 
-		$token = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'payment_token' );
+		$token = $this->get_gateway()->get_order_meta( $order, 'payment_token' );
 
 		// payment token must be present and valid
 		if ( empty( $token ) || ! $this->get_gateway()->get_payment_tokens_handler()->user_has_token( $order->get_user_id(), $token ) ) {
@@ -330,7 +331,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		// add subscriptions data to the order object prior to processing the payment
 		add_filter( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_get_order', array( $this, 'get_order' ) );
 
-		$this->get_gateway()->process_payment( SV_WC_Order_Compatibility::get_prop( $order, 'id' ) );
+		$this->get_gateway()->process_payment( $order->get_id() );
 	}
 
 
@@ -354,10 +355,10 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		$order->payment_total = $this->renewal_payment_total;
 
 		// set payment token
-		$order->payment->token = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'payment_token' );
+		$order->payment->token = $this->get_gateway()->get_order_meta( $order, 'payment_token' );
 
 		// use customer ID from renewal order, not user meta so the admin can update the customer ID for a subscription if needed
-		$customer_id = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $order, 'id' ), 'customer_id' );
+		$customer_id = $this->get_gateway()->get_order_meta( $order, 'customer_id' );
 
 		// only if a customer ID exists in order meta, otherwise this will default to the previously set value from user meta
 		if ( ! empty( $customer_id ) ) {
@@ -505,25 +506,28 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * over to renewal orders.
 	 *
 	 * @since 4.1.0
+	 *
 	 * @param array $result process_payment() result, unused
-	 * @param \WC_Subscription $subscription subscription object
+	 * @param int|\WC_Subscription $subscription subscription object
 	 * @return array
 	 */
 	public function remove_order_meta_from_change_payment( $result, $subscription ) {
 
 		// remove order-specific meta
 		foreach ( $this->get_order_specific_meta_keys() as $meta_key ) {
-			delete_post_meta( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ), $meta_key );
+			delete_post_meta( $subscription->get_id(), $meta_key );
 		}
 
 		// get a fresh subscription object after previous metadata changes
-		$subscription = wcs_get_subscription( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ) );
+		$subscription = is_numeric( $subscription ) ? wcs_get_subscription( $subscription ) : $subscription;
 
-		$old_payment_method = SV_WC_Order_Compatibility::get_meta( $subscription, '_old_payment_method' );
-		$new_payment_method = SV_WC_Order_Compatibility::get_prop( $subscription, 'payment_method' );
+		$old_payment_method = $subscription->get_meta( '_old_payment_method', true, 'edit' );
+		$new_payment_method = $subscription->get_payment_method( 'edit' );
+		$gateway_id         = $this->get_gateway()->get_id();
 
 		// if the payment method has been changed to another gateway, additionally remove the old payment token and customer ID meta
-		if ( $new_payment_method !== $this->get_gateway()->get_id() && $old_payment_method === $this->get_gateway()->get_id() ) {
+		if ( $new_payment_method !== $gateway_id && $old_payment_method === $gateway_id ) {
+
 			$this->get_gateway()->delete_order_meta( $subscription, 'payment_token' );
 			$this->get_gateway()->delete_order_meta( $subscription, 'customer_id' );
 		}
@@ -545,15 +549,15 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 		// if the order doesn't have a transaction date stored, bail
 		// this prevents updating the subscription with a failing token in case the merchant is switching the order status manually without new payment
-		if ( ! $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $renewal_order, 'id' ), 'trans_date' ) ) {
+		if ( ! $this->get_gateway()->get_order_meta( $renewal_order, 'trans_date' ) ) {
 			return;
 		}
 
-		if ( $customer_id = $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $renewal_order, 'id' ), 'customer_id' ) ) {
+		if ( $customer_id = $this->get_gateway()->get_order_meta( $renewal_order, 'customer_id' ) ) {
 			$this->get_gateway()->update_order_meta( $subscription, 'customer_id', $customer_id );
 		}
 
-		$this->get_gateway()->update_order_meta( $subscription, 'payment_token', $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $renewal_order, 'id' ), 'payment_token' ) );
+		$this->get_gateway()->update_order_meta( $subscription, 'payment_token', $this->get_gateway()->get_order_meta( $renewal_order, 'payment_token' ) );
 	}
 
 
@@ -613,11 +617,11 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	public function maybe_render_payment_method( $payment_method_to_display, $subscription ) {
 
 		// bail for other payment methods
-		if ( $this->get_gateway()->get_id() !== SV_WC_Order_Compatibility::get_prop( $subscription, 'payment_method' ) ) {
+		if ( $this->get_gateway()->get_id() !== $subscription->get_payment_method( 'edit' ) ) {
 			return $payment_method_to_display;
 		}
 
-		$token = $this->get_gateway()->get_payment_tokens_handler()->get_token( $subscription->get_user_id(), $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ), 'payment_token' ) );
+		$token = $this->get_gateway()->get_payment_tokens_handler()->get_token( $subscription->get_user_id(), $this->get_gateway()->get_order_meta( $subscription, 'payment_token' ) );
 
 		if ( $token instanceof SV_WC_Payment_Gateway_Payment_Token ) {
 			$payment_method_to_display = sprintf( __( 'Via %s ending in %s', 'woocommerce-plugin-framework' ), $token->get_type_full(), $token->get_last_four() );
@@ -729,7 +733,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * @since 4.3.0
 	 *
 	 * @param int $user_id the user
-	 * @param SV_WC_Payment_Gateway_Payment_Token the token object
+	 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
 	 * @return array the subscriptions or an empty array
 	 */
 	protected function get_payment_token_subscriptions( $user_id, $token ) {
@@ -738,8 +742,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 		foreach ( $subscriptions as $key => $subscription ) {
 
-			$payment_method  = SV_WC_Order_Compatibility::get_prop( $subscription, 'payment_method' );
-			$stored_token_id = (string) $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ), 'payment_token' );
+			$payment_method  = $subscription->get_payment_method( 'edit' );
+			$stored_token_id = (string) $this->get_gateway()->get_order_meta( $subscription, 'payment_token' );
 
 			if ( $stored_token_id !== (string) $token->get_id() || $payment_method !== $this->get_gateway()->get_id() ) {
 				unset( $subscriptions[ $key ] );
@@ -767,11 +771,11 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		$meta[ $this->get_gateway()->get_id() ] = array(
 			'post_meta' => array(
 				$prefix . 'payment_token' => array(
-					'value' => $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ), 'payment_token' ),
+					'value' => $this->get_gateway()->get_order_meta( $subscription, 'payment_token' ),
 					'label' => __( 'Payment Token', 'woocommerce-plugin-framework' ),
 				),
 				$prefix . 'customer_id'   => array(
-					'value' => $this->get_gateway()->get_order_meta( SV_WC_Order_Compatibility::get_prop( $subscription, 'id' ), 'customer_id' ),
+					'value' => $this->get_gateway()->get_order_meta( $subscription, 'customer_id' ),
 					'label' => __( 'Customer ID', 'woocommerce-plugin-framework' ),
 				),
 			)
@@ -810,4 +814,4 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 }
 
 
-endif;  // class exists check
+endif;

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
 
 /**
  * Subscriptions Integration

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -101,7 +101,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	public function get_token() {
 
-		_deprecated_function( __METHOD__, '4.0.0', 'SV_WC_Payment_Gateway_Payment_Token::get_id()' );
+		wc_deprecated_function( __METHOD__, '4.0.0', __CLASS__ . '::get_id()' );
 
 		return $this->get_id();
 	}
@@ -224,14 +224,18 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
-	 * Determine the credit card type from the full account number
+	 * Determines the credit card type from the full account number.
 	 *
 	 * @since 1.0.0
-	 * @deprecated since 4.0.0 in favor of SV_WC_Payment_Gateway_Helper::card_type_from_account_number()
+	 * @deprecated 4.0.0
+	 * @see SV_WC_Payment_Gateway_Helper::card_type_from_account_number()
+	 *
 	 * @param string $account_number the credit card account number
 	 * @return string the credit card type
 	 */
 	public static function type_from_account_number( $account_number ) {
+
+		wc_deprecated_function( __METHOD__, '4.0.0', __CLASS__, '::card_type_from_account_number()' );
 
 		return SV_WC_Payment_Gateway_Helper::card_type_from_account_number( $account_number );
 	}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Token' ) ) :
 
+
 /**
  * WooCommerce Payment Gateway Token
  *
@@ -91,15 +92,16 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
-	 * Returns the payment token string
+	 * Gets the payment token string.
 	 *
 	 * @since 1.0.0
-	 * @deprecated since 4.0.0
+	 * @deprecated 4.0.0
+	 *
 	 * @return string payment token string
 	 */
 	public function get_token() {
 
-		_deprecated_function( 'SV_WC_Payment_Gateway_Payment_Token::get_token()', '4.0.0', 'SV_WC_Payment_Gateway_Payment_Token::get_id()' );
+		_deprecated_function( __METHOD__, '4.0.0', 'SV_WC_Payment_Gateway_Payment_Token::get_id()' );
 
 		return $this->get_id();
 	}
@@ -154,13 +156,16 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
-	 * Returns true if this payment token represents an eCheck
+	 * Determines if this payment token represents an eCheck.
 	 *
 	 * @since 1.0.0
 	 * @deprecated since 4.0.0
-	 * @return boolean true if this payment token represents an eCheck
+	 *
+	 * @return bool
 	 */
 	public function is_check() {
+
+		wc_deprecated_function( __METHOD__, '4.0.0', __CLASS__ . '::is_echeck()' );
 
 		return $this->is_echeck();
 	}
@@ -461,4 +466,5 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 }
 
-endif;  // class exists check
+
+endif;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Token' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Token' ) ) :
 
 /**
  * WooCommerce Payment Gateway Token

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -638,7 +638,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 */
 	public function should_tokenize() {
 
-		return SV_WC_Helper::get_post( 'wc-' . $this->get_gateway()->get_id_dasherized() . '-tokenize-payment-method' ) && ! SV_WC_Helper::get_post( 'wc-' . $this->get_gateway()->get_id_dasherized() . '-payment-token' );
+		return SV_WC_Helper::get_posted_value( 'wc-' . $this->get_gateway()->get_id_dasherized() . '-tokenize-payment-method' ) && ! SV_WC_Helper::get_posted_value( 'wc-' . $this->get_gateway()->get_id_dasherized() . '-payment-token' );
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WC_Payment_Gateway_Payment_Tokens_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Tokens_Handler' ) ) :
 
 /**
  * Handle the payment tokenization related functionality.

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -28,6 +28,8 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WC_Payment_Gateway_Payment_Tokens_Handler' ) ) :
 
+
+
 /**
  * Handle the payment tokenization related functionality.
  *
@@ -898,5 +900,6 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 
 }
+
 
 endif;

--- a/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
+++ b/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
@@ -22,17 +22,17 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3\Payment_Gateway;
-use SkyVerge\WooCommerce\PluginFramework\v5_4_3\REST_API as Plugin_REST_API;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\Payment_Gateway;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API as Plugin_REST_API;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\Payment_Gateway\\REST_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\REST_API' ) ) :
 
 /**
  * The payment gateway plugin REST API handler class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_3\REST_API
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API
  *
  * @since 5.2.0
  */
@@ -44,7 +44,7 @@ class REST_API extends Plugin_REST_API {
 	 *
 	 * Plugins can override this to add their own data.
 	 *
-	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_4_3\REST_API::get_system_status_data()
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API::get_system_status_data()
 	 *
 	 * @since 5.2.0
 	 *

--- a/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
+++ b/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
@@ -29,6 +29,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\Payment_Gateway\\REST_API' ) ) :
 
+
 /**
  * The payment gateway plugin REST API handler class.
  *
@@ -85,5 +86,6 @@ class REST_API extends Plugin_REST_API {
 
 
 }
+
 
 endif;

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -153,4 +153,5 @@ class REST_API {
 
 }
 
+
 endif;

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\REST_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API' ) ) :
 
 
 /**

--- a/woocommerce/utilities/class-sv-wp-async-request.php
+++ b/woocommerce/utilities/class-sv-wp-async-request.php
@@ -23,11 +23,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Async_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Async_Request' ) ) :
 
 /**
  * SkyVerge Wordpress Async Request class

--- a/woocommerce/utilities/class-sv-wp-async-request.php
+++ b/woocommerce/utilities/class-sv-wp-async-request.php
@@ -29,6 +29,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Async_Request' ) ) :
 
+
 /**
  * SkyVerge Wordpress Async Request class
  *
@@ -186,5 +187,6 @@ abstract class SV_WP_Async_Request {
 
 
 }
+
 
 endif;

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -23,11 +23,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Background_Job_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Background_Job_Handler' ) ) :
 
 /**
  * SkyVerge WordPress Background Job Handler class

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -29,6 +29,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Background_Job_Handler' ) ) :
 
+
 /**
  * SkyVerge WordPress Background Job Handler class
  *
@@ -1071,11 +1072,6 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 			$result = false;
 		}
 
-		// WC 2.6 has no positive message output by default
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt_3_0() && $result ) {
-			echo "<div class='updated inline'><p>{$this->debug_message}</p></div>";
-		}
-
 		return $result;
 	}
 
@@ -1121,4 +1117,5 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 
 }
 
-endif; // Class exists check
+
+endif;

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -28,6 +28,7 @@
 
  if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Job_Batch_Handler' ) ) :
 
+
 /**
  * The job batch handler class.
  *
@@ -304,5 +305,6 @@ class SV_WP_Job_Batch_Handler {
 
 
 }
+
 
 endif;

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
- namespace SkyVerge\WooCommerce\PluginFramework\v5_4_3;
+ namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
  defined( 'ABSPATH' ) or exit;
 
- if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\SV_WP_Job_Batch_Handler' ) ) :
+ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\SV_WP_Job_Batch_Handler' ) ) :
 
 /**
  * The job batch handler class.


### PR DESCRIPTION
# Summary

Drops WC < 3.0 and PHP < 5.6 backwards compatibility methods.

### Stories

* [ch17418](https://app.clubhouse.io/skyverge/story/17418/remove-wc-2-6-compatibility-code) Remove WC 2.6 Compatibility code
* [ch17414](https://app.clubhouse.io/skyverge/story/17414/add-global-wrappers-for-common-helper-methods) Add global wrappers for common helper methods ([no implementation](https://app.clubhouse.io/skyverge/story/17414/add-global-wrappers-for-common-helper-methods), see [wiki](https://github.com/skyverge/wc-plugin-framework/wiki/Class-aliases-and-template-functions) instead)
* [ch14044](https://app.clubhouse.io/skyverge/story/14044/add-helper-method-for-wc-get-template-that-passes-default-path-automatically) Adds `wc_get_template()` helper method in main plugin class

### Additional details

#### Global wrappers

We figured we could use class aliases defined such as `class_alias( SV_WC_Helper::class, 'WC_Plugin_Name_Helpers' );` inside each plugin that needs to use helper/compatibility functions inside template files or other places where namespaces aren't safe to use. Instead of defining these aliases inside the framework, they can be defined case by case by plugins that need them. See [ClubHouse discussion](https://app.clubhouse.io/skyverge/story/17414/add-global-wrappers-for-common-helper-methods#activity-17564).


#### Add `SV_WC_Plugin::load_template()`

Adds a `SV_WC_Plugin::load_template()` helper method that is a replacement for `wc_get_template()`. The method accepts a template part/name (string) and an optional array of arguments to pass to the template. Plugins can replace `wc_get_template()` with this method instead.

The main difference is that we pass automatically a default path argument to `wc_get_template()` which was requested by [Leho on Teams](https://github.com/skyverge/wc-memberships-addons/issues/67), plus in this way we can ensure consistency.

#### Deprecations

No methods have been removed in this version, however, there are several backwards compatibility methods meant for backporting WC 3.0 CRUD methods to WC 2.6 and below. Since we no longer support 2.6, these can be marked as `@deprecated` and a `wc_deprecated_function()` notice will be issued. By version 6.0 we should probably permanently remove deprecated methods. We can keep the `\WC_Data` handlers probably as it's possible that in future versions WC core will add some methods that we wish to backport (currently there's one for the order edit URL).

Plugins wishing to update to this version of the Framework will need to remove any usage of deprecated methods to avoid triggering notices.

### List of deprecated methods

See newly created [Deprecated methods](https://github.com/skyverge/wc-plugin-framework/wiki/Deprecated-methods) page on wiki.