### PR TITLE
Hardens pre-orders integration to avoid fatal error in some circumstances

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,7 @@
 
 2019.nn.nn - version 5.5.1
  * Tweak - Allow multiple old hooks to be mapped to a single new one
+ * Fix - Harden integration with WooCommerce Pre-Orders to avoid a PHP error in some circumstances
 
 2019.10.15 - version 5.5.0
  * Feature - Add a plugin helper method to retrieve a template part while consistently passing the default template path to `wc_get_template()`

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -80,28 +80,32 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 
 	/**
-	 * Force tokenization for pre-orders
+	 * Forces tokenization for pre-orders.
+	 *
+	 * @see SV_WC_Payment_Gateway::tokenization_forced()
 	 *
 	 * @since 4.1.0
-	 * @see SV_WC_Payment_Gateway::tokenization_forced()
-	 * @param boolean $force_tokenization whether tokenization should be forced
-	 * @return boolean true if tokenization should be forced, false otherwise
+	 *
+	 * @param bool $force_tokenization whether tokenization should be forced
+	 * @return bool
 	 */
 	public function maybe_force_tokenization( $force_tokenization ) {
 
-		// pay page with pre-order?
 		$pay_page_pre_order = false;
+
+		// pay page with pre-order?
 		if ( $this->get_gateway()->is_pay_page_gateway() ) {
 
-			$order_id  = $this->get_gateway()->get_checkout_pay_page_order_id();
+			$order_id = $this->get_gateway()->get_checkout_pay_page_order_id();
 
-			if ( $order_id ) {
-				$pay_page_pre_order = \WC_Pre_Orders_Order::order_contains_pre_order( $order_id ) && \WC_Pre_Orders_Product::product_is_charged_upon_release( \WC_Pre_Orders_Order::get_pre_order_product( $order_id ) );
+			if ( $order_id && \WC_Pre_Orders_Order::order_contains_pre_order( $order_id ) ) {
+
+				$pre_order_product  = \WC_Pre_Orders_Order::get_pre_order_product( $order_id );
+				$pay_page_pre_order = $pre_order_product && \WC_Pre_Orders_Product::product_is_charged_upon_release( $pre_order_product );
 			}
 		}
 
-		if ( ( \WC_Pre_Orders_Cart::cart_contains_pre_order() && \WC_Pre_Orders_Product::product_is_charged_upon_release( \WC_Pre_Orders_Cart::get_pre_order_product() ) ) ||
-			 $pay_page_pre_order ) {
+		if ( $pay_page_pre_order || ( \WC_Pre_Orders_Cart::cart_contains_pre_order() && \WC_Pre_Orders_Product::product_is_charged_upon_release( \WC_Pre_Orders_Cart::get_pre_order_product() ) ) ) {
 
 			// always tokenize the card for pre-orders that are charged upon release
 			$force_tokenization = true;


### PR DESCRIPTION
### Summary

Hardens WooCommerce Pre-Orders handling to avoid a PHP critical error in some circumstances.

#### Details

Just introduces an additional sanity check to avoid causing a PHP error by passing a variable of the wrong type to Pre-Orders

### Resources

#352 - Issue reported by A8C