### PR TITLE
Implement SV_WC_Payment_Gateway_Payment_Token::delete()

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -673,7 +673,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
-	 * Deletes a token from the database.
+	 * Deletes the token from the database.
 	 *
 	 * Also deletes a token from the legacy user meta.
 	 * @see \WC_Payment_Token::delete()

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -689,20 +689,48 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		$deleted = false;
 
+		// delete the core token from WooCommerce tables
 		if ( $token = $this->get_woocommerce_payment_token() ) {
 			$deleted = $token->delete( $force_delete );
 		}
 
-		// delete legacy token in user meta data
-		$gateways   = WC()->payment_gateways()->payment_gateways();
-		$gateway_id = $this->get_gateway_id();
-
-		if ( ! empty( $gateway_id ) && ! empty( $gateway = $gateways[ $gateway_id ] ) ) {
-			/** @see SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_legacy_token() */
-			$gateway->get_payment_tokens_handler()->delete_legacy_token( $this->get_user_id(), $this );
+		// delete legacy token in WordPress user meta table
+		if ( $tokens_handler = $this->get_tokens_handler() ) {
+			$tokens_handler->delete_legacy_token( $this->get_user_id(), $this );
 		}
 
 		return $deleted;
+	}
+
+
+	/**
+	 * Gets the gateway tokens handler.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @return SV_WC_Payment_Gateway_Payment_Tokens_Handler|null
+	 */
+	protected function get_tokens_handler() {
+
+		$handler    = null;
+		$gateway_id = $this->get_gateway_id();
+
+		if ( ! empty( $gateway_id ) ) {
+
+			$gateways = WC()->payment_gateways()->payment_gateways();
+
+			if ( $gateways && isset( $gateways[ $gateway_id ] ) ) {
+
+				$gateway = $gateways[ $gateway_id ];
+
+				if ( $gateway instanceof SV_WC_Payment_Gateway ) {
+
+					$handler = $gateway->get_payment_tokens_handler();
+				}
+			}
+		}
+
+		return $handler;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -675,7 +675,8 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	/**
 	 * Deletes the token from the database.
 	 *
-	 * Also deletes a token from the legacy user meta.
+	 * Also deletes the token from the legacy user meta.
+	 *
 	 * @see \WC_Payment_Token::delete()
 	 * @see SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_legacy_token()
 	 *

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -672,6 +672,24 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	}
 
 
+	/**
+	 * Deletes a token from the database.
+	 *
+	 * Also deletes a token from the legacy user meta.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @param bool $force_delete argument mapped to {@see \WC_Data::delete()}
+	 */
+	public function delete( $force_delete = false ) {
+
+		if ( $token = $this->get_woocommerce_payment_token() ) {
+
+			$token->delete( $force_delete );
+		}
+	}
+
+
 }
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -676,6 +676,8 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * Deletes a token from the database.
 	 *
 	 * Also deletes a token from the legacy user meta.
+	 * @see \WC_Payment_Token::delete()
+	 * @see SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_legacy_token()
 	 *
 	 * @since 5.6.0-dev.1
 	 *

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -385,6 +385,38 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 
 	/**
+	 * Deletes a legacy payment token from user meta.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @param int $user_id WordPress user ID
+	 * @param SV_WC_Payment_Gateway_Payment_Token $token payment token object
+	 * @param string|null $environment_id gateway environment ID
+	 * @return bool whether the token was deleted from the user meta
+	 */
+	public function delete_legacy_token( $user_id, SV_WC_Payment_Gateway_Payment_Token $token, $environment_id = null ) {
+
+		$deleted = false;
+
+		// default to current environment
+		if ( null === $environment_id ) {
+			$environment_id = $this->get_environment_id();
+		}
+
+		$legacy_tokens = get_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), true );
+
+		if ( is_array( $legacy_tokens ) && isset( $legacy_tokens[ $token->get_id() ] ) ) {
+
+			unset( $legacy_tokens[ $token->get_id() ] );
+
+			$deleted = (bool) update_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), $legacy_tokens );
+		}
+
+		return $deleted;
+	}
+
+
+	/**
 	 * Sets the default token for a user.
 	 *
 	 * This is shown as "Default Card" in the frontend and will be auto-selected during checkout.

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -387,6 +387,8 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	/**
 	 * Deletes a legacy payment token from user meta.
 	 *
+	 * @see SV_WC_Payment_Gateway_Payment_Token::delete()
+	 *
 	 * @since 5.6.0-dev.1
 	 *
 	 * @param int $user_id WordPress user ID


### PR DESCRIPTION
# Summary

This PR adds a `delete()` method to the `SV_WC_Payment_Gateway_Payment_Token` class.

### Story: [CH 23993](https://app.clubhouse.io/skyverge/story/23993/implement-sv-wc-payment-gateway-payment-token-delete)
### Release: #362

### QA

#### Setup

Same setup as #370 

- Have a gateway configured with some test order placed
- Set up the gateway to use this version of the framework
- Temporarily update `SV_WC_Payment_Gateway_Payment_Tokens_Handler::build_token()` to set all the properties needed and save a token first:
```php
$data['type'] = 'credit_card';
$data['gateway_id'] = $this->get_gateway()->get_id();
$data['user_id'] = 8;

$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( $token, $data );

$token->save();
```

This should give you a token as in #370. 

#### Steps

Verify you have some token in db, saved as in `Setup` above.

Then, you may use the following to delete a token:

```php

// retrieve the token you have saved before
$core_token = new \WC_Payment_Token_CC( $token_identifier );

// instantiate our token 
$fw_token = new Framework\SV_WC_Payment_Gateway_Payment_Token( $user_id, core_token );

// delete the token:
$fw_token->delete();
```

The token now should be deleted from database.

Repeat the steps above with a legacy token that was saved and migrated: in this instance, both the legacy data from the corresponding WordPress user meta and the token entry in WooCommerce tables should be wiped.
