### PR TITLE
Prevent js error on my account > payment methods screen

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,7 @@
 
 2019.nn.nn - version 5.6.0-dev.1
  * Tweak - Migrate payment tokens to be compatible with WC core payment tokens
+ * Fix - Fix a JavaScript error when instantiating a class that hasn't been loaded
 
 2019.11.14 - version 5.5.1
  * Tweak - Refactor Apple Pay order creation to support the same filters and actions that are fired during regular checkout

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -217,36 +217,40 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function render_js() {
 
-		$args = array(
-			'id'              => $this->get_plugin()->get_id(),
-			'slug'            => $this->get_plugin()->get_id_dasherized(),
-			'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
-			'ajax_url'        => admin_url( 'admin-ajax.php' ),
-			'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
-			'i18n'            => array(
-				'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
-				'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
-				'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
-				'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
-			),
-		);
+        if ( $this->has_tokens ) {
 
-		/**
-		 * Filters the payment gateway payment methods JavaScript args.
-		 *
-		 * @since 5.1.0
-		 *
-		 * @param array $args arguments
-		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
-		 */
-		$args = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this );
+            $args = array(
+                'id' => $this->get_plugin()->get_id(),
+                'slug' => $this->get_plugin()->get_id_dasherized(),
+                'has_core_tokens' => (bool)wc_get_customer_saved_methods_list(get_current_user_id()),
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'ajax_nonce' => wp_create_nonce('wc_' . $this->get_plugin()->get_id() . '_save_payment_method'),
+                'i18n' => array(
+                    'edit_button' => esc_html__('Edit', 'woocommerce-plugin-framework'),
+                    'cancel_button' => esc_html__('Cancel', 'woocommerce-plugin-framework'),
+                    'save_error' => esc_html__('Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework'),
+                    'delete_ays' => esc_html__('Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework'),
+                ),
+            );
 
-		wc_enqueue_js( sprintf(
-			'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
-			esc_js( $this->get_plugin()->get_id() ),
-			esc_js( $this->get_js_handler_class() ),
-			json_encode( $args )
-		) );
+            /**
+             * Filters the payment gateway payment methods JavaScript args.
+             *
+             * @param array $args arguments
+             * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
+             * @since 5.1.0
+             *
+             */
+            $args = apply_filters('wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this);
+
+            wc_enqueue_js(sprintf(
+                'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
+                esc_js($this->get_plugin()->get_id()),
+                esc_js($this->get_js_handler_class()),
+                json_encode($args)
+            ));
+            
+        }
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -205,7 +205,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 			 */
 			do_action( 'wc_' . $this->get_plugin()->get_id() . '_after_my_payment_method_table', $this );
-
 		}
 	}
 
@@ -220,36 +219,35 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
         if ( $this->has_tokens ) {
 
             $args = array(
-                'id' => $this->get_plugin()->get_id(),
-                'slug' => $this->get_plugin()->get_id_dasherized(),
-                'has_core_tokens' => (bool)wc_get_customer_saved_methods_list(get_current_user_id()),
-                'ajax_url' => admin_url('admin-ajax.php'),
-                'ajax_nonce' => wp_create_nonce('wc_' . $this->get_plugin()->get_id() . '_save_payment_method'),
-                'i18n' => array(
-                    'edit_button' => esc_html__('Edit', 'woocommerce-plugin-framework'),
-                    'cancel_button' => esc_html__('Cancel', 'woocommerce-plugin-framework'),
-                    'save_error' => esc_html__('Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework'),
-                    'delete_ays' => esc_html__('Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework'),
+                'id'              => $this->get_plugin()->get_id(),
+                'slug'            => $this->get_plugin()->get_id_dasherized(),
+                'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
+                'ajax_url'        => admin_url( 'admin-ajax.php' ),
+                'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
+                'i18n'            => array(
+                    'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
+                    'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
+                    'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
+                    'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
                 ),
             );
 
             /**
              * Filters the payment gateway payment methods JavaScript args.
              *
+			 * @since 5.1.0
+			 *
              * @param array $args arguments
              * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
-             * @since 5.1.0
-             *
              */
-            $args = apply_filters('wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this);
+            $args = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this );
 
-            wc_enqueue_js(sprintf(
+            wc_enqueue_js( sprintf(
                 'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
-                esc_js($this->get_plugin()->get_id()),
-                esc_js($this->get_js_handler_class()),
-                json_encode($args)
-            ));
-            
+                esc_js( $this->get_plugin()->get_id() ),
+                esc_js( $this->get_js_handler_class() ),
+                json_encode( $args )
+            ) );
         }
 	}
 


### PR DESCRIPTION
# Summary

This PR adds a check to the `render_js` function to make sure there are existing tokens, therefore the front end class has been loaded, before attempting to initialize said class.

### Story: [ch24095](https://app.clubhouse.io/skyverge/story/24095/uncaught-error-when-customer-has-no-saved-cards)
### Release: #362

### QA

- [x] Navigating to my-account > payment methods with no previously saved tokens should not throw a JavaScript ReferenceError.
- [x] Navigating to my-account > payment methods with a saved token should still display previously saved cards.
