### PR TITLE
[ch16760] Revisit Apple Pay Order Creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "skyverge/wc-plugin-framework",
     "description": "The official SkyVerge WooCommerce plugin framework",
-    "version": "5.5.1-dev.1",
+    "version": "5.5.1-dev",
     "require-dev": {
         "lucatume/wp-browser": "^2.1"
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "skyverge/wc-plugin-framework",
     "description": "The official SkyVerge WooCommerce plugin framework",
-    "version": "5.5.0",
+    "version": "5.5.1-dev.1",
     "require-dev": {
         "lucatume/wp-browser": "^2.1"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.5.0",
+  "version": "5.5.1-dev.1",
   "title": "WooCommerce Plugin Framework",
   "author": "SkyVerge Team",
   "homepage": "https://github.com/skyverge/wc-plugin-framework#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.5.1-dev.1",
+  "version": "5.5.1-dev",
   "title": "WooCommerce Plugin Framework",
   "author": "SkyVerge Team",
   "homepage": "https://github.com/skyverge/wc-plugin-framework#readme",

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.1
+ * Fix - Refactor Apple Pay order creation to support the same filters and actions that are fired during regular checkout
 
 2019.10.15 - version 5.5.0
  * Feature - Add a plugin helper method to retrieve a template part while consistently passing the default template path to `wc_get_template()`

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.1
- * Fix - Refactor Apple Pay order creation to support the same filters and actions that are fired during regular checkout
+ * Tweak - Refactor Apple Pay order creation to support the same filters and actions that are fired during regular checkout
 
 2019.10.15 - version 5.5.0
  * Feature - Add a plugin helper method to retrieve a template part while consistently passing the default template path to `wc_get_template()`

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2019.nn.nn - version 5.5.1
+
 2019.10.15 - version 5.5.0
  * Feature - Add a plugin helper method to retrieve a template part while consistently passing the default template path to `wc_get_template()`
  * Misc - Deprecate backwards compatibility methods for unsupported WooCommerce and PHP versions

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -43,7 +43,7 @@ abstract class SV_WC_Plugin {
 
 
 	/** Plugin Framework Version */
-	const VERSION = '5.5.0';
+	const VERSION = '5.5.1';
 
 	/** @var object single instance of plugin */
 	protected static $instance;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -53,8 +53,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 		try {
 
-			wc_transaction_query( 'start' );
-
 			if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.6' ) ) {
 				$cart_hash = $cart->get_cart_hash();
 			} else {
@@ -85,8 +83,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			$order->save();
 
-			wc_transaction_query( 'commit' );
-
 			$order->update_taxes();
 
 			$order->calculate_totals( false ); // false to skip recalculating taxes
@@ -97,9 +93,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 			return $order;
 
 		} catch ( SV_WC_Payment_Gateway_Exception $e ) {
-
-			wc_transaction_query( 'rollback' );
-
 			throw $e;
 		}
 	}

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -116,6 +116,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 	 *
 	 * @since 4.7.0
 	 *
+	 * @see \WC_Checkout::create_order()
 	 * @param array $order_data the order data
 	 * @return \WC_Order
 	 * @throws SV_WC_Payment_Gateway_Exception
@@ -123,8 +124,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 	public static function get_order_object( $order_data ) {
 
 		$order_id = (int) WC()->session->get( 'order_awaiting_payment', 0 );
+		$order    = $order_id ? wc_get_order( $order_id ) : null;
 
-		if ( $order_id && $order_data['cart_hash'] === get_post_meta( $order_id, '_cart_hash', true ) && ( $order = wc_get_order( $order_id ) ) && $order->has_status( array( 'pending', 'failed' ) ) ) {
+		if ( $order && $order->has_cart_hash( $order_data['cart_hash'] ) && $order->has_status( [ 'pending', 'failed' ] ) ) {
 
 			$order_data['order_id'] = $order_id;
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -63,7 +63,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			$order_data = [
 				'status'      => apply_filters( 'woocommerce_default_order_status', 'pending' ),
-				'customer_id' => get_current_user_id(),
+				'customer_id' => apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ),
 				'cart_hash'   => md5( json_encode( wc_clean( $cart->get_cart_for_session() ) ) . $cart->total ),
 				'created_via' => 'apple_pay',
 			];
@@ -79,6 +79,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 			$checkout->create_order_fee_lines( $order, $cart );
 			$checkout->create_order_tax_lines( $order, $cart );
 
+			/** This action is documented by WooCommerce in includes/class-wc-checkout.php */
+			do_action( 'woocommerce_checkout_create_order', $order, [] );
 
 			$order->save();
 
@@ -88,6 +90,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			$order->calculate_totals( false ); // false to skip recalculating taxes
 
+			/** This action is documented by WooCommerce in includes/class-wc-checkout.php */
 			do_action( 'woocommerce_checkout_update_order_meta', $order->get_id(), [] );
 
 			return $order;
@@ -123,6 +126,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 			if ( is_wp_error( $order ) ) {
 				throw new SV_WC_Payment_Gateway_Exception( sprintf( __( 'Error %d: Unable to create order. Please try again.', 'woocommerce-plugin-framework' ), 522 ) );
 			}
+
+			/** This action is documented by WooCommerce in includes/class-wc-checkout.php */
+			do_action( 'woocommerce_resume_order', $order_id );
 
 			$order->remove_order_items();
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -49,12 +49,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 	 */
 	public static function create_order( \WC_Cart $cart ) {
 
-		// ensure totals are fully calculated by simulating checkout in WC 3.1 or lower
-		// TODO: remove this when WC 3.2+ can be required {CW 2017-11-17}
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) && SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
 		$cart->calculate_totals();
 
 		try {

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -76,6 +76,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			$order = self::get_order_object( $order_data );
 
+			$order->add_meta_data( 'is_vat_exempt', $cart->get_customer()->get_is_vat_exempt() ? 'yes' : 'no' );
 
 			$checkout = WC()->checkout();
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -61,10 +61,16 @@ class SV_WC_Payment_Gateway_Apple_Pay_Orders {
 
 			wc_transaction_query( 'start' );
 
+			if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.6' ) ) {
+				$cart_hash = $cart->get_cart_hash();
+			} else {
+				$cart_hash = md5( json_encode( wc_clean( $cart->get_cart_for_session() ) ) . $cart->get_total( 'edit' ) );
+			}
+
 			$order_data = [
 				'status'      => apply_filters( 'woocommerce_default_order_status', 'pending' ),
 				'customer_id' => apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ),
-				'cart_hash'   => md5( json_encode( wc_clean( $cart->get_cart_for_session() ) ) . $cart->total ),
+				'cart_hash'   => $cart_hash,
 				'created_via' => 'apple_pay',
 			];
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -300,12 +300,6 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 			throw new SV_WC_Payment_Gateway_Exception( 'Cart contains pre-orders.' );
 		}
 
-		// ensure totals are fully calculated by simulating checkout in WC 3.1 or lower
-		// TODO: remove this when WC 3.2+ can be required {CW 2017-11-17}
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) && ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
 		$cart->calculate_totals();
 
 		if ( count( WC()->shipping->get_packages() ) > 1 ) {
@@ -406,12 +400,6 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 	 * @return array
 	 */
 	protected function get_cart_totals( \WC_Cart $cart ) {
-
-		// ensure totals are fully calculated by simulating checkout in WC 3.1 or lower
-		// TODO: remove this when WC 3.2+ can be required {CW 2017-11-17}
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) && ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
 
 		$cart->calculate_totals();
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -764,7 +764,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	protected function add_apple_pay_not_supported_notices() {
 
-		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) && $this->is_apple_pay_activated() ) {
+		if ( 'wc-settings' === SV_WC_Helper::get_requested_value( 'page' ) && SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) && $this->is_apple_pay_activated() ) {
 
 			$this->get_admin_notice_handler()->add_admin_notice(
 				sprintf(

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -419,6 +419,19 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	public function maybe_init_apple_pay() {
 
+		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.2' ) && $this->is_apple_pay_activated() && $this->supports_apple_pay() ) {
+			$this->apple_pay = $this->build_apple_pay_instance();
+		}
+	}
+
+
+	/**
+	 * Determines whether Apple Pay is activated.
+	 *
+	 * @since 5.5.1-dev.1
+	 */
+	private function is_apple_pay_activated() {
+
 		/**
 		 * Filters whether Apple Pay is activated.
 		 *
@@ -426,11 +439,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		 *
 		 * @param bool $activated whether Apple Pay is activated
 		 */
-		$activated = (bool) apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_activate_apple_pay', false );
-
-		if ( $this->supports_apple_pay() && $activated ) {
-			$this->apple_pay = $this->build_apple_pay_instance();
-		}
+		return (bool) apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_activate_apple_pay', false );
 	}
 
 
@@ -572,6 +581,8 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 		// add notices about gateways not being configured
 		$this->add_gateway_not_configured_notices();
+
+		$this->add_apple_pay_not_supported_notices();
 	}
 
 
@@ -742,6 +753,30 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 					'notice_class' => 'error',
 				] );
 			}
+		}
+	}
+
+
+	/**
+	 * Adds notices about Apple Pay not supportted in the current WooCommerce version.
+	 *
+	 * @since 5.5.1
+	 */
+	protected function add_apple_pay_not_supported_notices() {
+
+		if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.2' ) && $this->is_apple_pay_activated() ) {
+
+			$this->get_admin_notice_handler()->add_admin_notice(
+				sprintf(
+					/* translators: Placeholders: %1$s - plugin name, %2$s - opening <a> HTML link tag, %3$s - closing </a> HTML link tag */
+					__( 'Heads up! Apple Pay for %1$s requires WooCommerce version 3.2 or greater. Please %2$supdate WooCommerce%3$s.', 'woocommerce-plugin-framework' ),
+					$this->get_plugin_name(),
+					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) .'">',
+					'</a>'
+				),
+				$this->get_id_dasherized() . '-apple-pay-requires-wc-version-3-2',
+				[ 'notice_class' => 'error' ]
+			);
 		}
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -428,7 +428,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	/**
 	 * Determines whether Apple Pay is activated.
 	 *
-	 * @since 5.5.1-dev.1
+	 * @since 5.5.1-dev
 	 */
 	private function is_apple_pay_activated() {
 


### PR DESCRIPTION
# Summary

This PR updates `SV_WC_Payment_Gateway_Apple_Pay_Orders::create_order()` to use `\WC_Checkout` methods so that creating orders for Apple Pay is as similar as possible to creating an order from the checkout page.

Particularly, we wanted that:

- all filters and actions that fire during regular checkout also fire when an Apple Pay order is created
- product options configured through the TM Global Extra Product Options plugin are included for product line items on Apple Pay orders

### Stories

- [CH 16760](https://app.clubhouse.io/skyverge/story/16760/revisit-apple-pay-order-creation)

## Details

Using Apple Pay now requires WooCommerce 3.2. A notice will be shown on older versions.

I set the version to 5.5.1, but maybe that's not the best choice since we are dropping Apple Pay support for WC < 3.2?

This PR doesn't include a commit to update the namespace on purpose to facilitate testing with the version of Authorize.Net in the master branch on [wc-plugins](https://github.com/skyverge/wc-plugins).

## UI

Admin notice shown if Apply Pay is enabled on WooCommerce 3.1.x or older: [screenshot](https://share.getcloudapp.com/xQuvE8Rp)

## QA

### Setup

**Authorize.Net**

Use the version of Authorize.Net in the master branch on [wc-plugins](https://github.com/skyverge/wc-plugins):
- Require version `dev-ch16760/revisit-apple-pay-order-creation#a23e6a8` of `skyverge/wc-plugin-framework` in `composer.json`
- Run `composer update`

**Test Device**

- You need a device where Apple Pay is supported
- You can use [Sandbox Tester account](https://developer.apple.com/apple-pay/sandbox-testing/) if not using your regular account.
- If you use a Sandbox Tester account, you can add the following [Test Card](https://developer.apple.com/apple-pay/sandbox-testing/) to your Wallet:
    * Number: 4761 1200 1000 0492
    * Expiration Date: 11/2022
    * CVV: 533
- Make sure to have a Billing Address, Shipping Address, Email Address, and Phone Number configured in Settings > Wallet & Apple Pay 

**TM Extra Product Options**

- Install and activate TM Extra Product Options plugin
- Go to Products > TM Global Extra Product Options
- Add a Global Form
- Enter a name for the global form
- Use the Add a Section button to add a section
    - Add a Radio Buttons field and edit its settings
        - Scroll to the bottom of the General Options tab and add A and B options with no price
- Add another section and move it to the bottom of the form
    - Add a Checkboxes field and edit its settings
        - Add options A1, A2, A3 with a different price for each
        - Go to the Conditional Logic tab and add a rule to show this field the value in the Radio Buttons field is A
    - Add another Checkboxes field and edit its settings
        - Add options B1, B2, B3 with a different price for each
        - Go to the Conditional Logic tab and add a rule to show this field the value in the Radio Buttons field is B
- Publish the global form

**WooCommerce**

- Configure the Test Enviroment for Authorize.Net Credit Card with Tokenization enabled.
- Disable Test Mode in Apple Pay settings so that payments are processed by the payment gateway
- Enable taxes and add 5% tax rate for any country code, state code, postcode or city
- Enable coupons and create a $10 coupon with no usage restriction
- Edit a Product and go to the TM Extra Product Options tab (below Attributes)
    - Add Radio Buttons field with two options and a price for each option
    - Switch to the Settings subtab
    - Check the option for the global form on the **Include additional Global forms** setting
    - Update the product

### Cases

Using your test device:

#### Create an order from the product page

1. Navigate to the modified product
1. Click the Buy with Pay button and pay
    - [x] The order is received successfully
    - [x] The order includes a line item for the modified product
    - [x] The order incldues a shipping item
    - [x] The order includes a tax item

#### Create an order from the cart page

1. Navigate to the modified product
1. Select different values for the extra product options so that the options amount is a non zero value
1. Change the quantity to a number other than 1
1. Add the product to the cart
1. Go to the cart page
1. Apply the test coupon
1. Click the Pay and pay
    - [x] The order is received successfully
    - [x] The order includes a line item for the modified product
    - [x] Selected extra product options match the values selected on the product page
    - [x] The order incldues a discount item
    - [x] The order incldues a shipping item
    - [x] The order includes a tax item
    - [x] The quantity of the produce matches the selected product
    - [x] The totals and subtotals were calculated correctly

#### Create an order from the checkout page

1. Navigate to the modified product
1. Select different values for the extra product options so that the options amount is a non zero value
1. Change the quantity to a number other than 1
1. Add the product to the cart
1. Go to the checkout page
1. Apply the test coupon
1. Click the Pay and pay
    - [x] The order is received successfully
    - [x] The order includes a line item for the modified product
    - [x] Selected extra product options match the values selected on the product page
    - [x] The order incldues a discount item
    - [x] The order incldues a shipping item
    - [x] The order includes a tax item
    - [x] The quantity of the produce matches the selected product
    - [x] The totals and subtotals were calculated correctly

#### Apple Pay not supported on WooCommerce < 3.2

1. Test using WooCommerce 3.1.2 (or ⚠️ add `define( 'WC_VERSION', '3.1.2' );` to your `wp-config.php`)
    - [x] An admin notice shows up indicating that Apple Pay requires WooCommerce 3.2
    - [x] Apple Pay settings are not available on WooCommerce > Settings > Payments

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
