### PR TITLE
Implement SV_WC_Payment_Gateway_Payment_Token::get_environment()

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -405,7 +405,7 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $woocommerce_token );
 
-		$this->assertSame( $expected_enviroment, $token->get_environment() );
+		$this->assertSame( $expected_environment, $token->get_environment() );
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -397,7 +397,7 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	 *
 	 * @dataProvider provider_get_enviroment
 	 */
-	public function test_get_environment( $stored_environment, $expected_enviroment ) {
+	public function test_get_environment( $stored_environment, $expected_environment ) {
 
 		$woocommerce_token = $this->get_new_woocommerce_credit_card_token();
 
@@ -410,11 +410,11 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
-	 * Provides test data for test_get_enviroment().
+	 * Provides test data for test_get_environment().
 	 *
 	 * @return array
 	 */
-	public function provider_get_enviroment() {
+	public function provider_get_environment() {
 
 		return [
 			'metadata is set'  => [ 'test_environment', 'test_environment' ],
@@ -437,7 +437,7 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 		$tokens_handler = \Codeception\Stub::make(
 			Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::class,
 			[
-				// mock delete_legacy_token() to check that the token enviroment is passed as the third parameter
+				// mock delete_legacy_token() to check that the token environment is passed as the third parameter
 				'delete_legacy_token' => \Codeception\Stub\Expected::once(
 					function( $user_id, $token, $environment_id ) use ( $environment ) {
 						$this->assertSame( $environment, $environment_id );

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -418,6 +418,8 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 		return [
 			'metadata is set'  => [ 'test_environment', 'test_environment' ],
+			'empty metadata'   => [ '', null ],
+			'metadata not set' => [ null, null ],
 		];
 	}
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -465,4 +465,27 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	}
 
 
+	/**
+	 * Gets a new \WC_Payment_Token_CC object.
+	 *
+	 * @return \WC_Payment_Token_CC
+	 */
+	private function get_new_woocommerce_credit_card_token() {
+
+		$token = new WC_Payment_Token_CC();
+
+		$token->set_user_id( 1 );
+		$token->set_token( '12345' );
+		$token->set_last4( '1111' );
+		$token->set_expiry_year( '2022' );
+		$token->set_expiry_month( '08' );
+		$token->set_card_type( Framework\SV_WC_Payment_Gateway_Helper::CARD_TYPE_VISA );
+
+		/** necessary so that \WC_Data::get_data() returns the props set above */
+		$token->save();
+
+		return $token;
+	}
+
+
 }

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -393,6 +393,23 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::get_environment()
+	 *
+	 * @dataProvider provider_get_enviroment
+	 */
+	public function test_get_environment( $stored_environment, $expected_enviroment ) {
+
+		$woocommerce_token = new WC_Payment_Token_CC();
+
+		$woocommerce_token->add_meta_data( 'environment', $stored_environment );
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $woocommerce_token );
+
+		$this->assertSame( $expected_enviroment, $token->get_environment() );
+	}
+
+
+	/**
 	 * Provides test data for test_get_enviroment().
 	 *
 	 * @return array

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -395,7 +395,7 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::get_environment()
 	 *
-	 * @dataProvider provider_get_enviroment
+	 * @dataProvider provider_get_environment
 	 */
 	public function test_get_environment( $stored_environment, $expected_environment ) {
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -392,6 +392,19 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	}
 
 
+	/**
+	 * Provides test data for test_get_enviroment().
+	 *
+	 * @return array
+	 */
+	public function provider_get_enviroment() {
+
+		return [
+			'metadata is set'  => [ 'test_environment', 'test_environment' ],
+		];
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -424,6 +424,42 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	}
 
 
+	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::delete()
+	 */
+	public function test_delete_passes_the_token_environment() {
+
+		$woocommerce_token = $this->get_new_woocommerce_credit_card_token();
+		$environment       = 'test_environment';
+
+		$woocommerce_token->add_meta_data( 'environment', $environment );
+
+		$tokens_handler = \Codeception\Stub::make(
+			Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::class,
+			[
+				// mock delete_legacy_token() to check that the token enviroment is passed as the third parameter
+				'delete_legacy_token' => \Codeception\Stub\Expected::once(
+					function( $user_id, $token, $environment_id ) use ( $environment ) {
+						$this->assertSame( $environment, $environment_id );
+					}
+				),
+			],
+			$this
+		);
+
+		$token = \Codeception\Stub::construct(
+			Framework\SV_WC_Payment_Gateway_Payment_Token::class,
+			[ '12345', $woocommerce_token ],
+			[
+				// mock get_tokens_handler() to return a stub
+				'get_tokens_handler' => $tokens_handler,
+			]
+		);
+
+		$token->delete();
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -399,7 +399,7 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	 */
 	public function test_get_environment( $stored_environment, $expected_enviroment ) {
 
-		$woocommerce_token = new WC_Payment_Token_CC();
+		$woocommerce_token = $this->get_new_woocommerce_credit_card_token();
 
 		$woocommerce_token->add_meta_data( 'environment', $stored_environment );
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -541,6 +541,22 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
+	 * Gets the gateway environment that this token is associated with.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @return string|null
+	 */
+	public function get_environment() {
+
+		$token       = $this->get_woocommerce_payment_token();
+		$environment = $token ? $token->get_meta( 'environment' ) : '';
+
+		return $environment ?: null;
+	}
+
+
+	/**
 	 * Gets the WooCommerce core payment token object related to this framework token.
 	 *
 	 * @since 5.6.0-dev.1

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -713,7 +713,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		// delete legacy token in WordPress user meta table
 		if ( $tokens_handler = $this->get_tokens_handler() ) {
-			$tokens_handler->delete_legacy_token( $this->get_user_id(), $this );
+			$tokens_handler->delete_legacy_token( $this->get_user_id(), $this, $this->get_environment() );
 		}
 
 		return $deleted;


### PR DESCRIPTION
# Summary

This PR implements the `SV_WC_Payment_Gateway_Payment_Token::get_environment()` and updates `SV_WC_Payment_Gateway_Payment_Token::delete()` to pass the token enviroment to `SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_legacy_token()`.

### Story: [CH 24057](https://app.clubhouse.io/skyverge/story/24057/implement-sv-wc-payment-gateway-payment-token-get-environment)
### Release: #362

## Details

This PR does not update `SV_WC_Payment_Gateway_Payment_Token::save()` to pass the token environment because we currently only update the legacy token when there is no `WC_Payment_Token` object, in which case there is no metadata to retrieve.

We may need to start taking the enviroment in the constructor, as we started doing with `gateway_id`.

## QA

- [x] SV_WC_Payment_Gateway_Payment_Token_Test::test_get_environment pass
- [x] SV_WC_Payment_Gateway_Payment_Token_Test::test_delete_passes_the_token_environment pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description
