### PR TITLE
Cast the token ID as string

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -91,6 +91,10 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 		$token = $this->get_new_credit_card_token();
 
 		$this->assertEquals( '12345', $token->get_id() );
+
+		$token = $this->get_new_credit_card_token( 12345 );
+
+		$this->assertIsString( $token->get_id() );
 	}
 
 
@@ -581,11 +585,12 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	/**
 	 * Gets a new credit card payment token object.
 	 *
+	 * @param string|int $token_id a token id (normally a string), will default to "12345"
 	 * @return Framework\SV_WC_Payment_Gateway_Payment_Token
 	 */
-	private function get_new_credit_card_token() {
+	private function get_new_credit_card_token( $token_id = '12345' ) {
 
-		return new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $this->get_legacy_credit_card_token_data() );
+		return new Framework\SV_WC_Payment_Gateway_Payment_Token( $token_id, $this->get_legacy_credit_card_token_data() );
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -129,7 +129,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			$this->data = $data;
 		}
 
-		$this->id = $id;
+		$this->id = (string) $id;
 	}
 
 


### PR DESCRIPTION
# Summary

This PR casts the token `$id` as a string when it's set in the `SV_WC_Payment_Gateway_Payment_Token` constructor. 

### Story: [CH 24943](https://app.clubhouse.io/skyverge/story/24943/make-sure-framework-tokens-are-always-stored-as-strings)
### Release: #362

## QA

There is already a test that compares a string 

- [ ] SV_WC_Payment_Gateway_Payment_Token_Test::test_get_id() passes (updated test to ensure the id is always returned as a string)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
