### PR TITLE
[ch14044] `wc_get_template()` replacement helper

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.0-dev
+ * Feature - Add a plugin helper method to retrieve a template part while consistently passing the default template path to `wc_get_template()`
 
 2019.09.05 - version 5.4.3
  * Fix - Do not show the checkbox to save the payment method on the checkout page if not logged in and registration during checkout is disabled

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -1165,7 +1165,7 @@ abstract class SV_WC_Plugin {
 	 * @param array $args associative array of optional template arguments
 	 * @param null|string $path optional template path, will use default from plugin if null
 	 */
-	public function load_template( $template, $args, $path = '' ) {
+	public function load_template( $template, array $args = [], $path = '' ) {
 
 		$default_path = trailingslashit( $this->get_template_path() );
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -1135,7 +1135,7 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Gets the plugin default template path.
+	 * Gets the plugin default template path, without a trailing slash.
 	 *
 	 * @since 5.5.0-dev
 	 *

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -1154,17 +1154,20 @@ abstract class SV_WC_Plugin {
 	/**
 	 * Loads and outputs a template file HTML.
 	 *
-	 * @see \wc_get_template() except we pass the plugin template path by default
+	 * @see \wc_get_template() except we define automatically the default path and pass the plugin template path by default
 	 *
 	 * @since 5.5.0-dev
 	 *
 	 * @param string $template template name/part
 	 * @param array $args associative array of optional template arguments
-	 * @param null|string $path optional template path, will use default from plugin if null
+	 * @param string $path optional template path, will use default from plugin if empty string
+	 * @param string $default_path optional default template path, will normally pass the one defined in plugin unless overridden
 	 */
-	public function load_template( $template, array $args = [], $path = '' ) {
+	public function load_template( $template, array $args = [], $path = '', $default_path = '' ) {
 
-		$default_path = trailingslashit( $this->get_template_path() );
+		if ( '' === $default_path || ! is_string( $default_path ) ) {
+			$default_path = trailingslashit( $this->get_template_path() );
+		}
 
 		if ( '' === $path || ! is_string( $path ) ) {
 			$path = $default_path;

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -1154,23 +1154,19 @@ abstract class SV_WC_Plugin {
 	/**
 	 * Loads and outputs a template file HTML.
 	 *
-	 * @see \wc_get_template() except we define automatically the default path and pass the plugin template path by default
+	 * @see \wc_get_template() except we define automatically the default path
 	 *
 	 * @since 5.5.0-dev
 	 *
 	 * @param string $template template name/part
 	 * @param array $args associative array of optional template arguments
-	 * @param string $path optional template path, will use default from plugin if empty string
-	 * @param string $default_path optional default template path, will normally pass the one defined in plugin unless overridden
+	 * @param string $path optional template path, can be empty, as themes can override this
+	 * @param string $default_path optional default template path, will normally use the plugin's own template path unless overridden
 	 */
 	public function load_template( $template, array $args = [], $path = '', $default_path = '' ) {
 
 		if ( '' === $default_path || ! is_string( $default_path ) ) {
 			$default_path = trailingslashit( $this->get_template_path() );
-		}
-
-		if ( '' === $path || ! is_string( $path ) ) {
-			$path = $default_path;
 		}
 
 		wc_get_template( $template, $args, $path, $default_path );

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -53,11 +53,14 @@ abstract class SV_WC_Plugin {
 	/** @var string version number */
 	private $version;
 
-	/** @var string plugin path without trailing slash */
+	/** @var string plugin path, without trailing slash */
 	private $plugin_path;
 
-	/** @var string plugin uri */
+	/** @var string plugin URL */
 	private $plugin_url;
+
+	/** @var string template path, without trailing slash */
+	private $template_path;
 
 	/** @var \WC_Logger instance */
 	private $logger;
@@ -1028,48 +1031,56 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Returns the plugin's path without a trailing slash, i.e.
-	 * /path/to/wp-content/plugins/plugin-directory
+	 * Gets the plugin's path without a trailing slash.
+	 *
+	 * e.g. /path/to/wp-content/plugins/plugin-directory
 	 *
 	 * @since 2.0.0
-	 * @return string the plugin path
+	 *
+	 * @return string
 	 */
 	public function get_plugin_path() {
 
-		if ( $this->plugin_path ) {
-			return $this->plugin_path;
+		if ( null === $this->plugin_path ) {
+			$this->plugin_path = untrailingslashit( plugin_dir_path( $this->get_file() ) );
 		}
 
-		return $this->plugin_path = untrailingslashit( plugin_dir_path( $this->get_file() ) );
+		return $this->plugin_path;
 	}
 
 
 	/**
-	 * Returns the plugin's url without a trailing slash, i.e.
-	 * http://skyverge.com/wp-content/plugins/plugin-directory
+	 * Gets the plugin's URL without a trailing slash.
+	 *
+	 * E.g. http://skyverge.com/wp-content/plugins/plugin-directory
 	 *
 	 * @since 2.0.0
-	 * @return string the plugin URL
+	 *
+	 * @return string
 	 */
 	public function get_plugin_url() {
 
-		if ( $this->plugin_url ) {
-			return $this->plugin_url;
+		if ( null === $this->plugin_url ) {
+			$this->plugin_url = untrailingslashit( plugins_url( '/', $this->get_file() ) );
 		}
 
-		return $this->plugin_url = untrailingslashit( plugins_url( '/', $this->get_file() ) );
+		return $this->plugin_url;
 	}
 
 
 	/**
-	 * Returns the woocommerce uploads path, without trailing slash.  Oddly WooCommerce
-	 * core does not provide a way to get this
+	 * Gets the woocommerce uploads path, without trailing slash.
+	 *
+	 * Oddly WooCommerce core does not provide a way to get this.
 	 *
 	 * @since 2.0.0
-	 * @return string upload path for woocommerce
+	 *
+	 * @return string
 	 */
 	public static function get_woocommerce_uploads_path() {
+
 		$upload_dir = wp_upload_dir();
+
 		return $upload_dir['basedir'] . '/woocommerce_uploads';
 	}
 
@@ -1087,8 +1098,9 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Returns the loaded framework path, without trailing slash. Ths is the highest
-	 * version framework that was loaded by the bootstrap.
+	 * Gets the loaded framework path, without trailing slash.
+	 *
+	 * This matches the path to the highest version of the framework currently loaded.
 	 *
 	 * @since 4.0.0
 	 * @return string
@@ -1100,10 +1112,10 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Returns the absolute path to the loaded framework image directory, without a
-	 * trailing slash
+	 * Gets the absolute path to the loaded framework image directory, without a trailing slash.
 	 *
 	 * @since 4.0.0
+	 *
 	 * @return string
 	 */
 	public function get_framework_assets_path() {
@@ -1113,14 +1125,55 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Returns the loaded framework assets URL without a trailing slash
+	 * Gets the loaded framework assets URL without a trailing slash.
 	 *
 	 * @since 4.0.0
+	 *
 	 * @return string
 	 */
 	public function get_framework_assets_url() {
 
 		return untrailingslashit( plugins_url( '/assets', $this->get_framework_file() ) );
+	}
+
+
+	/**
+	 * Gets the plugin default template path.
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @return string
+	 */
+	public function get_template_path() {
+
+		if ( null === $this->template_path ) {
+			$this->template_path = $this->get_plugin_path() . '/templates';
+		}
+
+		return $this->template_path;
+	}
+
+
+	/**
+	 * Loads and outputs a template file HTML.
+	 *
+	 * @see \wc_get_template() except we pass the plugin template path by default
+	 *
+	 * @since 5.5.0-dev
+	 *
+	 * @param string $template template name/part
+	 * @param array $args associative array of optional template arguments
+	 * @param null|string $path optional template path, will use default from plugin if null
+	 */
+	public function load_template( $template, $args, $path = '' ) {
+
+		$default_path = trailingslashit( $this->get_template_path() );
+
+		if ( '' === $path || ! is_string( $path ) ) {
+			$path = $default_path;
+		}
+
+		wc_get_template( $template, $args, $path, $default_path );
 	}
 
 


### PR DESCRIPTION
Adds a `SV_WC_Plugin::load_template()` helper method that is a replacement for `wc_get_template()`. The method accepts a template part/name (string) and an optional array of arguments to pass to the template. Plugins can replace `wc_get_template()` with this method instead.

#### Story: [ch14044](https://app.clubhouse.io/skyverge/story/14044/add-helper-method-for-wc-get-template-that-passes-default-path-automatically)

## Details

The method is added to the plugin main file, which also adds a `get_template_path()` which could be overridden (or, the property it uses could be set to string in constructor) by individual plugins that wish to modify the default template path in `<plugin_root>/templates`.

Note: the name is closer to WordPress own `load_template()` as the `wc_get_template()` method suggests that the template is returned, however, it really is included and thus its HTML echoed. `load_template()` feels more consistent.

## Resources

- [Issue on Teams for Memberships](https://github.com/skyverge/wc-memberships-addons/issues/67) detailing one problem the helper method could solve across plugins.
- [Print Invoices / Packing Lists](https://github.com/skyverge/wc-plugins/pull/3238) working implementation of the FWv5.5 incluiding the method introduced in this PR