### PR TITLE
Add a token object method to get the WC core token

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -473,6 +473,19 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
+	 * Gets the WooCommerce core payment token object related to this framework token.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @return \WC_Payment_Token|null
+	 */
+	public function get_woocommerce_payment_token() {
+
+		return $this->token instanceof \WC_Payment_Token ? $this->token : null;
+	}
+
+
+	/**
 	 * Returns a representation of this token suitable for persisting to a
 	 * datastore
 	 *


### PR DESCRIPTION
# Summary

This PR adds a `get_woocommerce_payment_token()` to the `SV_WC_Payment_Gateway_Payment_Token` object.

### Story: [ch23998](https://app.clubhouse.io/skyverge/story/23998/implement-sv-wc-payment-gateway-payment-token-get-woocommerce-payment-token)
### Release: #362

### QA

- [x] When using `get_woocommerce_payment_token()` if a token object is set for the current framework token, the return type is `\WC_Payment_Token` and matches `SV_WC_Payment_Gateway_Payment_Token::$token`.
- [x] When using `get_woocommerce_payment_token()` if a token object is _not_ set for the current framework token, the return type is `null`.