### PR TITLE
Retrieve nickname and billing hash from core token metadata

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -56,6 +56,23 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::read()
+	 *
+	 * @dataProvider provider_read_sets_core_token_metadata
+	 */
+	public function test_read_sets_core_token_metadata( $meta_key, $meta_value, $method_name ) {
+
+		$core_token = $this->get_new_woocommerce_credit_card_token();
+
+		$core_token->add_meta_data( $meta_key, $meta_value );
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $core_token );
+
+		$this->assertEquals( $meta_value, $token->{$method_name}() );
+	}
+
+
+	/**
 	 * Provides test data for test_read_sets_core_token_metadata()
 	 */
 	public function provider_read_sets_core_token_metadata() {

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -77,7 +77,8 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	 */
 	public function provider_read_sets_core_token_metadata() {
 		return [
-			'nickname' => [ 'nickname', 'personal card', 'get_nickname' ],
+			'nickname'     => [ 'nickname', 'personal card', 'get_nickname' ],
+			'billing_hash' => [ 'billing_hash', 'a5df', 'get_billing_hash' ],
 		];
 	}
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -56,6 +56,16 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
+	 * Provides test data for test_read_sets_core_token_metadata()
+	 */
+	public function provider_read_sets_core_token_metadata() {
+		return [
+			'nickname' => [ 'nickname', 'personal card', 'get_nickname' ],
+		];
+	}
+
+
+	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::get_id()
 	 */
 	public function test_get_id() {

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -67,6 +67,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * @var array key-value array to map WooCommerce core token meta data to framework token `$data` keys
 	 */
 	private $meta_data = [
+		'nickname'    => 'nickname',
 		'environment' => 'environment',
 	];
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -67,8 +67,9 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * @var array key-value array to map WooCommerce core token meta data to framework token `$data` keys
 	 */
 	private $meta_data = [
-		'nickname'    => 'nickname',
-		'environment' => 'environment',
+		'nickname'     => 'nickname',
+		'billing_hash' => 'billing_hash',
+		'environment'  => 'environment',
 	];
 
 	/**


### PR DESCRIPTION
# Summary

This PRs updates `read()` to also set `nickname` and `billing_hash` from the core token metadata.

### Story: [CH 24939](https://app.clubhouse.io/skyverge/story/24939/retrieve-nickname-and-billing-hash-from-core-token-metadata)
### Release: #362

## QA

This branch can't create framework tokens from core tokens through user interactions yet, so let's check the test result:

- [ ] SV_WC_Payment_Gateway_Payment_Token_Test::test_read_sets_core_token_metadata pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
