### PR TITLE
Implement SV_WC_Payment_Gateway_Payment_Token::save()

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -666,7 +666,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 				if ( false !== $core_key ) {
 					$token->set_props( [ $core_key => $value ] );
 				} else {
-					$token->add_meta_data( $key, $value, true );
+					$token->update_meta_data( $key, $value, true );
 				}
 			}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -538,6 +538,19 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	}
 
 
+	/**
+	 * Stores the token data in the database.
+	 *
+	 * Stores the token data as a Woocommerce payment token, in the `wp_woocommerce_payment_tokens` table,
+	 * with meta data in the `wp_woocommerce_payment_tokenmeta` table.
+	 *
+	 * @since 5.6.0-dev.1
+	 */
+	public function save() {
+
+	}
+
+
 }
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -593,6 +593,10 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 				foreach ( $this->data as $key => $value ) {
 
+					if ( 'exp_year' === $key && 2 === strlen( $value ) ) {
+						$value = '20' . $value;
+					}
+
 					$core_key = array_search( $key, $this->props );
 
 					if ( false !== $core_key ) {

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -563,6 +563,16 @@ class SV_WC_Payment_Gateway_Payment_Token {
 					break;
 				}
 			}
+
+			if ( empty( $token ) ) {
+
+				// instantiate a new token
+				if ( $this->is_credit_card() ) {
+					$token = new \WC_Payment_Token_CC();
+				} elseif ( $this->is_echeck() ) {
+					$token = new \WC_Payment_Token_ECheck();
+				}
+			}
 		}
 	}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -558,7 +558,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 			foreach ( $saved_tokens as $saved_token ) {
 
-				if ( $saved_token->get_id() === $this->get_id() ) {
+				if ( $saved_token->get_token() === $this->get_id() ) {
 					$token = $saved_token;
 					break;
 				}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -575,6 +575,16 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 				// mark the token as migrated
 				$this->data['migrated'] = true;
+
+				// update legacy token in user meta data
+				$gateways   = WC()->payment_gateways->payment_gateways();
+				// TODO: use `get_gateway_id`, once merged {DM 2019-12-12}
+				$gateway_id = $this->data['gateway_id'];
+
+				if ( ! empty( $gateway_id ) && ! empty( $gateway = $gateways[ $gateway_id ] ) ) {
+					// TODO: use `get_user_id`, once merged {DM 2019-12-12}
+					$gateway->get_payment_tokens_handler()->update_legacy_token( $this->data['user_id'], $this );
+				}
 			}
 
 			if ( ! empty( $token ) ) {

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -572,6 +572,9 @@ class SV_WC_Payment_Gateway_Payment_Token {
 				} elseif ( $this->is_echeck() ) {
 					$token = new \WC_Payment_Token_ECheck();
 				}
+
+				// mark the token as migrated
+				$this->data['migrated'] = true;
 			}
 
 			if ( ! empty( $token ) ) {

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -548,6 +548,9 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	public function save() {
 
+		if ( $this->token instanceof \WC_Payment_Token ) {
+			$token = $this->token;
+		}
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -641,7 +641,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			$this->data['migrated'] = true;
 
 			// update legacy token in user meta data
-			$gateways   = WC()->payment_gateways->payment_gateways();
+			$gateways   = WC()->payment_gateways()->payment_gateways();
 			$gateway_id = $this->get_gateway_id();
 
 			if ( ! empty( $gateway_id ) && ! empty( $gateway = $gateways[ $gateway_id ] ) ) {

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -606,6 +606,8 @@ class SV_WC_Payment_Gateway_Payment_Token {
 						$token->add_meta_data( $key, $value, true );
 					}
 				}
+
+				$token->save();
 			}
 		}
 	}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -573,6 +573,23 @@ class SV_WC_Payment_Gateway_Payment_Token {
 					$token = new \WC_Payment_Token_ECheck();
 				}
 			}
+
+			if ( ! empty( $token ) ) {
+
+				$token->set_token( $this->get_id() );
+
+				foreach ( $this->data as $key => $value ) {
+
+					$core_key = array_search( $key, $this->props );
+
+					if ( false !== $core_key ) {
+						$token->set_props( [ $core_key => $value ] );
+					} else {
+						// metadata
+						$token->add_meta_data( $key, $value, true );
+					}
+				}
+			}
 		}
 	}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -611,8 +611,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 		} else {
 
 			// see if there is already a token with this ID saved for this customer and gateway
-			// TODO: use `get_user_id` and `get_gateway_id`, once merged {DM 2019-12-12}
-			$saved_tokens = \WC_Payment_Tokens::get_customer_tokens( $this->data['user_id'], $this->data['gateway_id'] );
+			$saved_tokens = \WC_Payment_Tokens::get_customer_tokens( $this->get_user_id(), $this->get_gateway_id() );
 
 			foreach ( $saved_tokens as $saved_token ) {
 
@@ -636,12 +635,10 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 				// update legacy token in user meta data
 				$gateways   = WC()->payment_gateways->payment_gateways();
-				// TODO: use `get_gateway_id`, once merged {DM 2019-12-12}
-				$gateway_id = $this->data['gateway_id'];
+				$gateway_id = $this->get_gateway_id();
 
 				if ( ! empty( $gateway_id ) && ! empty( $gateway = $gateways[ $gateway_id ] ) ) {
-					// TODO: use `get_user_id`, once merged {DM 2019-12-12}
-					$gateway->get_payment_tokens_handler()->update_legacy_token( $this->data['user_id'], $this );
+					$gateway->get_payment_tokens_handler()->update_legacy_token( $this->get_user_id(), $this );
 				}
 			}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -666,7 +666,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 				if ( false !== $core_key ) {
 					$token->set_props( [ $core_key => $value ] );
 				} else {
-					// metadata
 					$token->add_meta_data( $key, $value, true );
 				}
 			}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -655,6 +655,8 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 			foreach ( $this->data as $key => $value ) {
 
+				// prefix the expiration year if needed (WC_Payment_Token requires it to be 4 digits long)
+				// TODO: figure out how to handle cards expiring before 2000 {DM 2019-12-13}
 				if ( 'exp_year' === $key && 2 === strlen( $value ) ) {
 					$value = '20' . $value;
 				}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -550,6 +550,19 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		if ( $this->token instanceof \WC_Payment_Token ) {
 			$token = $this->token;
+		} else {
+
+			// see if there is already a token with this ID saved for this customer and gateway
+			// TODO: use `get_user_id` and `get_gateway_id`, once merged {DM 2019-12-12}
+			$saved_tokens = \WC_Payment_Tokens::get_customer_tokens( $this->data['user_id'], $this->data['gateway_id'] );
+
+			foreach ( $saved_tokens as $saved_token ) {
+
+				if ( $saved_token->get_id() === $this->get_id() ) {
+					$token = $saved_token;
+					break;
+				}
+			}
 		}
 	}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -587,6 +587,8 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	/**
 	 * Updates a single legacy token in user meta.
 	 *
+	 * @see SV_WC_Payment_Gateway_Payment_Token::save()
+	 *
 	 * @since 5.6.0-dev.1
 	 *
 	 * @param int $user_id WP user ID

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -584,6 +584,35 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	}
 
 
+	/**
+	 * Updates a single legacy token in user meta.
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @param int $user_id WP user ID
+	 * @param SV_WC_Payment_Gateway_Payment_Token $token token to update
+	 * @param string|null $environment_id optional environment ID, defaults to plugin current environment
+	 * @return string|int updated user meta ID
+	 */
+	public function update_legacy_token( $user_id, $token, $environment_id = null ) {
+
+		// default to current environment
+		if ( null === $environment_id ) {
+			$environment_id = $this->get_environment_id();
+		}
+
+		$legacy_tokens = get_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), true );
+
+		if ( isset( $legacy_tokens[ $token->get_id() ] ) ) {
+			$legacy_tokens[ $token->get_id() ] = $token->to_datastore_format();
+		}
+
+		return update_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), $legacy_tokens );
+	}
+
+
 
 	/** Admin methods *****************************************************************************/
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -592,7 +592,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 * @param int $user_id WP user ID
 	 * @param SV_WC_Payment_Gateway_Payment_Token $token token to update
 	 * @param string|null $environment_id optional environment ID, defaults to plugin current environment
-	 * @return string|int updated user meta ID
+	 * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure
 	 */
 	public function update_legacy_token( $user_id, $token, $environment_id = null ) {
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -596,6 +596,8 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 */
 	public function update_legacy_token( $user_id, $token, $environment_id = null ) {
 
+		$updated = false;
+
 		// default to current environment
 		if ( null === $environment_id ) {
 			$environment_id = $this->get_environment_id();
@@ -603,11 +605,14 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 		$legacy_tokens = get_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), true );
 
-		if ( isset( $legacy_tokens[ $token->get_id() ] ) ) {
+		if ( is_array( $legacy_tokens ) && isset( $legacy_tokens[ $token->get_id() ] ) ) {
+
 			$legacy_tokens[ $token->get_id() ] = $token->to_datastore_format();
+
+			$updated = update_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), $legacy_tokens );
 		}
 
-		return update_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), $legacy_tokens );
+		return $updated;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -587,8 +587,6 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	/**
 	 * Updates a single legacy token in user meta.
 	 *
-	 * @internal
-	 *
 	 * @since 5.6.0-dev.1
 	 *
 	 * @param int $user_id WP user ID


### PR DESCRIPTION
# Summary

This PR adds a `save()` method to the `SV_WC_Payment_Gateway_Payment_Token` class.

### Story: [CH 23987](https://app.clubhouse.io/skyverge/story/23987/implement-sv-wc-payment-gateway-payment-token-save)
### Release: #362

### QA

#### Setup

- Saved a payment method in a configured gateway
- Set up the gateway to use this version of the framework (I've symlinked it in the `vendor/skyverge` folder)
- Temporarily update `SV_WC_Payment_Gateway_Payment_Tokens_Handler::build_token` to set all the properties needed and save the token:
```
$data['type'] = 'credit_card';
$data['gateway_id'] = $this->get_gateway()->get_id();
$data['user_id'] = 8;

$token = new SV_WC_Payment_Gateway_Payment_Token( $token, $data );

$token->save();

return $token;
```
- Add `gateway_id` and `user_id` to the `props` property in `SV_WC_Payment_Gateway_Payment_Token` (if #364 and #365 are not merged yet)

#### Steps

1. Add a new payment method in your payment gateway using this branch of the framework
    - [x] The payment token in user meta is updated with the `migrated` key set to true/1
    - [x] The payment token is saved in the `wp_woocommerce_payment_tokens` and its meta is saved in `wp_woocommerce_payment_tokenmeta`
1. Refresh the page
    - [x] The payment token is not duplicated in `wp_woocommerce_payment_tokens`