### PR TITLE
Set framework token type from WC_Payment_Token type

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -30,6 +30,20 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::read()
+	 *
+	 * @dataProvider provider_read_sets_token_type
+	 */
+	public function test_read_sets_token_type( $core_token, $expected_type ) {
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $core_token );
+
+		$this->assertEquals( $expected_type, $token->get_type() );
+		$this->assertTrue( $token->{"is_$expected_type"}() );
+	}
+
+
+	/**
 	 * Provides test data for test_read_sets_token_type()
 	 */
 	public function provider_read_sets_token_type() {

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -30,6 +30,18 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
+	 * Provides test data for test_read_sets_token_type()
+	 */
+	public function provider_read_sets_token_type() {
+
+		return [
+			'credit_card' => [ new WC_Payment_Token_CC(), 'credit_card' ],
+			'echeck'      => [ new WC_Payment_Token_ECheck(), 'echeck' ],
+		];
+	}
+
+
+	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::get_id()
 	 */
 	public function test_get_id() {

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -643,6 +643,13 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		unset( $token_data['meta_data'] );
 
+		/** default to 'echeck' if core token is not an instance of \WC_Payment_Token_CC */
+		if ( $core_token instanceof \WC_Payment_Token_CC ) {
+			$this->data['type'] = 'credit_card';
+		} else {
+			$this->data['type'] = 'echeck';
+		}
+
 		foreach ( $meta_data as $meta_datum ) {
 			$token_data[ $meta_datum->key ] = $meta_datum->value;
 		}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -57,7 +57,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 		'gateway_id'   => 'gateway_id',
 		'user_id'      => 'user_id',
 		'is_default'   => 'default',
-		'type'         => 'type',
 		'last4'        => 'last_four',
 		'expiry_year'  => 'exp_year',
 		'expiry_month' => 'exp_month',


### PR DESCRIPTION
# Summary

This PR sets the framework token's type to `credit_card` or `echeck` based on the type of the core token passed to the constructor.

### Story: [CH 24253](https://app.clubhouse.io/skyverge/story/24253/set-framework-token-type-from-wc-payment-token-type)
### Release: #362

## QA

- [x] SV_WC_Payment_Gateway_Payment_Token_Test::test_read_sets_token_type pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
