### PR TITLE
Update SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -58,6 +58,46 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()
+	 */
+	public function test_delete_token_marks_another_token_as_deafult() {
+
+		$token_id         = '12345';
+		$default_token_id = '45678';
+
+		// store test tokens
+		$tokens = [
+			'12345' => new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', [
+				'type' => 'credit_card',
+				'last_four' => '1111',
+				'exp_month' => '01',
+				'exp_year'  => '20',
+				'card_type' => 'visa',
+				'default'   => true,
+			] ),
+			'45678' => new Framework\SV_WC_Payment_Gateway_Payment_Token( '45678', [
+				'type' => 'credit_card',
+				'last_four' => '2222',
+				'exp_month' => '01',
+				'exp_year'  => '20',
+				'card_type' => 'visa',
+			] ),
+		];
+
+		$this->get_handler()->update_tokens( 1, $tokens );
+
+		$this->get_handler()->delete_token( 1, $this->get_handler()->get_token( 1, $token_id ) );
+
+		$this->assertNull( $this->get_handler()->get_token( 1, $token_id ) );
+
+		$deafult_token = $this->get_handler()->get_token( 1, $default_token_id );
+
+		$this->assertInstanceOf( Framework\SV_WC_Payment_Gateway_Payment_Token::class, $deafult_token );
+		$this->assertTrue( $deafult_token->is_default() );
+	}
+
+
+	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::update_tokens()
 	 */
 	public function test_update_tokens() {

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -90,12 +90,12 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 		$this->assertNull( $this->get_handler()->get_token( 1, $token_id ) );
 
-		$deafult_token = $this->get_handler()->get_token( 1, $default_token_id );
+		$default_token = $this->get_handler()->get_token( 1, $default_token_id );
 
-		$this->assertInstanceOf( Framework\SV_WC_Payment_Gateway_Payment_Token::class, $deafult_token );
-		$this->assertTrue( $deafult_token->is_default() );
+		$this->assertInstanceOf( Framework\SV_WC_Payment_Gateway_Payment_Token::class, $default_token );
+		$this->assertTrue( $default_token->is_default() );
 
-		$core_token = $deafult_token->get_woocommerce_payment_token();
+		$core_token = $default_token->get_woocommerce_payment_token();
 
 		$this->assertTrue( $core_token->get_is_default() );
 	}

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -85,8 +85,6 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 		$this->get_handler()->delete_token( 1, $this->get_handler()->get_token( 1, $token_id ) );
 
-		$this->assertNull( $this->get_handler()->get_token( 1, $token_id ) );
-
 		$default_token = $this->get_handler()->get_token( 1, $default_token_id );
 
 		$this->assertInstanceOf( Framework\SV_WC_Payment_Gateway_Payment_Token::class, $default_token );

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -27,6 +27,37 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()
+	 */
+	public function test_delete_token() {
+
+		// store a test token
+		$framework_token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', [
+			'type' => 'credit_card',
+			'last_four' => '1111',
+			'exp_month' => '01',
+			'exp_year'  => '20',
+			'card_type' => 'visa',
+		] );
+
+		$this->get_handler()->update_tokens( 1, [ $framework_token->get_id() => $framework_token ] );
+
+		// prepare a mock token with the same ID of the test token
+		$token = \Codeception\Stub::make(
+			Framework\SV_WC_Payment_Gateway_Payment_Token::class,
+			[
+				'get_id' => $framework_token->get_id(),
+				'delete' => \Codeception\Stub\Expected::once(),
+			],
+			$this
+		);
+
+		// test that the token's delete method is called
+		$this->get_handler()->delete_token( 1, $token );
+	}
+
+
+	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::update_tokens()
 	 */
 	public function test_update_tokens() {

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -31,29 +31,26 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 	 */
 	public function test_delete_token() {
 
+		$token_id = '12345';
+
 		// store a test token
-		$framework_token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', [
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( $token_id, [
 			'type' => 'credit_card',
 			'last_four' => '1111',
 			'exp_month' => '01',
 			'exp_year'  => '20',
 			'card_type' => 'visa',
+			'default'   => true,
 		] );
 
-		$this->get_handler()->update_tokens( 1, [ $framework_token->get_id() => $framework_token ] );
+		$this->get_handler()->update_tokens( 1, [ $token_id => $token ] );
 
-		// prepare a mock token with the same ID of the test token
-		$token = \Codeception\Stub::make(
-			Framework\SV_WC_Payment_Gateway_Payment_Token::class,
-			[
-				'get_id' => $framework_token->get_id(),
-				'delete' => \Codeception\Stub\Expected::once(),
-			],
-			$this
-		);
+		$core_token_id = $token->get_woocommerce_payment_token()->get_id();
 
-		// test that the token's delete method is called
 		$this->get_handler()->delete_token( 1, $token );
+
+		$this->assertNull( $this->get_handler()->get_token( 1, $token_id ) );
+		$this->assertNull( \WC_Payment_Tokens::get( $core_token_id ) );
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -94,6 +94,10 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 		$this->assertInstanceOf( Framework\SV_WC_Payment_Gateway_Payment_Token::class, $deafult_token );
 		$this->assertTrue( $deafult_token->is_default() );
+
+		$core_token = $deafult_token->get_woocommerce_payment_token();
+
+		$this->assertTrue( $core_token->get_is_default() );
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -87,7 +87,6 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 		$default_token = $this->get_handler()->get_token( 1, $default_token_id );
 
-		$this->assertInstanceOf( Framework\SV_WC_Payment_Gateway_Payment_Token::class, $default_token );
 		$this->assertTrue( $default_token->is_default() );
 
 		$core_token = $default_token->get_woocommerce_payment_token();

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -688,7 +688,10 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 			$core_key = array_search( $key, $this->props, false );
 
-			if ( false !== $core_key ) {
+			/** \WC_Payment_Token does not define a set_is_default method */
+			if ( 'is_default' === $core_key ) {
+				$token->set_default( $value );
+			} elseif ( false !== $core_key ) {
 				$token->set_props( [ $core_key => $value ] );
 			} else {
 				$token->update_meta_data( $key, $value, true );

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -369,7 +369,13 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 		unset( $tokens[ $token->get_id() ] );
 
-		// if the deleted card was the default one, make another one the new default
+		// delete token from local cache
+		unset( $this->tokens[ $environment_id ][ $user_id ][ $token->get_id() ] );
+
+		// clear the transient
+		$this->clear_transient( $user_id );
+
+		// if the deleted token was the default token, make another one the new default
 		if ( $token->is_default() ) {
 
 			foreach ( array_keys( $tokens ) as $key ) {
@@ -379,10 +385,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			}
 		}
 
-		$token->delete();
-
-		// persist the updated tokens
-		return $this->update_tokens( $user_id, $tokens );
+		return $token->delete();
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -356,7 +356,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	public function delete_token( $user_id, SV_WC_Payment_Gateway_Payment_Token $token, $environment_id = null ) {
 
 		// default to current environment
-		if ( is_null( $environment_id ) ) {
+		if ( null === $environment_id ) {
 			$environment_id = $this->get_environment_id();
 		}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -381,6 +381,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			foreach ( array_keys( $tokens ) as $key ) {
 
 				$tokens[ $key ]->set_default( true );
+				$tokens[ $key ]->save();
 				break;
 			}
 		}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -379,6 +379,8 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			}
 		}
 
+		$token->delete();
+
 		// persist the updated tokens
 		return $this->update_tokens( $user_id, $tokens );
 	}


### PR DESCRIPTION
# Summary

This PR updates `SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()` to call `delete()` on the token object and stop calling `SV_WC_Payment_Gateway_Payment_Tokens_Handler::update_tokens()`.

### Story: [CH 24100](https://app.clubhouse.io/skyverge/story/24100/update-sv-wc-payment-gateway-payment-tokens-handler-delete-token)
### Release: #362

## Details

`SV_WC_Payment_Gateway_Payment_Tokens_Handler::update_tokens()` also updates the internal cache, so in order to keep getting accurate results from `SV_WC_Payment_Gateway_Payment_Tokens_Handler::get_tokens()`, `delete_token()` now updates the internal cache and clear the user's transient too.

## QA

- [x] SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test::test_delete_token pass
- [x] SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test::test_delete_token_marks_another_token_as_deafult pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description
