### PR TITLE
Remove deprecated methods from token object

### DIFF
--- a/tests/_archive/unit/payment-gateway-payment-token.php
+++ b/tests/_archive/unit/payment-gateway-payment-token.php
@@ -132,7 +132,7 @@ class Payment_Gateway_Payment_Token extends Test_Case {
 
 
 	/**
-	 * Tests false for \SV_WC_Payment_Gateway_Payment_Token::is_check()
+	 * Tests false for \SV_WC_Payment_Gateway_Payment_Token::is_echeck()
 	 *
 	 * @since 4.5.0
 	 */

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -256,22 +256,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	/**
 	 * Determines if this payment token represents an eCheck.
 	 *
-	 * @since 1.0.0
-	 * @deprecated since 4.0.0
-	 *
-	 * @return bool
-	 */
-	public function is_check() {
-
-		wc_deprecated_function( __METHOD__, '4.0.0', __CLASS__ . '::is_echeck()' );
-
-		return $this->is_echeck();
-	}
-
-
-	/**
-	 * Determines if this payment token represents an eCheck.
-	 *
 	 * @since 4.0.0
 	 *
 	 * @return bool

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -310,24 +310,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
-	 * Determines the credit card type from the full account number.
-	 *
-	 * @since 1.0.0
-	 * @deprecated 4.0.0
-	 * @see SV_WC_Payment_Gateway_Helper::card_type_from_account_number()
-	 *
-	 * @param string $account_number the credit card account number
-	 * @return string the credit card type
-	 */
-	public static function type_from_account_number( $account_number ) {
-
-		wc_deprecated_function( __METHOD__, '4.0.0', __CLASS__, '::card_type_from_account_number()' );
-
-		return SV_WC_Payment_Gateway_Helper::card_type_from_account_number( $account_number );
-	}
-
-
-	/**
 	 * Gets the bank account type, one of 'checking' or 'savings'.
 	 *
 	 * eCheck gateways only.

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -136,22 +136,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	/**
 	 * Gets the payment token string.
 	 *
-	 * @since 1.0.0
-	 * @deprecated 4.0.0
-	 *
-	 * @return string payment token string
-	 */
-	public function get_token() {
-
-		wc_deprecated_function( __METHOD__, '4.0.0', __CLASS__ . '::get_id()' );
-
-		return $this->get_id();
-	}
-
-
-	/**
-	 * Gets the payment token string.
-	 *
 	 * @since 4.0.0
 	 *
 	 * @return string payment token string


### PR DESCRIPTION
# Summary

This PR just removes some deprecated methods in the token object which have been deprecated since v4.0.0.

### Story: [CH 24271](https://app.clubhouse.io/skyverge/story/24271/remove-deprecated-methods-in-the-tokens-handler-and-token-object)
### Release: #362

## QA

Ensure these methods are not called anywhere in our project (they were already set to throw deprecation notices).

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
