### PR TITLE
Update the constructor of the token object to accept the environment ID

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -410,6 +410,22 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::get_environment()
+	 *
+	 * @dataProvider provider_get_environment
+	 */
+	public function test_get_environment_set_using_legacy_data( $stored_environment, $expected_environment ) {
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', array_merge(
+			$this->get_legacy_credit_card_token_data(),
+			[ 'environment' => $stored_environment ]
+		) );
+
+		$this->assertSame( $expected_environment, $token->get_environment() );
+	}
+
+
+	/**
 	 * Provides test data for test_get_environment().
 	 *
 	 * @return array

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -489,6 +489,38 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	}
 
 
+	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::save()
+	 *
+	 * @dataProvider provider_passes_the_token_environment
+	 */
+	public function test_save_passes_the_token_environment( $stored_environment, $expected_environment ) {
+
+		$user_meta_name = sv_wc_test_plugin()->get_gateway()->get_payment_tokens_handler()->get_user_meta_name( $expected_environment );
+		$token_id       = '12345';
+
+		$data = array_merge(
+			$this->get_legacy_credit_card_token_data(),
+			[ 'environment' => $stored_environment ]
+		);
+
+		// store fake legacy token data to be updated
+		update_user_meta( $data['user_id'], $user_meta_name, [ $token_id => $data ] );
+
+		// we will set a different expiry month to check legacy token data was modified
+		$exp_month = $data['exp_month'] === '07' ? '08' : '07';
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( $token_id, $data );
+
+		$token->set_exp_month( $exp_month );
+		$token->save();
+
+		$stored_tokens = get_user_meta( $data['user_id'], $user_meta_name, true );
+
+		$this->assertEquals( $exp_month, $stored_tokens[ $token_id ]['exp_month'] );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -470,16 +470,7 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	 */
 	private function get_new_credit_card_token() {
 
-		return new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', [
-			'type'       => 'credit_card',
-			'user_id'    => 1,
-			'gateway_id' => 'test_gateway',
-			'default'    => true,
-			'last_four'  => '1111',
-			'card_type'  => Framework\SV_WC_Payment_Gateway_Helper::CARD_TYPE_VISA,
-			'exp_month'  => '01',
-			'exp_year'   => '2020',
-		] );
+		return new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $this->get_legacy_credit_card_token_data() );
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -434,8 +434,8 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 		return [
 			'metadata is set'  => [ 'test_environment', 'test_environment' ],
-			'empty metadata'   => [ '', null ],
-			'metadata not set' => [ null, null ],
+			'empty metadata'   => [ '', '' ],
+			'metadata not set' => [ null, '' ],
 		];
 	}
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -442,21 +442,22 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::delete()
+	 *
+	 * @dataProvider provider_passes_the_token_environment
 	 */
-	public function test_delete_passes_the_token_environment() {
+	public function test_delete_passes_the_token_environment( $stored_environment, $expected_environment ) {
 
 		$woocommerce_token = $this->get_new_woocommerce_credit_card_token();
-		$environment       = 'test_environment';
 
-		$woocommerce_token->add_meta_data( 'environment', $environment );
+		$woocommerce_token->add_meta_data( 'environment', $stored_environment );
 
 		$tokens_handler = \Codeception\Stub::make(
 			Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::class,
 			[
 				// mock delete_legacy_token() to check that the token environment is passed as the third parameter
 				'delete_legacy_token' => \Codeception\Stub\Expected::once(
-					function( $user_id, $token, $environment_id ) use ( $environment ) {
-						$this->assertSame( $environment, $environment_id );
+					function( $user_id, $token, $environment_id ) use ( $expected_environment ) {
+						$this->assertSame( $expected_environment, $environment_id );
 					}
 				),
 			],

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -484,6 +484,26 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
+	 * Gets legacy credit card token array data, as it would exist in user meta.
+	 *
+	 * @return array
+	 */
+	private function get_legacy_credit_card_token_data() {
+
+		return [
+			'type'       => 'credit_card',
+			'user_id'    => 1,
+			'gateway_id' => 'test_gateway',
+			'default'    => true,
+			'last_four'  => '1111',
+			'card_type'  => Framework\SV_WC_Payment_Gateway_Helper::CARD_TYPE_VISA,
+			'exp_month'  => '01',
+			'exp_year'   => '2020',
+		];
+	}
+
+
+	/**
 	 * Gets a new eCheck payment token object.
 	 *
 	 * @return Framework\SV_WC_Payment_Gateway_Payment_Token

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -476,6 +476,18 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	}
 
 
+	/**
+	 * Provides test data for test_delete_passes_the_token_environment() and test_save_passes_the_token_environment()
+	 */
+	public function provider_passes_the_token_environment() {
+
+		return [
+			'environment set'     => [ 'test_environment', 'test_environment' ],
+			'environment not set' => [ '', null ]
+		];
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -722,7 +722,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		// delete legacy token in WordPress user meta table
 		if ( $tokens_handler = $this->get_tokens_handler() ) {
-			$tokens_handler->delete_legacy_token( $this->get_user_id(), $this, $this->get_environment() );
+			$tokens_handler->delete_legacy_token( $this->get_user_id(), $this, $this->get_environment() ?: null );
 		}
 
 		return $deleted;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -84,6 +84,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * exp_month    - string optional expiration month MM (credit card only)
 	 * exp_year     - string optional expiration year YYYY (credit card only)
 	 * account_type - string one of 'checking' or 'savings' (checking gateway only)
+	 * environment  - string optional gateway environment id
 	 *
 	 * @since 1.0.0
 	 *

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -65,6 +65,13 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	];
 
 	/**
+	 * @var array key-value array to map WooCommerce core token meta data to framework token `$data` keys
+	 */
+	private $meta_data = [
+		'environment' => 'environment',
+	];
+
+	/**
 	 * @var null|\WC_Payment_Token WooCommerce core token corresponding to the framework token, if set
 	 */
 	private $token;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -671,7 +671,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 			// update legacy token to mark it migrated
 			if ( $tokens_handler = $this->get_tokens_handler() ) {
-				$tokens_handler->update_legacy_token( $this->get_user_id(), $this );
+				$tokens_handler->update_legacy_token( $this->get_user_id(), $this, $this->get_environment() ?: null );
 			}
 		}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -553,14 +553,11 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 *
 	 * @since 5.6.0-dev.1
 	 *
-	 * @return string|null
+	 * @return string
 	 */
 	public function get_environment() {
 
-		$token       = $this->get_woocommerce_payment_token();
-		$environment = $token ? $token->get_meta( 'environment' ) : '';
-
-		return $environment ?: null;
+		return isset( $this->data['environment'] ) && is_string( $this->data['environment'] ) ? $this->data['environment'] : '';
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -637,6 +637,10 @@ class SV_WC_Payment_Gateway_Payment_Token {
 				$framework_key = $this->props[ $core_key ];
 
 				$this->data[ $framework_key ] = $value;
+
+			} elseif ( array_key_exists( $core_key, $this->meta_data ) ) {
+
+				$this->data[ $this->meta_data[ $core_key ] ] = $value;
 			}
 		}
 	}


### PR DESCRIPTION
# Summary

This is a follow up PR for #373. We can set the base branch to `v5.6.0` once that one is merged.

This PRs updates the `get_environment` method to retrieve data from the token's `$data` array.

Additionally, it makes it possible to pass the environment ID to the constructor of the token, using the legacy data array or stored as meta data in the core token.

### Story: [CH 24528](https://app.clubhouse.io/skyverge/story/24528/update-the-constructor-of-the-token-object-to-accept-the-environment)
### Release: #362

## QA

- [x] SV_WC_Payment_Gateway_Payment_Token_Test::test_get_environment pass
- [x] SV_WC_Payment_Gateway_Payment_Token_Test::test_delete_passes_the_token_environment pass
- [x] SV_WC_Payment_Gateway_Payment_Token_Test::test_save_passes_the_token_environment pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
