### PR TITLE
Add properties to the SV_WC_Payment_Gateway_Payment_Token object

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -50,6 +50,11 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	protected $img_url;
 
+	/**
+	 * @var \WC_Payment_Token WC core token
+	 */
+	private $token = null;
+
 
 	/**
 	 * Initialize a payment token with associated $data which is expected to

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -51,6 +51,18 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	protected $img_url;
 
 	/**
+	 * @var array key-value array to map WC core token props to framework token `$data` keys
+	 */
+	private $props = [
+		'is_default'   => 'default',
+		'type'         => 'type',
+		'last4'        => 'last_four',
+		'expiry_year'  => 'exp_year',
+		'expiry_month' => 'exp_month',
+		'card_type'    => 'card_type',
+	];
+
+	/**
 	 * @var \WC_Payment_Token WC core token
 	 */
 	private $token = null;


### PR DESCRIPTION
# Summary

This PR adds the `props` and `token` private properties to `SV_WC_Payment_Gateway_Payment_Token`.

### Story: [CH 23974](https://app.clubhouse.io/skyverge/story/23974/add-properties-to-the-sv-wc-payment-gateway-payment-token-object)
### Release: #362

## Open Questions

- What do we do about the following keys in `WC_Payment_Token::data`, that do not have matching keys in our data? 
```
'gateway_id' => '',
'token'      => '',
'user_id'    => 0,
```