### PR TITLE
[ch16778] [ch16779] Debug API endpoints

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.0-dev
+ * Feature - Add a `debug` endpoint to display or toggle the plugin debug mode and for any included gateways
+ * Feature - Add a `log` endpoint for accessing the plugin logs and those of any included gateways
  * Misc - Deprecate backwards compatibility methods for unsupported WooCommerce and PHP versions
 
 2019.09.05 - version 5.4.3

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -89,6 +89,9 @@ abstract class SV_WC_Plugin {
 	/** @var SV_WC_Admin_Notice_Handler the admin notice handler class */
 	private $admin_notice_handler;
 
+	/** @var string optional debug mode */
+	protected $debug_mode;
+
 
 	/**
 	 * Initialize the plugin.
@@ -907,6 +910,40 @@ abstract class SV_WC_Plugin {
 	 */
 	public function get_version() {
 		return $this->version;
+	}
+
+
+	/**
+	 * Gets the debug mode status.
+	 *
+	 * Child plugins can override this method and return an appropriate value.
+	 * @see SV_WC_Payment_Gateway::get_debug_mode() for individual gateways contained in a gateway plugin
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @return string normally one of 'off' or 'log'
+	 */
+	public function get_debug_mode() {
+
+		// returns 'log' by default as plugins may record general information to the log file like during upgrade routines
+		return ! is_string( $this->debug_mode ) ? 'log' : $this->debug_mode;
+	}
+
+
+	/**
+	 * Sets the debug mode.
+	 *
+	 * Provides a normalized method to set a debug mode in the plugin.
+	 * Child plugins can override and extend this method to update the plugin settings, or call internal methods to set the debug mode accordingly.
+	 * @see SV_WC_Payment_Gateway::set_debug_mode() for setting debug mode in individual gateways of a gateway plugin
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $mode normally one of 'off' or 'log'
+	 */
+	public function set_debug_mode( $mode ) {
+
+		$this->debug_mode = $mode;
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -934,16 +934,17 @@ abstract class SV_WC_Plugin {
 	 * Sets the debug mode.
 	 *
 	 * Provides a normalized method to set a debug mode in the plugin.
-	 * Child plugins can override and extend this method to update the plugin settings, or call internal methods to set the debug mode accordingly.
+	 * Child plugins can override and extend this method to update the plugin settings, or call internal methods to set a persistent debug mode accordingly.
 	 * @see SV_WC_Payment_Gateway::set_debug_mode() for setting debug mode in individual gateways of a gateway plugin
 	 *
 	 * @since 5.5.0-dev
 	 *
-	 * @param string $mode normally one of 'off' or 'log'
+	 * @param string $debug_mode normally one of 'off' or 'log'
+	 * @throws SV_WC_Plugin_Exception child implementations may choose to throw exception on errors or invalid input
 	 */
-	public function set_debug_mode( $mode ) {
+	public function set_debug_mode( $debug_mode ) {
 
-		$this->debug_mode = $mode;
+		$this->debug_mode = $debug_mode;
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -911,6 +911,30 @@ abstract class SV_WC_Plugin {
 
 
 	/**
+	 * Determines whether the debug mode is enabled or has a status.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string[]|string either 'enabled', 'disabled' (for loose checks) or specific debug mode status (or statuses)
+	 * @return bool
+	 */
+	public function is_debug_mode( $status ) {
+
+		$debug_mode = $this->get_debug_mode();
+
+		if ( 'enabled' === $status ) {
+			$is_debug_mode_status = $debug_mode && 'off' !== $debug_mode;
+		} elseif ( 'disabled' === $status ) {
+			$is_debug_mode_status = ! $debug_mode || 'off' === $debug_mode;
+		} else {
+			$is_debug_mode_status = is_array( $status ) ? in_array( $debug_mode, $status, true ) : $status === $debug_mode;
+		}
+
+		return $is_debug_mode_status;
+	}
+
+
+	/**
 	 * Gets the debug mode status.
 	 *
 	 * Child plugins can override this method and return an appropriate value.
@@ -936,10 +960,14 @@ abstract class SV_WC_Plugin {
 	 *
 	 * @since 5.5.0-dev
 	 *
-	 * @param string $debug_mode normally one of 'off' or 'log'
+	 * @param bool|string $debug_mode normally one of 'off' or 'log' (but the loose boolean value could also be interpreted by child plugins)
 	 * @throws SV_WC_Plugin_Exception child implementations may choose to throw exception on errors or invalid input
 	 */
 	public function set_debug_mode( $debug_mode ) {
+
+		if ( is_bool( $debug_mode ) ) {
+			$debug_mode = true === $debug_mode ? 'log' : 'off';
+		}
 
 		$this->debug_mode = $debug_mode;
 	}

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -918,22 +918,12 @@ abstract class SV_WC_Plugin {
 	 *
 	 * @since 5.5.0-dev
 	 *
-	 * @param string[]|string|bool|null a valid debug mode status
+	 * @param array|string|bool|null a valid debug mode status or multiple statuses to check
 	 * @return bool
 	 */
 	public function is_debug_mode( $status ) {
 
-		$debug_mode = $this->get_debug_mode();
-
-		if ( in_array( $status, [ true, 'on', 'enabled' ], true ) ) {
-			$is_debug_mode = 'on' === $debug_mode || 'enabled' === $debug_mode || true === (bool) $debug_mode;
-		} elseif ( in_array( $status, [ false, 'off', 'disabled' ], true ) ) {
-			$is_debug_mode = 'off' === $debug_mode || 'disabled' === $debug_mode || false === (bool) $debug_mode;
-		} else {
-			$is_debug_mode = is_array( $status ) ? in_array( $this->get_debug_mode(), $status, true ) : $status === $this->get_debug_mode();
-		}
-
-		return $is_debug_mode;
+		return is_array( $status ) ? in_array( $this->get_debug_mode(), $status, true ) : $status === $this->get_debug_mode();
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1192,20 +1192,16 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		}
 
 		// debug mode
-		$this->form_fields['debug_mode'] = array(
+		$this->form_fields['debug_mode'] = [
 			'title'   => esc_html__( 'Debug Mode', 'woocommerce-plugin-framework' ),
 			'type'    => 'select',
 			/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
 			'desc'    => sprintf( esc_html__( 'Show Detailed Error Messages and API requests/responses on the checkout page and/or save them to the %1$sdebug log%2$s', 'woocommerce-plugin-framework' ), '<a href="' . SV_WC_Helper::get_wc_log_file_url( $this->get_id() ) . '">', '</a>' ),
 			'default' => self::DEBUG_MODE_OFF,
-			'options' => array(
-				self::DEBUG_MODE_OFF      => esc_html__( 'Off', 'woocommerce-plugin-framework' ),
-				self::DEBUG_MODE_CHECKOUT => esc_html__( 'Show on Checkout Page', 'woocommerce-plugin-framework' ),
-				self::DEBUG_MODE_LOG      => esc_html__( 'Save to Log', 'woocommerce-plugin-framework' ),
-				/* translators: show debugging information on both checkout page and in the log */
-				self::DEBUG_MODE_BOTH     => esc_html__( 'Both', 'woocommerce-plugin-framework' ),
-			),
-		);
+		];
+		foreach ( $this->get_debug_modes() as $debug_mode => $debug_mode_label ) {
+			$this->form_fields['debug_mode']['options'][ $debug_mode ] = esc_html( $debug_mode_label );
+		}
 
 		// if there is more than just the production environment available
 		if ( count( $this->get_environments() ) > 1 ) {
@@ -4036,15 +4032,15 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		$debug_mode = $this->get_debug_mode();
 
-		if ( 'enabled' === $status ) {
-			$is_debug_mode_status = $debug_mode && self::DEBUG_MODE_OFF !== $debug_mode;
-		} elseif ( 'disabled' === $status ) {
-			$is_debug_mode_status = ! $debug_mode || self::DEBUG_MODE_OFF === $debug_mode;
+		if ( 'enabled' === $status || 'on' === $status ) {
+			$is_debug_mode = $debug_mode && self::DEBUG_MODE_OFF !== $debug_mode;
+		} elseif ( 'disabled' === $status || 'off' === $status ) {
+			$is_debug_mode = ! $debug_mode || self::DEBUG_MODE_OFF === $debug_mode;
 		} else {
-			$is_debug_mode_status = is_array( $status ) ? in_array( $debug_mode, $status, true ) : $status === $debug_mode;
+			$is_debug_mode = is_array( $status ) ? in_array( $debug_mode, $status, true ) : $status === $debug_mode;
 		}
 
-		return $is_debug_mode_status;
+		return $is_debug_mode;
 	}
 
 
@@ -4064,6 +4060,24 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
+	 * Gets a list of possible debug modes, with labels.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @return array
+	 */
+	public function get_debug_modes() {
+
+		return [
+			self::DEBUG_MODE_OFF      => __( 'Off', 'woocommerce-plugin-framework' ),
+			self::DEBUG_MODE_CHECKOUT => __( 'Show on Checkout Page', 'woocommerce-plugin-framework' ),
+			self::DEBUG_MODE_LOG      => __( 'Save to Log', 'woocommerce-plugin-framework' ),
+			self::DEBUG_MODE_BOTH     => _x( 'Both', 'Show debugging information on both checkout page and in the log', 'woocommerce-plugin-framework' ),
+		];
+	}
+
+
+	/**
 	 * Sets the gateway debug mode.
 	 *
 	 * @since 5.5.0-dev
@@ -4078,7 +4092,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			$debug_mode = true === $debug_mode ? self::DEBUG_MODE_LOG : self::DEBUG_MODE_OFF;
 		}
 
-		$debug_modes = [ self::DEBUG_MODE_LOG, self::DEBUG_MODE_CHECKOUT, self::DEBUG_MODE_BOTH, self::DEBUG_MODE_OFF ];
+		$debug_modes = array_keys( $this->get_debug_modes() );
 
 		if ( ! in_array( $debug_mode, $debug_modes, true ) ) {
 			throw new SV_WC_Plugin_Exception( sprintf(

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4025,6 +4025,30 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
+	 * Determines whether the debug mode is enabled or has a status.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string[]|string either 'enabled', 'disabled' (for loose checks) or specific debug mode status (or statuses)
+	 * @return bool
+	 */
+	public function is_debug_mode( $status ) {
+
+		$debug_mode = $this->get_debug_mode();
+
+		if ( 'enabled' === $status ) {
+			$is_debug_mode_status = $debug_mode && self::DEBUG_MODE_OFF !== $debug_mode;
+		} elseif ( 'disabled' === $status ) {
+			$is_debug_mode_status = ! $debug_mode || self::DEBUG_MODE_OFF === $debug_mode;
+		} else {
+			$is_debug_mode_status = is_array( $status ) ? in_array( $debug_mode, $status, true ) : $status === $debug_mode;
+		}
+
+		return $is_debug_mode_status;
+	}
+
+
+	/**
 	 * Gets the gateway current debug mode.
 	 *
 	 * @see SV_WC_Plugin::get_debug_mode() for the base plugin debug mode
@@ -4044,11 +4068,15 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 5.5.0-dev
 	 *
-	 * @param string $debug_mode debug mode expected value
+	 * @param bool|string $debug_mode debug mode expected value (but boolean is also accepted for off or log)
 	 * @throws SV_WC_Plugin_Exception if trying to set an unrecognized debug mode
 	 * @see SV_WC_Plugin::set_debug_mode() for setting the debug mode in the base plugin
 	 */
 	public function set_debug_mode( $debug_mode ) {
+
+		if ( is_bool( $debug_mode ) ) {
+			$debug_mode = true === $debug_mode ? self::DEBUG_MODE_LOG : self::DEBUG_MODE_OFF;
+		}
 
 		$debug_modes = [ self::DEBUG_MODE_LOG, self::DEBUG_MODE_CHECKOUT, self::DEBUG_MODE_BOTH, self::DEBUG_MODE_OFF ];
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4019,35 +4019,81 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Returns true if all debugging is disabled
+	 * Gets the gateway current debug mode.
+	 *
+	 * @see SV_WC_Plugin::get_debug_mode() for the base plugin debug mode
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_debug_mode() {
+
+		return is_string( $this->debug_mode ) ? $this->debug_mode : self::DEBUG_MODE_OFF;
+	}
+
+
+	/**
+	 * Sets the gateway debug mode.
+	 *
+	 * @see SV_WC_Plugin::set_debug_mode() for setting the debug mode in the base plugin
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $mode debug mode expected value
+	 */
+	public function set_debug_mode( $mode ) {
+
+		if ( in_array( $mode, [ self::DEBUG_MODE_LOG, self::DEBUG_MODE_CHECKOUT, self::DEBUG_MODE_BOTH, self::DEBUG_MODE_OFF ], true ) ) {
+
+			$this->debug_mode = $mode;
+
+			$settings = get_option( $this->get_option_key() );
+
+			$settings['debug_mode'] = $this->debug_mode;
+
+			update_option( $this->get_option_key(), $settings );
+		}
+	}
+
+
+	/**
+	 * Checks if all debugging is disabled.
 	 *
 	 * @since 1.0.0
-	 * @return boolean if all debuging is disabled
+	 *
+	 * @return bool
 	 */
 	public function debug_off() {
+
 		return self::DEBUG_MODE_OFF === $this->debug_mode;
 	}
 
 
 	/**
-	 * Returns true if debug logging is enabled
+	 * Checks whether debug logging is enabled.
 	 *
 	 * @since 1.0.0
-	 * @return boolean if debug logging is enabled
+	 *
+	 * @return bool
 	 */
 	public function debug_log() {
+
 		return self::DEBUG_MODE_LOG === $this->debug_mode || self::DEBUG_MODE_BOTH === $this->debug_mode;
 	}
 
 
 	/**
-	 * Returns true if checkout debugging is enabled.  This will cause debugging
-	 * statements to be displayed on the checkout/pay pages
+	 * Determines if checkout debug logging is enabled.
+	 *
+	 * Checkout debug will cause debugging statements to be displayed on the checkout/pay pages.
 	 *
 	 * @since 1.0.0
-	 * @return boolean if checkout debugging is enabled
+	 *
+	 * @return bool
 	 */
 	public function debug_checkout() {
+
 		return self::DEBUG_MODE_CHECKOUT === $this->debug_mode || self::DEBUG_MODE_BOTH === $this->debug_mode;
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4036,24 +4036,32 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/**
 	 * Sets the gateway debug mode.
 	 *
-	 * @see SV_WC_Plugin::set_debug_mode() for setting the debug mode in the base plugin
-	 *
 	 * @since 5.5.0-dev
 	 *
-	 * @param string $mode debug mode expected value
+	 * @param string $debug_mode debug mode expected value
+	 * @throws SV_WC_Plugin_Exception if trying to set an unrecognized debug mode
+	 * @see SV_WC_Plugin::set_debug_mode() for setting the debug mode in the base plugin
 	 */
-	public function set_debug_mode( $mode ) {
+	public function set_debug_mode( $debug_mode ) {
 
-		if ( in_array( $mode, [ self::DEBUG_MODE_LOG, self::DEBUG_MODE_CHECKOUT, self::DEBUG_MODE_BOTH, self::DEBUG_MODE_OFF ], true ) ) {
+		$debug_modes = [ self::DEBUG_MODE_LOG, self::DEBUG_MODE_CHECKOUT, self::DEBUG_MODE_BOTH, self::DEBUG_MODE_OFF ];
 
-			$this->debug_mode = $mode;
-
-			$settings = get_option( $this->get_option_key() );
-
-			$settings['debug_mode'] = $this->debug_mode;
-
-			update_option( $this->get_option_key(), $settings );
+		if ( ! in_array( $debug_mode, $debug_modes, true ) ) {
+			throw new SV_WC_Plugin_Exception( sprintf(
+				/* translators: Placeholder: %1$s - debug mode identifier, %2$s - list of valid debug modes */
+				__( 'Invalid debug mode %1$s. Must be one of: %2$s.', 'woocommerce-plugin-framework' ),
+				is_string( $debug_mode ) ? $debug_mode : gettype( $debug_mode ),
+				implode( ', ', $debug_modes )
+			) );
 		}
+
+		$this->debug_mode = $debug_mode;
+
+		$settings = get_option( $this->get_option_key() );
+
+		$settings['debug_mode'] = $this->debug_mode;
+
+		update_option( $this->get_option_key(), $settings );
 	}
 
 

--- a/woocommerce/rest-api/Debug_Controller.php
+++ b/woocommerce/rest-api/Debug_Controller.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Payment_Gateway;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Payment_Gateway_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin_Exception;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Debug_Controller' ) ) :
+
+/**
+ * The plugin REST API Debug endpoint.
+ *
+ * @since 5.5.0-dev
+ */
+abstract class Debug_Controller extends \WC_REST_Controller {
+
+
+	/** @var SV_WC_Plugin main instance */
+	private $plugin;
+
+	/** @var string endpoint namespace */
+	protected $namespace;
+
+	/** @var string the route base */
+	protected $rest_base;
+
+
+	/**
+	 * Debug controller constructor.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param SV_WC_Plugin $plugin main instance
+	 */
+	public function __construct( SV_WC_Plugin $plugin ) {
+
+		$this->plugin    = $plugin;
+		$this->namespace = 'wc/v1';
+		$this->rest_base = $plugin->get_id();
+	}
+
+
+	/**
+	 * Registers the routes for the plugin debug endpoint.
+	 *
+	 * @since 5.5.0-dev
+	 */
+	public function register_routes() {
+
+		// endpoint: 'wc/v<n>/<plugin_id>/debug/'
+		register_rest_route( $this->namespace, "/{$this->rest_base}/debug", [
+			// GET the debug mode status
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				/* @see \WC_REST_Controller::get_item() */
+				'callback'            => [ $this, 'get_item' ],
+				/* @see \WC_REST_Controller::get_item_permissions_check() */
+				'permission_callback' => [ $this, 'get_item_permissions_check' ],
+			],
+			// UPDATE (toggle) the debug mode
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				/** @see \WC_REST_Controller::update_item() */
+				'callback'            => [ $this, 'update_item' ],
+				/** @see \WC_REST_Controller::update_item_permissions_check() */
+				'permission_callback' => [ $this, 'update_item_permissions_check' ],
+			),
+		], true );
+	}
+
+
+	/**
+	 * Determines if a given request has access to read the plugin debug mode status.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return true|\WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new \WP_Error( 'wc_' . $this->get_plugin()->get_id() . '_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'wc-plugin-framework' ), [ 'status' => rest_authorization_required_code() ] );
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Gets the plugin debug mode status.
+	 *
+	 * @since 5.5.0-dev.1
+	 *
+	 * @param \WP_REST_Request $request API request
+	 * @return \WP_Error|\WP_REST_Response API response
+	 */
+	public function get_item( $request ) {
+
+		$plugin     = $this->get_plugin();
+		$debug_mode = [
+			'plugin' => $plugin->get_debug_mode(),
+		];
+
+		if ( $plugin instanceof SV_WC_Payment_Gateway_Plugin ) {
+			foreach ( $plugin->get_gateways() as $gateway ) {
+				$debug_mode[ $gateway->get_id() ] = $gateway->get_debug_mode();
+			}
+		}
+
+		return rest_ensure_response( [
+			'debug_mode' => $debug_mode,
+			'debug_log'  => defined( 'WC_LOG_HANDLER' ) ? WC_LOG_HANDLER: 'file',
+		] );
+	}
+
+
+	/**
+	 * Determines if a given request has rights to enable or disable the plugin debug mode.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return true|\WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new \WP_Error( 'wc_' . $this->get_plugin()->get_id() . '_rest_cannot_update', __( 'Sorry, you cannot update resources.', 'wc-plugin-framework' ), [ 'status' => rest_authorization_required_code() ] );
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Gets the plugin debug mode status.
+	 *
+	 * @since 5.5.0-dev.1
+	 *
+	 * @param \WP_REST_Request $request API request
+	 * @return \WP_Error|\WP_REST_Response API response
+	 */
+	public function update_item( $request ) {
+
+		try {
+
+			$plugin    = $this->get_plugin();
+			$plugin_id = $plugin->get_id();
+
+			if ( empty( $request['debug_mode'] ) || ! is_array( $request['debug_mode'] ) ) {
+				throw new \WC_REST_Exception( "woocommerce_rest_invalid_{$plugin_id}_debug_mode", __( 'Invalid debug mode data.', 'woocommerce-plugin-framework' ), 404 );
+			}
+
+			$mode = $request['debug_mode'];
+
+			try {
+
+				if ( isset( $mode['plugin'] ) ) {
+					$plugin->set_debug_mode( $mode['plugin'] );
+				}
+
+				if ( $plugin instanceof SV_WC_Payment_Gateway_Plugin ) {
+
+					foreach ( $plugin->get_gateways() as $gateway ) {
+
+						if ( array_key_exists( $gateway->get_id(), $mode ) ) {
+
+							$gateway->set_debug_mode( $mode[ $gateway->get_id() ] );
+						}
+					}
+				}
+
+			} catch ( \Exception $e ) {
+
+				throw new \WC_REST_Exception( "woocommerce_rest_{$plugin_id}_set_debug_mode_error", sprintf( __( 'Error while setting debug mode: %s', 'woocommerce-plugin-framework' ), $e->getMessage() ), 404 );
+			}
+
+			$response = $this->get_item( $request );
+
+		} catch ( \WC_REST_Exception $e ) {
+
+			$response = new \WP_Error( $e->getErrorCode(), $e->getMessage(), $e->getErrorData() );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+
+	/**
+	 * Gets the main plugin instance.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @return SV_WC_Plugin|SV_WC_Payment_Gateway_Plugin
+	 */
+	protected function get_plugin() {
+
+		return $this->plugin;
+	}
+
+
+}
+
+endif;

--- a/woocommerce/rest-api/Debug_Controller.php
+++ b/woocommerce/rest-api/Debug_Controller.php
@@ -125,10 +125,10 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 		$plugin     = $this->get_plugin();
 		$plugin_id  = $plugin->get_id();
 		$debug_mode = [
-			'plugin' => [
-				'debug_mode_enabled' => $plugin->is_debug_mode( 'enabled' ),
-				'debug_mode_status'  => $plugin->get_debug_mode(),
-			],
+			'debug_mode_enabled' => $plugin->is_debug_mode( 'enabled' ),
+			'debug_mode_status'  => $plugin->get_debug_mode(),
+			'debug_modes'        => $plugin->get_debug_modes(),
+			'gateways'           => null,
 		];
 
 		if ( $plugin instanceof SV_WC_Payment_Gateway_Plugin ) {
@@ -141,6 +141,7 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 
 				$debug_mode['gateways'][ $gateway_id ]['debug_mode_enabled'] = $gateway->is_debug_mode( 'enabled' );
 				$debug_mode['gateways'][ $gateway_id ]['debug_mode_status']  = $gateway->get_debug_mode();
+				$debug_mode['gateways'][ $gateway_id ]['debug_modes']        = $gateway->get_debug_modes();
 			}
 		}
 

--- a/woocommerce/rest-api/Debug_Controller.php
+++ b/woocommerce/rest-api/Debug_Controller.php
@@ -174,15 +174,15 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 
 		try {
 
-			$plugin    = $this->get_plugin();
-			$plugin_id = $plugin->get_id();
-			$params    = $request->get_params();
+			$plugin     = $this->get_plugin();
+			$plugin_id  = $plugin->get_id();
+			$params     = $request->get_params();
 
-			if ( empty( $params['debug_mode'] ) || ! is_array( $params['debug_mode'] ) ) {
-				throw new \WC_REST_Exception( "woocommerce_rest_invalid_{$plugin_id}_debug_mode", __( 'Invalid or missing debug mode.', 'woocommerce-plugin-framework' ), 404 );
+			if ( empty( $params['debug_mode'] ) ) {
+				throw new \WC_REST_Exception( "woocommerce_rest_missing_{$plugin_id}_debug_mode", __( 'Missing debug mode parameter.', 'woocommerce-plugin-framework' ), 404 );
 			}
 
-			$debug_mode = $params['debug_mode'];
+			$debug_mode = (array) $params['debug_mode'];
 
 			try {
 

--- a/woocommerce/rest-api/Debug_Controller.php
+++ b/woocommerce/rest-api/Debug_Controller.php
@@ -126,7 +126,8 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 		$plugin_id  = $plugin->get_id();
 		$debug_mode = [
 			'plugin' => [
-				$plugin_id => $plugin->get_debug_mode(),
+				'debug_mode_enabled' => $plugin->is_debug_mode( 'enabled' ),
+				'debug_mode_status'  => $plugin->get_debug_mode(),
 			],
 		];
 
@@ -136,7 +137,10 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 
 			foreach ( $plugin->get_gateways() as $gateway ) {
 
-				$debug_mode['gateways'][ $gateway->get_id() ] = $gateway->get_debug_mode();
+				$gateway_id = $gateway->get_id();
+
+				$debug_mode['gateways'][ $gateway_id ]['debug_mode_enabled'] = $gateway->is_debug_mode( 'enabled' );
+				$debug_mode['gateways'][ $gateway_id ]['debug_mode_status']  = $gateway->get_debug_mode();
 			}
 		}
 
@@ -197,11 +201,11 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 
 			try {
 
-				if ( isset( $debug_mode['plugin'][ $plugin_id ] ) ) {
-					$plugin->set_debug_mode( $debug_mode['plugin'][ $plugin_id ] );
+				if ( isset( $debug_mode['plugin'] ) ) {
+					$plugin->set_debug_mode( $debug_mode['plugin'] );
 				}
 
-				if (  $plugin instanceof SV_WC_Payment_Gateway_Plugin && isset( $debug_mode['gateways'] ) ) {
+				if ( $plugin instanceof SV_WC_Payment_Gateway_Plugin && isset( $debug_mode['gateways'] ) ) {
 
 					foreach ( $plugin->get_gateways() as $gateway ) {
 

--- a/woocommerce/rest-api/Debug_Controller.php
+++ b/woocommerce/rest-api/Debug_Controller.php
@@ -127,7 +127,7 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 		$debug_mode = [
 			'debug_mode_enabled' => $plugin->is_debug_mode( 'enabled' ),
 			'debug_mode_status'  => $plugin->get_debug_mode(),
-			'debug_modes'        => $plugin->get_debug_modes(),
+			'debug_modes'        => array_keys( $plugin->get_debug_modes() ),
 			'gateways'           => null,
 		];
 
@@ -141,7 +141,7 @@ abstract class Debug_Controller extends \WC_REST_Controller {
 
 				$debug_mode['gateways'][ $gateway_id ]['debug_mode_enabled'] = $gateway->is_debug_mode( 'enabled' );
 				$debug_mode['gateways'][ $gateway_id ]['debug_mode_status']  = $gateway->get_debug_mode();
-				$debug_mode['gateways'][ $gateway_id ]['debug_modes']        = $gateway->get_debug_modes();
+				$debug_mode['gateways'][ $gateway_id ]['debug_modes']        = array_keys( $gateway->get_debug_modes() );
 			}
 		}
 

--- a/woocommerce/rest-api/Log_Controller.php
+++ b/woocommerce/rest-api/Log_Controller.php
@@ -243,13 +243,14 @@ abstract class Log_Controller extends \WC_REST_Controller {
 				continue;
 			}
 
-			$log_contents = file_get_contents( trailingslashit( $log_dir ) . $log_file );
+			$log_file     = trailingslashit( $log_dir ) . $log_file;
+			$log_contents = file_get_contents( $log_file );
 			$log_files[]  = [
 				'type'       => 'file',
 				'source'     => basename( $log_file ),
-				'level'      => 300,
+				'level'      => \WC_Log_Levels::get_level_severity( \WC_Log_Levels::NOTICE ),
 				'contents'   => $log_contents ?: '',
-				'updated_at' => date( 'Y-m-d\TH:i:s\Z', (int) filemtime( $file_path ) ),
+				'updated_at' => date( 'Y-m-d\TH:i:s\Z', (int) filemtime( $log_file ) ),
 			];
 		}
 

--- a/woocommerce/rest-api/Log_Controller.php
+++ b/woocommerce/rest-api/Log_Controller.php
@@ -257,8 +257,11 @@ abstract class Log_Controller extends \WC_REST_Controller {
 				continue;
 			}
 
+			// log files are considered notice-level logs by WooCommerce
+			$default_log_level = \WC_Log_Levels::get_level_severity( \WC_Log_Levels::NOTICE );
+
 			// optionally filter by level
-			if ( $log_level && ( ( is_int( $log_level ) && $log_level !== 300 ) || ( is_array( $log_level ) && ! in_array( 300, $log_level, true ) ) ) ) {
+			if ( $log_level && ( ( is_int( $log_level ) && $log_level !== $default_log_level ) || ( is_array( $log_level ) && ! in_array( $default_log_level, $log_level, true ) ) ) ) {
 				continue;
 			}
 
@@ -267,7 +270,7 @@ abstract class Log_Controller extends \WC_REST_Controller {
 			$log_files[]  = [
 				'type'       => 'file',
 				'source'     => basename( $log_file ),
-				'level'      => \WC_Log_Levels::get_level_severity( \WC_Log_Levels::NOTICE ),
+				'level'      => $default_log_level,
 				'contents'   => $log_contents ?: '',
 				'updated_at' => date( 'Y-m-d\TH:i:s\Z', (int) filemtime( $log_file ) ),
 			];

--- a/woocommerce/rest-api/Log_Controller.php
+++ b/woocommerce/rest-api/Log_Controller.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Payment_Gateway_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Log_Controller' ) ) :
+
+/**
+ * The plugin REST API Debug endpoint.
+ *
+ * @since 5.5.0-dev
+ */
+abstract class Log_Controller extends \WC_REST_Controller {
+
+
+	/** @var SV_WC_Plugin main instance */
+	private $plugin;
+
+	/** @var string endpoint namespace */
+	protected $namespace;
+
+	/** @var string the route base */
+	protected $rest_base;
+
+
+	/**
+	 * Debug controller constructor.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param SV_WC_Plugin $plugin main instance
+	 */
+	public function __construct( SV_WC_Plugin $plugin ) {
+
+		$this->plugin    = $plugin;
+		$this->namespace = 'wc/v1';
+		$this->rest_base = $plugin->get_id();
+	}
+
+
+	/**
+	 * Registers the routes for the plugin debug endpoint.
+	 *
+	 * @since 5.5.0-dev
+	 */
+	public function register_routes() {
+
+		// endpoint: 'wc/v<n>/<plugin_id>/log/'
+		register_rest_route( $this->namespace, "/{$this->rest_base}/log", [
+			// GET the plugin logs
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				/* @see \WC_REST_Controller::get_items() */
+				'callback'            => [ $this, 'get_items' ],
+				/* @see \WC_REST_Controller::get_items_permissions_check() */
+				'permission_callback' => [ $this, 'get_items_permissions_check' ],
+			]
+		], true );
+	}
+
+
+	/**
+	 * Determines if a given request has access to read the plugin logs.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return true|\WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new \WP_Error( 'wc_' . $this->get_plugin()->get_id() . '_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-plugin-framework' ), [ 'status' => rest_authorization_required_code() ] );
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Gets the plugin logs.
+	 *
+	 * @since 5.5.0-dev.1
+	 *
+	 * @param \WP_REST_Request $request API request
+	 * @return \WP_Error|\WP_REST_Response API response
+	 */
+	public function get_items( $request ) {
+
+		$params   = $request->get_params();
+		$log_src  = isset( $params['source'] ) ? $params['source'] : null;
+		$log_date = null;
+
+		if ( isset( $params['date'] ) && preg_match( '/\d{4}-\d{2}-\d{2}/', $params['date'] ) ) {
+			$log_date = $params['date'];
+		}
+
+		try {
+
+			$response  = [];
+			$plugin    = $this->get_plugin();
+			$plugin_id = $plugin->get_id();
+
+			if ( defined( 'WC_LOG_HANDLER' ) && 'WC_Log_Handler_DB' === WC_LOG_HANDLER ) {
+
+				// TODO add support for log handler database logs {FN 2019-09-17}
+
+			} else {
+
+				$file_path = \WC_Log_Handler_File::get_log_file_path( $plugin->get_id() );
+
+				if ( ! $file_path ) {
+					throw new \WC_REST_Exception( "woocommerce_rest_{$plugin_id}_log_file_not_found", __( 'The resource does not exist.', 'woocommerce-plugin-framework' ), 404 );
+				}
+
+				$log_files = preg_grep( '~^' . $plugin->get_id() . '-.*\.php$~', scandir( $file_path ) );
+
+				foreach ( $log_files as $log_file ) {
+
+					if ( ( $log_src && $log_src !== $plugin_id ) || ( is_string( $log_date ) && false === strpos( $log_file, $log_date ) ) ) {
+						continue;
+					}
+
+					$response[ $plugin_id ][] = [
+						'type'       => 'file',
+						'origin'     => basename( $log_file ),
+						'contents'   => file_get_contents( $log_file ) ?: '',
+						'updated_at' => date( 'Y-m-d\TH:i:s\Z', filemtime( $file_path ) ),
+					];
+				}
+
+				if ( $plugin instanceof SV_WC_Payment_Gateway_Plugin ) {
+
+					foreach ( $plugin->get_gateways() as $gateway ) {
+
+						$gateway_id = $gateway->get_id();
+
+						if ( $log_src && $log_src !== $gateway_id ) {
+							continue;
+						}
+
+						$file_path = \WC_Log_Handler_File::get_log_file_path( $gateway_id );
+
+						if ( ! $file_path ) {
+							throw new \WC_REST_Exception( "woocommerce_rest_{$plugin_id}_{$gateway_id}_log_file_not_found", __( 'The resource does not exist.', 'woocommerce-plugin-framework' ), 404 );
+						}
+
+						$log_files = preg_grep( '~^' . $gateway_id . '-.*\.php$~', scandir( $file_path ) );
+
+						foreach ( $log_files as $log_file ) {
+
+							if ( is_string( $log_date ) && false === strpos( $log_file, $log_date ) ) {
+								continue;
+							}
+
+							$response[ $gateway_id ][] = [
+								'type'       => 'file',
+								'origin'     => basename( $log_file ),
+								'contents'   => file_get_contents( $log_file ) ?: '',
+								'updated_at' => date( 'Y-m-d\TH:i:s\Z', filemtime( $file_path ) ),
+							];
+						}
+					}
+				}
+			}
+
+		} catch ( \WC_REST_Exception $e ) {
+
+			$response = new \WP_Error( $e->getErrorCode(), $e->getMessage(), $e->getErrorData() );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+
+	/**
+	 * Gets the main plugin instance.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @return SV_WC_Plugin|SV_WC_Payment_Gateway_Plugin
+	 */
+	protected function get_plugin() {
+
+		return $this->plugin;
+	}
+
+
+}
+
+endif;

--- a/woocommerce/rest-api/Log_Controller.php
+++ b/woocommerce/rest-api/Log_Controller.php
@@ -314,12 +314,11 @@ abstract class Log_Controller extends \WC_REST_Controller {
 
 				$upload_url       = trailingslashit( $upload_dir['baseurl'] );
 				$upload_url_parts = explode( '/', $upload_url );
-				$wc_log_dir_parts = explode( '/', WC_LOG_DIR );
 				$shared_path      = '';
 
-				foreach ( $wc_log_dir_parts as $part ) {
+				foreach ( explode( '/', WC_LOG_DIR ) as $part ) {
 					if ( $part && in_array( $part, $upload_url_parts, false ) ) {
-						$shared_path   .= $part . '/';
+						$shared_path .= $part . '/';
 					}
 				}
 
@@ -333,7 +332,7 @@ abstract class Log_Controller extends \WC_REST_Controller {
 						$log_file_url = $upload_url;
 
 						foreach ( explode( '/', $relative_path ) as $part ) {
-							if ( ! in_array( $part, $upload_url_parts, false ) ) {
+							if ( $part && ! in_array( $part, $upload_url_parts, false ) ) {
 								$log_file_url .= $part . '/';
 							}
 						}

--- a/woocommerce/rest-api/Log_Controller.php
+++ b/woocommerce/rest-api/Log_Controller.php
@@ -172,8 +172,12 @@ abstract class Log_Controller extends \WC_REST_Controller {
 			$log_date = $params['date'];
 		}
 
-		if ( isset( $params['level'] ) && is_numeric( $params['level'] ) ) {
-			$log_level = (int) $params['level'];
+		if ( isset( $params['level'] ) && $params['level'] ) {
+			if ( is_numeric( $params['level'] ) ) {
+				$log_level = (int) $params['level'];
+			} else {
+				$log_level = array_map( 'absint', (array) $params['level'] );
+			}
 		}
 
 		$log_table = "{$wpdb->prefix}woocommerce_log";
@@ -185,8 +189,13 @@ abstract class Log_Controller extends \WC_REST_Controller {
 
 		foreach ( $log_rows as $log_entry ) {
 
-			// optionally filter by log level or date
-			if ( ( $log_level && (int) $log_entry->level !== $log_level ) || ( $log_date && 0 === strpos( $log_entry->timestamp, $log_date ) ) ) {
+			// optionally filter by date
+			if ( $log_date && 0 === strpos( $log_entry->timestamp, $log_date ) ) {
+				continue;
+			}
+
+			// optionally filter by level
+			if ( $log_level && ( ( is_int( $log_level ) && $log_level !== (int) $log_entry->level ) || ( is_array( $log_level ) && ! in_array( (int) $log_entry->level, $log_level, true ) ) ) ) {
 				continue;
 			}
 
@@ -224,8 +233,12 @@ abstract class Log_Controller extends \WC_REST_Controller {
 			$log_date = $params['date'];
 		}
 
-		if ( isset( $params['level'] ) && is_numeric( $params['level'] ) ) {
-			$log_level = (int) $params['level'];
+		if ( isset( $params['level'] ) && $params['level'] ) {
+			if ( is_numeric( $params['level'] ) ) {
+				$log_level = (int) $params['level'];
+			} else {
+				$log_level = array_map( 'absint', (array) $params['level'] );
+			}
 		}
 
 		$log_file_path = \WC_Log_Handler_File::get_log_file_path( $log_id );
@@ -239,7 +252,13 @@ abstract class Log_Controller extends \WC_REST_Controller {
 
 		foreach ( $found_files as $log_file ) {
 
-			if ( ( $log_level && 300 !== $log_level ) || ( $log_date && false !== strpos( $log_file, $log_date ) ) ) {
+			// optionally filter by date
+			if ( $log_date && false !== strpos( $log_file, $log_date ) ) {
+				continue;
+			}
+
+			// optionally filter by level
+			if ( $log_level && ( ( is_int( $log_level ) && $log_level !== 300 ) || ( is_array( $log_level ) && ! in_array( 300, $log_level, true ) ) ) ) {
 				continue;
 			}
 

--- a/woocommerce/rest-api/Log_Controller.php
+++ b/woocommerce/rest-api/Log_Controller.php
@@ -127,7 +127,7 @@ abstract class Log_Controller extends \WC_REST_Controller {
 				$get_logs_method = 'get_log_files';
 			}
 
-			$response['plugin'] = $this->$get_logs_method( $plugin_id, $params );
+			$response['plugin'][ $plugin_id ] = $this->$get_logs_method( $plugin_id, $params );
 
 			if ( $plugin instanceof SV_WC_Payment_Gateway_Plugin ) {
 
@@ -146,7 +146,15 @@ abstract class Log_Controller extends \WC_REST_Controller {
 			$response = new \WP_Error( $e->getErrorCode(), $e->getMessage(), $e->getErrorData() );
 		}
 
-		return rest_ensure_response( $response );
+		/**
+		 * Filters the REST API response for the log endpoint.
+		 *
+		 * @since 5.5.0-dev
+		 *
+		 * @param \WP_Error|array $response_data associative array of log data
+		 * @param \WP_REST_Request $request request object
+		 */
+		return rest_ensure_response( apply_filters( "wc_{$plugin_id}_rest_api_logs_data", $response, $request ) );
 	}
 
 

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -26,8 +26,6 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\Debug_Controller;
 use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\Log_Controller;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\v3\Debug;
-use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\v3\Controller;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -48,8 +46,8 @@ class REST_API {
 	/** @var SV_WC_Plugin plugin instance */
 	private $plugin;
 
-	/** @var array associative array of supported framework endpoints for given API versions */
-	private $supports = [];
+	/** @var array associative array of REST API endpoints and supported WooCommerce REST API versions added by the framework */
+	private $endpoints;
 
 	/** @var Debug_Controller[] debug endpoint handlers according to supported API version in use */
 	private $debug_controller = [];
@@ -67,7 +65,15 @@ class REST_API {
 	 */
 	public function __construct( SV_WC_Plugin $plugin ) {
 
-		$this->plugin = $plugin;
+		$this->plugin    = $plugin;
+		$this->endpoints = [
+			'debug' => [
+				'v3',
+			],
+			'log'   => [
+				'v3',
+			],
+		];
 
 		$this->add_hooks();
 	}
@@ -148,11 +154,7 @@ class REST_API {
 	 */
 	public function register_routes() {
 
-		foreach ( $this->supports as $endpoint => $versions ) {
-
-			if ( ! is_array( $versions ) ) {
-				continue;
-			}
+		foreach ( $this->endpoints as $endpoint => $versions ) {
 
 			foreach ( $versions as $version ) {
 
@@ -179,17 +181,15 @@ class REST_API {
 	 */
 	public function get_debug_controller_instance( $api_version = 'v3' ) {
 
-		$supported_versions = [ 'v3' ];
-
-		if ( in_array( $api_version, $supported_versions, true ) ) {
+		if ( ! in_array( $api_version, $this->endpoints['debug'], true ) ) {
 			return null;
 		}
 
-		if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Debug_Controller' ) ) {
-			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/Debug_Controller.php' );
-		}
-
 		if ( ! isset( $this->debug_controller[ $api_version ] ) ) {
+
+			if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Debug_Controller' ) ) {
+				require_once( $this->get_plugin()->get_framework_path() . '/rest-api/Debug_Controller.php' );
+			}
 
 			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Debug.php' );
 
@@ -212,17 +212,15 @@ class REST_API {
 	 */
 	public function get_log_controller_instance( $api_version = 'v3' ) {
 
-		$supported_versions = [ 'v3' ];
-
-		if ( in_array( $api_version, $supported_versions, true ) ) {
+		if ( ! in_array( $api_version, $this->endpoints['log'], true ) ) {
 			return null;
 		}
 
-		if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Log_Controller' ) ) {
-			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/Log_Controller.php' );
-		}
-
 		if ( ! isset( $this->log_controller[ $api_version ] ) ) {
+
+			if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Log_Controller' ) ) {
+				require_once( $this->get_plugin()->get_framework_path() . '/rest-api/Log_Controller.php' );
+			}
 
 			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Log.php' );
 

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -47,7 +47,7 @@ class REST_API {
 	private $plugin;
 
 	/** @var array associative array of REST API endpoints and supported WooCommerce REST API versions added by the framework */
-	private $endpoints;
+	protected $endpoints;
 
 	/** @var Debug_Controller[] debug endpoint handlers according to supported API version in use */
 	private $debug_controller = [];

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -29,7 +29,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\Log_Controller;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_4_3\\REST_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API' ) ) :
 
 
 /**

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -230,14 +230,14 @@ class REST_API {
 			$debug_class_abstract_name = $this->get_debug_controller_class_name();
 			$debug_class_abstract_path = $this->get_debug_controller_class_path();
 
-			if ( ! class_exists( $debug_class_abstract_name ) ) {
+			if ( ! class_exists( $debug_class_abstract_name, false ) ) {
 				require_once( $debug_class_abstract_path );
 			}
 
 			$debug_class_name = $this->get_debug_controller_class_name( $api_version );
 			$debug_class_path = $this->get_debug_controller_class_path( $api_version );
 
-			if ( ! class_exists( $debug_class_name ) ) {
+			if ( ! class_exists( $debug_class_name, false ) ) {
 				require_once( $debug_class_path );
 			}
 
@@ -307,14 +307,14 @@ class REST_API {
 			$log_class_abstract_name = $this->get_log_controller_class_name();
 			$log_class_abstract_path = $this->get_log_controller_class_path();
 
-			if ( ! class_exists( $log_class_abstract_name ) ) {
+			if ( ! class_exists( $log_class_abstract_name, false ) ) {
 				require_once( $log_class_abstract_path );
 			}
 
 			$log_class_name = $this->get_log_controller_class_name( $api_version );
 			$log_class_path = $this->get_log_controller_class_path( $api_version );
 
-			if ( ! class_exists( $log_class_name ) ) {
+			if ( ! class_exists( $log_class_name, false ) ) {
 				require_once( $log_class_path );
 			}
 

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -193,7 +193,7 @@ class REST_API {
 
 			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Debug.php' );
 
-			$controller = $api_version . '\\Debug';
+			$controller = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\' . $api_version . '\\Debug';
 
 			$this->debug_controller[ $api_version ] = new $controller( $this->get_plugin() );
 		}
@@ -224,7 +224,7 @@ class REST_API {
 
 			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Log.php' );
 
-			$controller = $api_version . '\\Log';
+			$controller = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\' . $api_version . '\\Log';
 
 			$this->log_controller[ $api_version ] = new $controller( $this->get_plugin() );
 		}

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -172,11 +172,51 @@ class REST_API {
 
 
 	/**
+	 * Gets the debug controller class name.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string|null $api_version API version, or null for abstract
+	 * @return string
+	 */
+	protected function get_debug_controller_class_name( $api_version = null ) {
+
+		if ( null === $api_version ) {
+			$class_name = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Debug_Controller';
+		} else {
+			$class_name = "\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\{$api_version}\\Debug_Controller";
+		}
+
+		return $class_name;
+	}
+
+
+	/**
+	 * Gets the debug controller class path.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string|null $api_version API version, or null for abstract
+	 * @return string
+	 */
+	protected function get_debug_controller_class_path( $api_version = null ) {
+
+		if ( null === $api_version ) {
+			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/Debug_Controller.php';
+		} else {
+			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Debug_Controller.php';
+		}
+
+		return $class_path;
+	}
+
+
+	/**
 	 * Gets the debug controller endpoint handler instance.
 	 *
 	 * @since 5.5.0-dev
 	 *
-	 * @param string $api_version API version for the controller to be returned
+	 * @param string $api_version API version for the controller to be returned (default: latest supported)
 	 * @return null|Debug_Controller
 	 */
 	public function get_debug_controller_instance( $api_version = 'v3' ) {
@@ -187,18 +227,64 @@ class REST_API {
 
 		if ( ! isset( $this->debug_controller[ $api_version ] ) ) {
 
-			if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Debug_Controller' ) ) {
-				require_once( $this->get_plugin()->get_framework_path() . '/rest-api/Debug_Controller.php' );
+			$debug_class_abstract_name = $this->get_debug_controller_class_name();
+			$debug_class_abstract_path = $this->get_debug_controller_class_path();
+
+			if ( ! class_exists( $debug_class_abstract_name ) ) {
+				require_once( $debug_class_abstract_path );
 			}
 
-			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Debug.php' );
+			$debug_class_name = $this->get_debug_controller_class_name( $api_version );
+			$debug_class_path = $this->get_debug_controller_class_path( $api_version );
 
-			$controller = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\' . $api_version . '\\Debug';
+			if ( ! class_exists( $debug_class_name ) ) {
+				require_once( $debug_class_path );
+			}
 
-			$this->debug_controller[ $api_version ] = new $controller( $this->get_plugin() );
+			$this->debug_controller[ $api_version ] = new $debug_class_name( $this->get_plugin() );
 		}
 
 		return $this->debug_controller[ $api_version ];
+	}
+
+
+	/**
+	 * Gets the log controller class name.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string|null $api_version API version, or null for abstract
+	 * @return string
+	 */
+	protected function get_log_controller_class_name( $api_version = null ) {
+
+		if ( null === $api_version ) {
+			$class_name = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Log_Controller';
+		} else {
+			$class_name = "\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\{$api_version}\\Log_Controller";
+		}
+
+		return $class_name;
+	}
+
+
+	/**
+	 * Gets the log controller class path.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string|null $api_version API version, or null for abstract
+	 * @return string
+	 */
+	protected function get_log_controller_class_path( $api_version = null ) {
+
+		if ( null === $api_version ) {
+			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/Log_Controller.php';
+		} else {
+			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Log_Controller.php';
+		}
+
+		return $class_path;
 	}
 
 
@@ -207,7 +293,7 @@ class REST_API {
 	 *
 	 * @since 5.5.0-dev
 	 *
-	 * @param string $api_version API version for the controller to be returned
+	 * @param string $api_version API version for the controller to be returned (default: latest supported)
 	 * @return null|Log_Controller
 	 */
 	public function get_log_controller_instance( $api_version = 'v3' ) {
@@ -218,15 +304,21 @@ class REST_API {
 
 		if ( ! isset( $this->log_controller[ $api_version ] ) ) {
 
-			if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Log_Controller' ) ) {
-				require_once( $this->get_plugin()->get_framework_path() . '/rest-api/Log_Controller.php' );
+			$log_class_abstract_name = $this->get_log_controller_class_name();
+			$log_class_abstract_path = $this->get_log_controller_class_path();
+
+			if ( ! class_exists( $log_class_abstract_name ) ) {
+				require_once( $log_class_abstract_path );
 			}
 
-			require_once( $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Log.php' );
+			$log_class_name = $this->get_log_controller_class_name( $api_version );
+			$log_class_path = $this->get_log_controller_class_path( $api_version );
 
-			$controller = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\' . $api_version . '\\Log';
+			if ( ! class_exists( $log_class_name ) ) {
+				require_once( $log_class_path );
+			}
 
-			$this->log_controller[ $api_version ] = new $controller( $this->get_plugin() );
+			$this->log_controller[ $api_version ] = new $log_class_name( $this->get_plugin() );
 		}
 
 		return $this->log_controller[ $api_version ];

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -184,7 +184,7 @@ class REST_API {
 		if ( null === $api_version ) {
 			$class_name = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Debug_Controller';
 		} else {
-			$class_name = "\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\{$api_version}\\Debug_Controller";
+			$class_name = "\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\{$api_version}\\Debug";
 		}
 
 		return $class_name;
@@ -204,7 +204,7 @@ class REST_API {
 		if ( null === $api_version ) {
 			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/Debug_Controller.php';
 		} else {
-			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Debug_Controller.php';
+			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Debug.php';
 		}
 
 		return $class_path;
@@ -261,7 +261,7 @@ class REST_API {
 		if ( null === $api_version ) {
 			$class_name = '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\Log_Controller';
 		} else {
-			$class_name = "\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\{$api_version}\\Log_Controller";
+			$class_name = "\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\{$api_version}\\Log";
 		}
 
 		return $class_name;
@@ -281,7 +281,7 @@ class REST_API {
 		if ( null === $api_version ) {
 			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/Log_Controller.php';
 		} else {
-			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Log_Controller.php';
+			$class_path = $this->get_plugin()->get_framework_path() . '/rest-api/' . $api_version . '/Log.php';
 		}
 
 		return $class_path;

--- a/woocommerce/rest-api/v3/Debug.php
+++ b/woocommerce/rest-api/v3/Debug.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\v3;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\Debug_Controller;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\v3\\DebugController' ) ) :
+
+/**
+ * The plugin REST API Debug endpoint for v3 API
+ *
+ * @since 5.5.0-dev.1
+ */
+class Debug extends Debug_Controller {
+
+
+	/**
+	 * Debug controller constructor for v3.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param SV_WC_Plugin $plugin main instance
+	 */
+	public function __construct( SV_WC_Plugin $plugin ) {
+
+		parent::__construct( $plugin );
+
+		$this->namespace = 'wc/v3';
+	}
+
+
+}
+
+endif;

--- a/woocommerce/rest-api/v3/Debug.php
+++ b/woocommerce/rest-api/v3/Debug.php
@@ -31,6 +31,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\v3\\DebugController' ) ) :
 
+
 /**
  * The plugin REST API Debug endpoint for v3 API
  *
@@ -55,5 +56,6 @@ class Debug extends Debug_Controller {
 
 
 }
+
 
 endif;

--- a/woocommerce/rest-api/v3/Log.php
+++ b/woocommerce/rest-api/v3/Log.php
@@ -31,6 +31,7 @@ defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\v3\\Log_Controller' ) ) :
 
+
 /**
  * The plugin REST API Log endpoint for v3 API
  *
@@ -55,5 +56,6 @@ class Log extends Log_Controller {
 
 
 }
+
 
 endif;

--- a/woocommerce/rest-api/v3/Log.php
+++ b/woocommerce/rest-api/v3/Log.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2019, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\v3;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\SV_WC_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_5_0\REST_API\Log_Controller;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_0\\REST_API\\v3\\Log_Controller' ) ) :
+
+/**
+ * The plugin REST API Log endpoint for v3 API
+ *
+ * @since 5.5.0-dev.1
+ */
+class Log extends Log_Controller {
+
+
+	/**
+	 * Log controller constructor for v3.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param SV_WC_Plugin $plugin main instance
+	 */
+	public function __construct( SV_WC_Plugin $plugin ) {
+
+		parent::__construct( $plugin );
+
+		$this->namespace = 'wc/v3';
+	}
+
+
+}
+
+endif;


### PR DESCRIPTION
## Summary

Implements 2 API endpoints for remote debugging of WC plugins:

* `wc/v3/<plugin_id>/debug` route to get the current debug mode of the plugin (and any of its gateways), or update the debug mode
* `wc/v3/<plugin_id>/log` route to list logs for the plugin (and any of its gateways)

### Related stories

* [16778](https://app.clubhouse.io/skyverge/story/16778/add-api-endpoint-to-toggle-debug-logging)
* [16779](https://app.clubhouse.io/skyverge/story/16779/add-an-api-endpoint-to-retrieve-debug-logs)

## Details

The PR extends the current `REST_API` handler to initialize the two new endpoints in all plugins that will use the framework at this version. Currently only the `v3` namespace of the WooCommerce REST API is supported, but the code is structured in a way that is possible to extend support to newer versions of the REST API in the future. 

### Debug mode

The debug endpoint will list the current debug mode used by the plugin and, if a gateway, of any gateways added by the plugin.

#### Plugins

Not all plugins have a debug mode, but we do make use of log files for a parent plugin, for example to record data during upgrade routines, or other notable errors. As such, child plugins that do not define a debug mode or offer a way to toggle it, will be assumed as if they had a debug mode set to log. In this case, plugins implementing this do not need to do anything. 

Plugins that may have a debug mode, can implement `get_debug_mode()` and `set_debug_mode()` methods to get and set the corresponding mode. 

#### Gateways

Gateways do not need to do anything either as they have a more structured debug mode and known debug modes. The parent plugin that handles the individual gateways, should it have a special debug mode unrelated to gateways, can implement the two methods mentioned before just like any other plugin.

When setting a debug mode from a POST/PUT/PATCH request, the data format to be sent matches the one from GET responses. 

### Logs

The log endpoint will list all the logs found for the matching plugin, and its gateways (if any). This is because, symmetrically to debug mode, some plugins can have a separate parent plugin log file and log files specifically for gateways. 

The response will normalize the output regardless if the installation is using log files or log entries in database using `WC_Log_Handler_DB`.

Plugins do not need to do anything to support this endpoint. 

## Open questions

### Debug modes normalization

While gateways have structured debug modes defined in constants, plugins do not have these. For example, MailChimp uses only "yes" or "no" as debug mode. Other plugins may use "enabled" or "disabled" and so on. 

- Should we normalize these? Most likely they are going to be "log" or "off" statuses, but we can't predict if some plugins will require a different mode. 

- Otherwise, should we list the accepted debug modes in a separate property of the response object?

### Log files size

Could there be any issue to send large file contents via REST API? WC should limit these by date/size but they can still grow large.

_In theory_ one could attempt to parse the debug log contents, since the logs always begin with a date. However, this could be unreliable since it's not markup/structured data and data could be missing in the response.

## Resources

The current PR is implemented in 2 plugins ready for testing:

- [MailChimp Sync](https://github.com/skyverge/wc-memberships-addons/pull/112/files)
- [Authorize.Net](https://github.com/skyverge/wc-plugins/pull/3223)