### PR TITLE
Fix verification in SV_WC_Payment_Gateway_Apple_Pay::process_payment()

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,10 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2019.nn.nn - version 5.6.0-dev.1
+
+* Fix - `SV_WC_Payment_Gateway_Apple_Pay::process_payment()` now throws an exception if the result returned by the processing gateway doesn't indicate whether the transaction was successful or not
+* Fix - Update `SV_WC_Payment_Gateway_Direct::process_payment()` to cover for and edge case in which `SV_WC_Payment_Gateway_Direct::do_transaction()` fails without throwing an exception
+
 2019.11.14 - version 5.5.1
  * Tweak - Refactor Apple Pay order creation to support the same filters and actions that are fired during regular checkout
  * Tweak - Allow multiple old hooks to be mapped to a single new one via the hook deprecator

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -134,7 +134,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 				$result = $this->get_processing_gateway()->process_payment( $order->get_id() );
 			}
 
-			if ( isset( $result['result'] ) && 'success' !== $result['result'] ) {
+			if ( ! isset( $result['result'] ) || 'success' !== $result['result'] ) {
 				throw new SV_WC_Payment_Gateway_Exception( 'Gateway processing error.' );
 			}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -428,6 +428,13 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 					'result'   => 'success',
 					'redirect' => $this->get_return_url( $order ),
 				);
+
+			} else {
+
+				return [
+					'result'  => 'failure',
+					'message' => 'The transaction failed.',
+				];
 			}
 
 		} catch ( SV_WC_Plugin_Exception $e ) {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -424,10 +424,10 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 				 */
 				do_action( 'wc_payment_gateway_' . $this->get_id() . '_payment_processed', $order, $this );
 
-				return array(
+				return [
 					'result'   => 'success',
 					'redirect' => $this->get_return_url( $order ),
-				);
+				];
 
 			} else {
 
@@ -441,10 +441,10 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 
 			$this->mark_order_as_failed( $order, $e->getMessage() );
 
-			return array(
+			return [
 				'result'  => 'failure',
 				'message' => $e->getMessage(),
-			);
+			];
 		}
 
 		return $default;


### PR DESCRIPTION
# Summary

This PR fixes `SV_WC_Payment_Gateway_Apple_Pay::process_payment()` to throw an exception if the processing gateway doesn't return a successful response.

Additionally, it updates `SV_WC_Payment_Gateway_Direct::process_payment()` to cover for and edge case in which `SV_WC_Payment_Gateway_Direct::do_transaction()` fails to create a transaction, but returns `false` instead of throwing an exception.

### Story: [CH 24235](https://app.clubhouse.io/skyverge/story/24235/)

## QA

This bug is an edge case I discovered while performing some Apple Pay tests for [HS 111556](https://secure.helpscout.net/conversation/953413936/111556/#thread-2912230502) and not having a device that supports Apple Pay. As a results the steps to test are a bit hacky.

### Setup

Activate WooCommerce Authorize.Net Gateway and enable Apple Pay. You can use a fake merchant ID and certificate as no real transactions will be processed.

### Using the version of the framework included in the extension

1. Go to a product page and add the product to the cart
1. Execute the following on the browsers console:

	    sv_wc_apple_pay_handler.process_authorization( {} )

	- [x] The response for the associated Ajax request is `{"success":true,"data":[]}`

### Using this branch of the framework

* Symlink or replace the copy of `woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php` in the extension's vendor directory with a copy of the file in this branch
* Symlink or replace the copy of `woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php` in the extension's vendor directory with a copy of the file in this branch

Symlinking the entire project causes scripts not be loaded correctly because URLs are not properly generated (at least on my setup).

1. Go to a product page and add the product to the cart
1. Execute the following on the browsers console:

	    sv_wc_apple_pay_handler.process_authorization( {} )

	- [x] The response for the associated Ajax request is `{"success":false,"data":{"message":"Gateway processing error.","code":0}}`

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
