### PR TITLE
Mark build_token() method in token handler to accept core tokens

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -64,14 +64,17 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 
 	/**
-	 * A factory method to build and return a payment token object for the
-	 * gateway.  Concrete classes can override this method to return a custom
-	 * payment token implementation.
+	 * Builds the token object.
+	 *
+	 * A factory method to build and return a payment token object for the gateway.
+	 * Child implementations can override this method to return a custom payment token.
+	 *
+	 * From version 5.6.0, this method can accept a core \WC_Payment_Token type as the second argument to read data from.
 	 *
 	 * @since 4.3.0
 	 *
 	 * @param string $token payment token
-	 * @param array $data {
+	 * @param \WC_Payment_Token|array $data {
 	 *     Payment token data.
 	 *
 	 *     @type bool   $default   Optional. Indicates this is the default payment token


### PR DESCRIPTION
# Summary

This PR marks the `SV_WC_Payment_Gateway_Payment_Tokens_Handler::build_token()` method to be able to accept a `\WC_Payment_Token` object as the 2nd argument and updates the corresponding phpdoc.

### Story: [ch24003](https://app.clubhouse.io/skyverge/story/24003/update-sv-wc-payment-gateway-payment-tokens-handler-build-token-method)
### Release: #362
