### PR TITLE
Update SV_WC_Payment_Gateway_Payment_Token constructor

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -82,7 +82,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 *
 	 * @since 1.0.0
 	 * @param string $id the payment gateway token ID
-	 * @param array $data associated data
+	 * @param array|\WC_Payment_Token $data associated data array or WC core token
 	 */
 	public function __construct( $id, $data ) {
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -493,6 +493,30 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	}
 
 
+	/**
+	 * Reads the properties and meta data of the WC core token
+	 * and sets the found key-values as an array in the `data` property.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @param \WC_Payment_Token $core_token
+	 */
+	private function read( \WC_Payment_Token $core_token ) {
+
+		$token_data = $core_token->get_data();
+
+		foreach ( $token_data as $core_key => $value ) {
+
+			if ( array_key_exists( $core_key, $this->props ) ) {
+
+				$framework_key = $this->props[ $core_key ];
+
+				$this->data[ $framework_key ] = $value;
+			}
+		}
+	}
+
+
 }
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -504,6 +504,12 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	private function read( \WC_Payment_Token $core_token ) {
 
 		$token_data = $core_token->get_data();
+		$meta_data  = $token_data['meta_data'] ?: [];
+		unset( $token_data['meta_data'] );
+
+		foreach ( $meta_data as $meta_datum ) {
+			$token_data[ $meta_datum->key ] = $meta_datum->value;
+		}
 
 		foreach ( $token_data as $core_key => $value ) {
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -86,25 +86,33 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	public function __construct( $id, $data ) {
 
-		if ( isset( $data['type'] ) && 'credit_card' == $data['type'] ) {
+		if ( $data instanceof \WC_Payment_Token ) {
 
-			// normalize the provided card type to adjust for possible abbreviations if set
-			if ( isset( $data['card_type'] ) && $data['card_type'] ) {
+			$this->token = $data;
 
-				$data['card_type'] = SV_WC_Payment_Gateway_Helper::normalize_card_type( $data['card_type'] );
+		} else {
 
-			// otherwise, get the payment type from the account number
-			} elseif ( isset( $data['account_number'] ) ) {
+			if ( isset( $data['type'] ) && 'credit_card' == $data['type'] ) {
 
-				$data['card_type'] = SV_WC_Payment_Gateway_Helper::card_type_from_account_number( $data['account_number'] );
+				// normalize the provided card type to adjust for possible abbreviations if set
+				if ( isset( $data['card_type'] ) && $data['card_type'] ) {
+
+					$data['card_type'] = SV_WC_Payment_Gateway_Helper::normalize_card_type( $data['card_type'] );
+
+				// otherwise, get the payment type from the account number
+				} elseif ( isset( $data['account_number'] ) ) {
+
+					$data['card_type'] = SV_WC_Payment_Gateway_Helper::card_type_from_account_number( $data['account_number'] );
+				}
 			}
+
+			// remove account number so it's not saved to the token
+			unset( $data['account_number'] );
+
+			$this->data = $data;
 		}
 
-		// remove account number so it's not saved to the token
-		unset( $data['account_number'] );
-
 		$this->id    = $id;
-		$this->data  = $data;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -90,6 +90,8 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 			$this->token = $data;
 
+			$this->read( $this->token );
+
 		} else {
 
 			if ( isset( $data['type'] ) && 'credit_card' == $data['type'] ) {


### PR DESCRIPTION
# Summary

This PR:
- adds the `read` function to read data from the core token and store it in the `data` property 
- updates the constructor to accept a `WC_Payment_Token` as a param, store it in a property and call the read function

### Story: [CH 23980](https://app.clubhouse.io/skyverge/story/23980/update-sv-wc-payment-gateway-payment-token-constructor)
### Release: #362
