### PR TITLE
Add user ID setter & getter methods to token object 

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -54,6 +54,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * @var array key-value array to map WooCommerce core token props to framework token `$data` keys
 	 */
 	private $props = [
+		'user_id'      => 'user_id',
 		'is_default'   => 'default',
 		'type'         => 'type',
 		'last4'        => 'last_four',
@@ -133,6 +134,32 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	public function get_id() {
 
 		return $this->id;
+	}
+
+
+	/**
+	 * Gets the ID of the user associated with the token.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @return int
+	 */
+	public function get_user_id() {
+
+		return isset( $this->data['user_id'] ) ? absint( $this->data['user_id'] ) : 0;
+	}
+
+
+	/**
+	 * Sets the ID of the user associated with the token.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @param int $user_id
+	 */
+	public function set_user_id( $user_id ) {
+
+		$this->data['user_id'] = is_numeric( $user_id ) ? absint( $user_id ) : 0;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -70,9 +70,11 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
-	 * Initialize a payment token with associated $data which is expected to
-	 * have the following members:
+	 * Initializes a payment token.
 	 *
+	 * The token $data is expected to have the following members:
+	 *
+	 * user_id      - int identifier of the customer user associated to this token
 	 * default      - boolean optional indicates this is the default payment token
 	 * type         - string one of 'credit_card' or 'echeck' ('check' for backwards compatibility)
 	 * last_four    - string last four digits of account number
@@ -82,6 +84,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * account_type - string one of 'checking' or 'savings' (checking gateway only)
 	 *
 	 * @since 1.0.0
+	 *
 	 * @param string $id the payment gateway token ID
 	 * @param array $data associated data
 	 */


### PR DESCRIPTION
# Summary

This PR adds a `get_user_id()` and a `set_user_id()` public methods to the `SV_WC_Payment_Gateway_Payment_Token` object.

### Story: [ch24067](https://app.clubhouse.io/skyverge/story/24067/add-user-id-methods-to-the-framework-token-object)
### Release: #362

### QA

- [ ] When using `set_user_id( (int) $user_id )` a `user_id` should be added to the `SV_WC_Payment_Gateway_Payment_Token::$data` array.
- [ ] When using `get_user_id()` a `user_id` should be returned as it appears in the `SV_WC_Payment_Gateway_Payment_Token::$data` array.
