### PR TITLE
Do not reduce stock levels for held orders 

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2019.nn.nn - version 5.5.1
+ * Fix - Do not reduce twice the stock level of a product when the order is held and payment is not completed
 
 2019.10.15 - version 5.5.0
  * Feature - Add a plugin helper method to retrieve a template part while consistently passing the default template path to `wc_get_template()`

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -311,10 +311,8 @@ abstract class Abstract_Payment_Handler {
 		$this->get_gateway()->add_payment_gateway_transaction_data( $order, $response );
 
 		if ( $order->has_status( $this->get_held_order_status( $order, $response ) ) ) {
-			// reduce stock for held orders, but don't complete payment (WooCommerce versions 3.5 and newer will do this for us)
-			if ( FrameworkBase\SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
-				wc_reduce_stock_levels( $order );
-			}
+			// reduce stock for held orders, but don't complete payment (pass order ID so WooCommerce fetches fresh order object with reduced_stock meta set on order status change)
+			wc_reduce_stock_levels( $order->get_id() );
 		} else {
 			// mark order as having received payment
 			$order->payment_complete();

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -311,8 +311,10 @@ abstract class Abstract_Payment_Handler {
 		$this->get_gateway()->add_payment_gateway_transaction_data( $order, $response );
 
 		if ( $order->has_status( $this->get_held_order_status( $order, $response ) ) ) {
-			// reduce stock for held orders, but don't complete payment
-			wc_reduce_stock_levels( $order );
+			// reduce stock for held orders, but don't complete payment (WooCommerce versions 3.5 and newer will do this for us)
+			if ( FrameworkBase\SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
+				wc_reduce_stock_levels( $order );
+			}
 		} else {
 			// mark order as having received payment
 			$order->payment_complete();

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -401,10 +401,8 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 				$held_order_status = apply_filters( 'wc_' . $this->get_id() . '_held_order_status', 'on-hold', $order, null );
 
 				if ( $order->has_status( $held_order_status ) ) {
-					// reduce stock for held orders, but don't complete payment (WooCommerce will do this for us from WC 3.5+)
-					if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
-						wc_reduce_stock_levels( $order );
-					}
+					// reduce stock for held orders, but don't complete payment (pass order ID so WooCommerce fetches fresh order object with reduced_stock meta set on order status change)
+					wc_reduce_stock_levels( $order->get_id() );
 				} else {
 					// mark order as having received payment
 					$order->payment_complete();

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -401,8 +401,10 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 				$held_order_status = apply_filters( 'wc_' . $this->get_id() . '_held_order_status', 'on-hold', $order, null );
 
 				if ( $order->has_status( $held_order_status ) ) {
-					// reduce stock for held orders, but don't complete payment
-					wc_reduce_stock_levels( $order );
+					// reduce stock for held orders, but don't complete payment (WooCommerce will do this for us from WC 3.5+)
+					if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
+						wc_reduce_stock_levels( $order );
+					}
 				} else {
 					// mark order as having received payment
 					$order->payment_complete();

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1734,10 +1734,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 			$this->mark_order_as_held( $order, $message, $response );
 
-			// WooCommerce versions from 3.5+ will reduce stock for us on held orders
-			if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
-				wc_reduce_stock_levels( $order );
-			}
+			// pass order ID so WooCommerce fetches fresh order object with reduced_stock meta set on order status change
+			wc_reduce_stock_levels( $order->get_id() );
 
 		} else {
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1734,7 +1734,10 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 			$this->mark_order_as_held( $order, $message, $response );
 
-			wc_reduce_stock_levels( $order );
+			// WooCommerce versions from 3.5+ will reduce stock for us on held orders
+			if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
+				wc_reduce_stock_levels( $order );
+			}
 
 		} else {
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -369,10 +369,8 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 					$this->get_gateway()->mark_order_as_held( $order, $this->get_gateway()->supports( SV_WC_Payment_Gateway::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->get_gateway()->perform_credit_card_authorization( $order ) ? __( 'Authorization only transaction', 'woocommerce-plugin-framework' ) : $response->get_status_message(), $response );
 
-					// reduce stock for held orders, but don't complete payment (WC 3.5+ will do this for us)
-					if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
-						wc_reduce_stock_levels( $order );
-					}
+					// reduce stock for held orders, but don't complete payment (pass order ID so WooCommerce fetches fresh order object with reduced_stock meta set on order status change)
+					wc_reduce_stock_levels( $order->get_id() );
 
 				} else {
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -365,8 +365,10 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 					$this->get_gateway()->mark_order_as_held( $order, $this->get_gateway()->supports( SV_WC_Payment_Gateway::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->get_gateway()->perform_credit_card_authorization( $order ) ? __( 'Authorization only transaction', 'woocommerce-plugin-framework' ) : $response->get_status_message(), $response );
 
-					// reduce stock for held orders, but don't complete payment
-					wc_reduce_stock_levels( $order );
+					// reduce stock for held orders, but don't complete payment (WC 3.5+ will do this for us)
+					if ( SV_WC_Plugin_Compatibility::is_wc_version_lt( '3.5.0' ) ) {
+						wc_reduce_stock_levels( $order );
+					}
 
 				} else {
 


### PR DESCRIPTION
## Summary

The framework will manually reduce stock for orders which have a held status.

However, WooCommerce 3.5+ will do this already, resulting in twice reduced stock for such orders. 

### Story

- [ch20837](https://app.clubhouse.io/skyverge/story/20837/stock-reduced-twice-when-order-is-held-but-payment-not-completed)

### Details

This PR will introduce a WC 3.5 check before reducing stock levels for held orders.

## QA

- [x] Follow QA steps in this [PR for Authorize.Net](https://github.com/skyverge/wc-plugins/pull/3328) which generated most support tickets
- [x] Similar [PR for Elavon](https://github.com/skyverge/wc-plugins/pull/3330), also present in support tickets

### Resources

 - [Current WC code to reduce stock for held orders](https://github.com/woocommerce/woocommerce/blob/d9f971627401d46589de088457411663f41135a6/includes/wc-stock-functions.php#L108)
- [Commit in WC to reduce stock, tagged for 3.5.0-beta](https://github.com/woocommerce/woocommerce/commit/70c9cff608761fcd48b57f709059e00b1ffeee38)