### PR TITLE
[ch14277] Address occasional temporary errors on plugin upgrades

### DIFF
--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -75,22 +75,22 @@ class Lifecycle {
 	protected function add_hooks() {
 
 		// handle activation
-		add_action( 'admin_init', array( $this, 'handle_activation' ) );
+		add_action( 'admin_init', [ $this, 'handle_activation' ] );
 
 		// handle deactivation
-		add_action( 'deactivate_' . $this->get_plugin()->get_plugin_file(), array( $this, 'handle_deactivation' ) );
+		add_action( 'deactivate_' . $this->get_plugin()->get_plugin_file(), [ $this, 'handle_deactivation' ] );
 
 		if ( is_admin() && ! is_ajax() ) {
 
 			// initialize the plugin lifecycle
-			add_action( 'wp_loaded', array( $this, 'init' ) );
+			add_action( 'wp_loaded', [ $this, 'init' ] );
 
 			// add the admin notices
-			add_action( 'init', array( $this, 'add_admin_notices' ) );
+			add_action( 'init', [ $this, 'add_admin_notices' ] );
 		}
 
 		// catch any milestones triggered by action
-		add_action( 'wc_' . $this->get_plugin()->get_id() . '_milestone_reached', array( $this, 'trigger_milestone' ), 10, 3 );
+		add_action( 'wc_' . $this->get_plugin()->get_id() . '_milestone_reached', [ $this, 'trigger_milestone' ], 10, 3 );
 	}
 
 
@@ -202,6 +202,64 @@ class Lifecycle {
 		do_action( 'wc_' . $this->get_plugin()->get_id() . '_deactivated' );
 
 		delete_option( 'wc_' . $this->get_plugin()->get_id() . '_is_active' );
+
+		$this->flush_cache();
+	}
+
+
+	/**
+	 * Tries to flush all known caches.
+	 *
+	 * @since 5.5.0-dev
+	 */
+	private function flush_cache() {
+
+		// APC
+		if ( function_exists( 'apc_clear_cache' ) ) {
+			foreach ( [ 'user', 'opcode', '' ] as $cache_type ) {
+				@apc_clear_cache( $cache_type );
+			}
+		}
+
+		// APCU
+		if ( function_exists( 'apcu_clear_cache' ) ) {
+			@apcu_clear_cache();
+		}
+
+		// OPCache
+		if ( function_exists( 'opcache_reset' ) ) {
+			@opcache_reset();
+		}
+
+		// Memcache
+		if ( function_exists( 'memcache_flush' ) ) {
+			@memcache_flush();
+		}
+
+		// WordPress Object Cache
+		if ( function_exists( 'wp_cache_flush' ) ) {
+			@wp_cache_flush();
+		}
+
+		// WP Super Cache
+		if ( function_exists( 'wp_cache_clear_cache' ) ) {
+			@wp_cache_clear_cache( get_current_blog_id() );
+		}
+
+		// WP Rocket
+		if ( function_exists( 'rocket_clean_domain' ) ) {
+			@rocket_clean_domain();
+		}
+
+		// W3 Total Cache
+		if ( function_exists( 'w3tc_flush_all' ) ) {
+			@w3tc_flush_all();
+		}
+
+		// WP Fastest Cache
+		if ( function_exists( 'wpfc_clear_all_cache' ) ) {
+			@wpfc_clear_all_cache();
+		}
 	}
 
 

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -231,6 +231,10 @@ class Lifecycle {
 			@opcache_reset();
 		}
 
+		if ( function_exists( 'wincache_ucache_clear' ) ) {
+			@wincache_ucache_clear();
+		}
+
 		// Memcache
 		if ( function_exists( 'memcache_flush' ) ) {
 			@memcache_flush();

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -214,19 +214,16 @@ class Lifecycle {
 	 */
 	private function flush_cache() {
 
-		// APC
 		if ( function_exists( 'apc_clear_cache' ) ) {
 			foreach ( [ 'user', 'opcode', '' ] as $cache_type ) {
 				@apc_clear_cache( $cache_type );
 			}
 		}
 
-		// APCU
 		if ( function_exists( 'apcu_clear_cache' ) ) {
 			@apcu_clear_cache();
 		}
 
-		// OPCache
 		if ( function_exists( 'opcache_reset' ) ) {
 			@opcache_reset();
 		}
@@ -235,34 +232,8 @@ class Lifecycle {
 			@wincache_ucache_clear();
 		}
 
-		// Memcache
 		if ( function_exists( 'memcache_flush' ) ) {
 			@memcache_flush();
-		}
-
-		// WordPress Object Cache
-		if ( function_exists( 'wp_cache_flush' ) ) {
-			@wp_cache_flush();
-		}
-
-		// WP Super Cache
-		if ( function_exists( 'wp_cache_clear_cache' ) ) {
-			@wp_cache_clear_cache( get_current_blog_id() );
-		}
-
-		// WP Rocket
-		if ( function_exists( 'rocket_clean_domain' ) ) {
-			@rocket_clean_domain();
-		}
-
-		// W3 Total Cache
-		if ( function_exists( 'w3tc_flush_all' ) ) {
-			@w3tc_flush_all();
-		}
-
-		// WP Fastest Cache
-		if ( function_exists( 'wpfc_clear_all_cache' ) ) {
-			@wpfc_clear_all_cache();
 		}
 	}
 

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,7 @@
 
 2019.nn.nn - version 5.5.0-dev
  * Misc - Deprecate backwards compatibility methods for unsupported WooCommerce and PHP versions
+ * Misc - Attempt to clear known caches when updating or deactivating a plugin
 
 2019.09.05 - version 5.4.3
  * Fix - Do not show the checkbox to save the payment method on the checkout page if not logged in and registration during checkout is disabled


### PR DESCRIPTION
# Summary

We had reports of users running into PHP errors (class not found...) when running a WordPress upgrade on frameworked plugins that carry a new version of the framework.

#### Story

- [ch14277](https://app.clubhouse.io/skyverge/story/14277/updating-a-plugin-can-cause-temporary-fatal-errors)

### Additional Details

It looks like this might be a cache issue, where the server doesn't pick up the updated plugin class contents early enough. The error seems to be triggered when there's a framework update, which prompts for an entire class name to change. The server assumes the old class/code to exist while it's been replaced.

A tentative solution could be to clear possible known cache systems during plugin deactivation, which occurs also when a plugin is being updated. The `WP_Upgrader` handler runs `add_filter( 'upgrader_pre_install', array( $this, 'deactivate_plugin_before_upgrade' ), 10, 2 )` when upgrading a plugin (right before re-installation due to plugin update).

I did a bit of research to see if other users ever ran this for other PHP projects or WordPress plugins. The consensus seems to be that opcode or other PHP caches might produce the issue. Probably clearing the caches of known WordPress plugins is unnecessary and we could take that part out (see PR contents). I might double check which hosts the folks that were running into these problems were using; and try to understand if they all shared a known caching system for example.

Either way, so far this is a conjecture as I've been unable to replicate the issue even when prompting a real update from one older version of a plugin to a most recent one using the WooCommerce updater.

Unfortunately to really test this properly, we should:

1. consistently be able to replicate this issue on server of ours
2. simulate a plugin upgrade to trigger the error or evaluate if the patch works

While we can test a un upgrade by installing an older version then upgrading via WP Admin, the newer file will always come from WP or WC servers and won't contain added code to test a potential patch. If we want to spend more time on this likely we need to:

1. have a server where the issue appears as with customers upgrading existing plugins
2. create a mock frameworked plugin
3. set up the mock plugin upgrader pointing to one of our servers (like free Memberships add ons)
4. verify that the server experiences consistently the same issue as # 1 
5. verify that the proposed changes in this PR eliminate the issue

Alternatively, we could try to introduce the change (perhaps limit to PHP modules rather than WP cache plugins), as it seems innocuous, in the next framework version and see real life results. 

## Resources

* [APC](https://www.inmotionhosting.com/support/website/php-troubleshooting/php-files-do-not-show-changes) "Files do not show changes"
* [Apache/APC](https://serverfault.com/questions/534410/apache-restart-needed-after-php-code-change) "Apache restart needed after php code change"
* [Apache/opcache](https://unix.stackexchange.com/questions/184722/apache-not-reading-changes-to-php-files) "Apache not reading changes to php files"
* [nginx/opcache](https://stackoverflow.com/questions/30419304/changes-to-php-file-doesnt-reflect-unless-i-restart-php-fpm-on-ubuntu) "Changes to PHP file do not reflect unless I restart php-fm on Ubuntu"
* [PHP.net: Functions affecting PHP Behavior](https://www.php.net/manual/en/refs.basic.php.php)
* [PHP.net: APC](https://www.php.net/manual/en/book.apc.php) (defunct)
* [PHP.net: APCu](https://www.php.net/manual/en/book.apcu.php) (probably we can skip this since the module is stripped of opcache)
* [PHP.net: opcache](https://www.php.net/manual/en/book.opcache.php)
* [PHP.net: wincache](https://www.php.net/manual/en/book.wincache.php)