### PR TITLE
Allow multiple old hooks to be mapped to a single new one

### DIFF
--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -116,8 +116,8 @@ class SV_WC_Hook_Deprecator {
 
 		$new_hooks = wp_list_pluck( $this->hooks, 'replacement' );
 
-		// check if there is a matching old hook for the current hook
-		if ( $old_hook = array_search( $new_hook, $new_hooks ) ) {
+		// check if there are matching old hooks for the current hook
+		foreach ( array_keys( $new_hooks, $new_hook ) as $old_hook ) {
 
 			// check if there are any hooks added to the old hook
 			if ( has_filter( $old_hook ) ) {


### PR DESCRIPTION
# Summary

Updates the `SV_WC_Hook_Deprecator` class to allow multiple old hooks to be mapped to the same new hook. 

Related to https://github.com/skyverge/wc-plugins/pull/3329

## Details

Version 5.0.0 of the Customer/Order/Coupon Export plugin includes filters from both the CSV and XML Export plugins. Some of those hooks have the exact same purpose and are mapped to a single hook in the new unified plugin. Sine the `SV_WC_Hook_Deprecator` currently assumes there is only one old hook mapped to any of the new hooks, some of the hooks in the previous versions of the export plugins are not being properly mapped and fired.