### PR TITLE
Update get_tokens() to retrieve customers tokens from core tables

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -96,6 +96,43 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::get_tokens()
+	 *
+	 * @dataProvider provider_get_tokens
+	 */
+	public function test_get_tokens_retrieves_core_tokens( $token_environment, $requested_environment, array $found_tokens_ids ) {
+
+		// store a test core token
+		$core_token = new WC_Payment_Token_CC();
+		$user_id    = 1;
+
+		$core_token->set_user_id( $user_id );
+		$core_token->set_gateway_id( sv_wc_test_plugin()->get_gateway()->get_id() );
+		$core_token->set_token( '12345' );
+		$core_token->set_last4( '1111' );
+		$core_token->set_expiry_year( '2022' );
+		$core_token->set_expiry_month( '08' );
+		$core_token->set_card_type( Framework\SV_WC_Payment_Gateway_Helper::CARD_TYPE_VISA );
+
+		$core_token->add_meta_data( 'environment', $token_environment );
+
+		$core_token->save();
+
+		// use a new instance of the payment tokens handler to bypass the handler's internal cache
+		$handler = new Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler( sv_wc_test_plugin()->get_gateway() );
+
+		$tokens = $handler->get_tokens( $user_id, [ 'environment_id' => $requested_environment ] );
+
+		$this->assertEquals( array_keys( $tokens ), $found_tokens_ids );
+
+		/** test that found tokens are instances of Framework\SV_WC_Payment_Gateway_Payment_Token */
+		foreach ( $found_tokens_ids as $found_token_id ) {
+			$this->assertInstanceOf( Framework\SV_WC_Payment_Gateway_Payment_Token::class, $tokens[ $found_token_id ] );
+		}
+	}
+
+
+	/**
 	 * Provides test data for test_get_tokens_retrieves_core_tokens()
 	 *
 	 * @return array

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -96,6 +96,22 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 
 	/**
+	 * Provides test data for test_get_tokens_retrieves_core_tokens()
+	 *
+	 * @return array
+	 */
+	public function provider_get_tokens() {
+
+		$token_id = '12345';
+
+		return [
+			'same environment'      => [ 'test_environment_a', 'test_environment_a', [ $token_id ] ],
+			'different environment' => [ 'test_environment_a', 'test_environment_b', [] ],
+		];
+	}
+
+
+	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::update_tokens()
 	 */
 	public function test_update_tokens() {


### PR DESCRIPTION
# Summary

This story updates `get_tokens()` to retrieve customer tokens from core tables using `\WC_Payment_Tokens::get_customer_tokens()`.

### Story: [CH 24086](https://app.clubhouse.io/skyverge/story/24086/update-sv-wc-payment-gateway-payment-tokens-handler-get-tokens)
### Release: #362

## Details

Right now `get_tokens()` combines the tokens created from the result of `\WC_Payment_Tokens::get_customer_tokens()` with the legacy tokens found using `get_legacy_tokens()`. Legacy tokens will later be included in the result of `\WC_Payment_Tokens::get_customer_tokens()` using a filter.

## QA

### Setup

* Install and configure NETBilling as-is
* Update the FW composer version to `dev-ch24086/update-get-tokens`
* Create a fake core token for NETBilling gateway:
    ```php
    $token = new WC_Payment_Token_CC();

    $token->set_user_id( 2 ); // TODO: replace 2 with the test user ID
    $token->set_token( '113820400000' );
    $token->set_gateway_id( 'netbilling' );
    $token->set_last4( '2222' );
    $token->set_expiry_year( '2020' );
    $token->set_expiry_month( '01' );
    $token->set_card_type( 'visa' );

    $token->add_meta_data( 'environment', 'test' );

    $token->save();
    ```

### Core token shows up in the Payment Methods page

1. Login as the test user
1. Go to My Account > Payment Methods
    - [ ] The fake core token shows up in the core table of payment methods
    - [ ] The fake core token shows up in the framework table of payment methods

### Test pass

- [ ] SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test::test_get_tokens_retrieves_core_tokens pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
