### PR TITLE
Remove token object legacy handling

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -499,83 +499,15 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 
 
 	/**
-	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::delete()
-	 *
-	 * @dataProvider provider_passes_the_token_environment
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::set_environment()
 	 */
-	public function test_delete_passes_the_token_environment( $stored_environment, $expected_environment ) {
+	public function test_set_environment() {
 
-		$woocommerce_token = $this->get_new_woocommerce_credit_card_token();
+		$token = $this->get_new_credit_card_token();
 
-		$woocommerce_token->add_meta_data( 'environment', $stored_environment );
+		$token->set_environment( 'test' );
 
-		$tokens_handler = \Codeception\Stub::make(
-			Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::class,
-			[
-				// mock delete_legacy_token() to check that the token environment is passed as the third parameter
-				'delete_legacy_token' => \Codeception\Stub\Expected::once(
-					function( $user_id, $token, $environment_id ) use ( $expected_environment ) {
-						$this->assertSame( $expected_environment, $environment_id );
-					}
-				),
-			],
-			$this
-		);
-
-		$token = \Codeception\Stub::construct(
-			Framework\SV_WC_Payment_Gateway_Payment_Token::class,
-			[ '12345', $woocommerce_token ],
-			[
-				// mock get_tokens_handler() to return a stub
-				'get_tokens_handler' => $tokens_handler,
-			]
-		);
-
-		$token->delete();
-	}
-
-
-	/**
-	 * Provides test data for test_delete_passes_the_token_environment() and test_save_passes_the_token_environment()
-	 */
-	public function provider_passes_the_token_environment() {
-
-		return [
-			'environment set'     => [ 'test_environment', 'test_environment' ],
-			'environment not set' => [ '', null ]
-		];
-	}
-
-
-	/**
-	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::save()
-	 *
-	 * @dataProvider provider_passes_the_token_environment
-	 */
-	public function test_save_passes_the_token_environment( $stored_environment, $expected_environment ) {
-
-		$user_meta_name = sv_wc_test_plugin()->get_gateway()->get_payment_tokens_handler()->get_user_meta_name( $expected_environment );
-		$token_id       = '12345';
-
-		$data = array_merge(
-			$this->get_legacy_credit_card_token_data(),
-			[ 'environment' => $stored_environment ]
-		);
-
-		// store fake legacy token data to be updated
-		update_user_meta( $data['user_id'], $user_meta_name, [ $token_id => $data ] );
-
-		// we will set a different expiry month to check legacy token data was modified
-		$exp_month = $data['exp_month'] === '07' ? '08' : '07';
-
-		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( $token_id, $data );
-
-		$token->set_exp_month( $exp_month );
-		$token->save();
-
-		$stored_tokens = get_user_meta( $data['user_id'], $user_meta_name, true );
-
-		$this->assertEquals( $exp_month, $stored_tokens[ $token_id ]['exp_month'] );
+		$this->assertEquals( 'test', $token->get_environment() );
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -27,37 +27,107 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 
 	/**
-	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::add_token()
 	 */
-	public function test_delete_token() {
+	public function test_add_token() {
 
-		$token_id = '12345';
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $this->get_legacy_token_data() );
 
-		// store a test token
-		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( $token_id, [
-			'type' => 'credit_card',
-			'last_four' => '1111',
-			'exp_month' => '01',
-			'exp_year'  => '20',
-			'card_type' => 'visa',
-			'default'   => true,
-		] );
+		$token_id = $this->get_handler()->add_token( 1, $token );
 
-		$this->get_handler()->update_tokens( 1, [ $token_id => $token ] );
+		$core_token = \WC_Payment_Tokens::get( $token_id );
 
-		$core_token_id = $token->get_woocommerce_payment_token()->get_id();
+		$this->assertInstanceOf( \WC_Payment_Token::class, $core_token );
+	}
 
-		$this->get_handler()->delete_token( 1, $token );
 
-		$this->assertNull( $this->get_handler()->get_token( 1, $token_id ) );
-		$this->assertNull( \WC_Payment_Tokens::get( $core_token_id ) );
+	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::add_token()
+	 */
+	public function test_add_token_set_default() {
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $this->get_legacy_token_data() );
+		$token->set_default( true );
+
+		$this->get_handler()->add_token( 1, $token );
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '67890', $this->get_legacy_token_data() );
+		$token->set_default( true );
+
+		$this->get_handler()->add_token( 1, $token );
+
+		$token = $this->get_handler()->get_token( 1, '12345' );
+
+		$this->assertFalse( $token->is_default() );
+	}
+
+
+	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::update_token()
+	 */
+	public function test_update_token() {
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $this->get_legacy_token_data() );
+
+		$core_token_id = $token->save();
+
+		$token->set_exp_month( '02' );
+
+		$this->get_handler()->update_token( 1, $token );
+
+		$core_token = \WC_Payment_Tokens::get( $core_token_id );
+
+		$this->assertEquals( '02', $core_token->get_expiry_month() );
+	}
+
+
+	/**
+	 * Tests that the local cache is updated when a token is updated.
+	 *
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::update_token()
+	 */
+	public function test_update_token_cache() {
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $this->get_legacy_token_data() );
+
+		// store the token initially
+		$this->get_handler()->update_token( 1, $token );
+
+		// prime the cache
+		$this->get_handler()->get_tokens( 1 );
+
+		$token->set_exp_month( '02' );
+
+		$this->get_handler()->update_token( 1, $token );
+
+		$token = $this->get_handler()->get_token( 1, $token->get_id() );
+
+		$this->assertEquals( '02', $token->get_exp_month() );
 	}
 
 
 	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()
 	 */
-	public function test_delete_token_marks_another_token_as_deafult() {
+	public function test_delete_token() {
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $this->get_legacy_token_data() );
+
+		$token->set_user_id( 1 );
+		$token->set_gateway_id( 'test_gateway' );
+
+		$token_id = $token->save();
+
+		$this->get_handler()->delete_token( 1, $token );
+
+		$this->assertNull( \WC_Payment_Tokens::get( $token_id ) );
+	}
+
+
+	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()
+	 */
+	public function test_delete_token_marks_another_token_as_default() {
 
 		$token_id         = '12345';
 		$default_token_id = '45678';
@@ -92,6 +162,32 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 		$core_token = $default_token->get_woocommerce_payment_token();
 
 		$this->assertTrue( $core_token->get_is_default() );
+	}
+
+
+	/**
+	 * Ensures legacy token data is deleted when a core token is deleted.
+	 *
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()
+	 */
+	public function test_delete_token_legacy() {
+
+		$token_data = $this->get_legacy_token_data();
+
+		$token = new Framework\SV_WC_Payment_Gateway_Payment_Token( '12345', $token_data );
+
+		// store in user meta (legacy)
+		$this->get_handler()->update_legacy_token( 1, $token );
+
+		// store in core
+		$token->set_user_id( 1 );
+		$token->set_gateway_id( 'test_gateway' );
+		$token->save();
+
+		// delete from core
+		$this->get_handler()->delete_token( 1, $token );
+
+		$this->assertEmpty( $this->get_handler()->get_legacy_tokens( 1 ) );
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -663,14 +663,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			} elseif ( $this->is_echeck() ) {
 				$token = new \WC_Payment_Token_ECheck();
 			}
-
-			// mark the token as migrated
-			$this->data['migrated'] = true;
-
-			// update legacy token to mark it migrated
-			if ( $tokens_handler = $this->get_tokens_handler() ) {
-				$tokens_handler->update_legacy_token( $this->get_user_id(), $this, $this->get_environment() ?: null );
-			}
 		}
 
 		$token->set_token( $this->get_id() );
@@ -700,12 +692,9 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
-	 * Deletes the token from the database.
-	 *
-	 * Also deletes the token from the legacy user meta.
+	 * Deletes the associated WooCommerce core token from the database, if any.
 	 *
 	 * @see \WC_Payment_Token::delete()
-	 * @see SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_legacy_token()
 	 *
 	 * @since 5.6.0-dev.1
 	 *
@@ -721,43 +710,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			$deleted = $token->delete( $force_delete );
 		}
 
-		// delete legacy token in WordPress user meta table
-		if ( $tokens_handler = $this->get_tokens_handler() ) {
-			$tokens_handler->delete_legacy_token( $this->get_user_id(), $this, $this->get_environment() ?: null );
-		}
-
 		return $deleted;
-	}
-
-
-	/**
-	 * Gets the gateway tokens handler.
-	 *
-	 * @since 5.6.0-dev.1
-	 *
-	 * @return SV_WC_Payment_Gateway_Payment_Tokens_Handler|null
-	 */
-	protected function get_tokens_handler() {
-
-		$handler    = null;
-		$gateway_id = $this->get_gateway_id();
-
-		if ( ! empty( $gateway_id ) ) {
-
-			$gateways = WC()->payment_gateways()->payment_gateways();
-
-			if ( $gateways && isset( $gateways[ $gateway_id ] ) ) {
-
-				$gateway = $gateways[ $gateway_id ];
-
-				if ( $gateway instanceof SV_WC_Payment_Gateway ) {
-
-					$handler = $gateway->get_payment_tokens_handler();
-				}
-			}
-		}
-
-		return $handler;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -109,7 +109,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		} else {
 
-			if ( isset( $data['type'] ) && 'credit_card' == $data['type'] ) {
+			if ( isset( $data['type'] ) && 'credit_card' === $data['type'] ) {
 
 				// normalize the provided card type to adjust for possible abbreviations if set
 				if ( isset( $data['card_type'] ) && $data['card_type'] ) {
@@ -649,7 +649,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 *
 	 * @since 5.6.0-dev.1
 	 *
-	 * @retur int ID of the token saved as returned by {@see \WC_Payment_Token::save()}
+	 * @return int ID of the token saved as returned by {@see \WC_Payment_Token::save()}
 	 */
 	public function save() {
 
@@ -699,7 +699,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * @since 5.6.0-dev.1
 	 *
 	 * @param bool $force_delete argument mapped to {@see \WC_Data::delete()}
-	 * @return bool whether a token was deleted (note: it will not evaluate deletion of legacy data)
+	 * @return bool
 	 */
 	public function delete( $force_delete = false ) {
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -536,6 +536,20 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
+	 * Sets the gateway environment that this token is associated with.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @param string $value environment to set
+	 * @return string
+	 */
+	public function set_environment( $value ) {
+
+		$this->data['environment'] = $value;
+	}
+
+
+	/**
 	 * Gets the WooCommerce core payment token object related to this framework token.
 	 *
 	 * @since 5.6.0-dev.1

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -687,7 +687,13 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			}
 		}
 
-		return $token->save();
+		$saved = $token->save();
+
+		if ( $saved ) {
+			$this->token = $token;
+		}
+
+		return $saved;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -229,7 +229,10 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 		// if saved, update the local cache
 		if ( $saved ) {
+
 			$this->tokens[ $environment_id ][ $user_id ][ $token->get_id() ] = $token;
+
+			$this->clear_transient( $user_id );
 		}
 
 		return $saved;
@@ -287,7 +290,10 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 		// if saved, update the local cache
 		if ( $saved ) {
+
 			$this->tokens[ $environment_id ][ $user_id ][ $token->get_id() ] = $token;
+
+			$this->clear_transient( $user_id );
 		}
 
 		return $saved;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -279,13 +279,18 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			$environment_id = $this->get_environment_id();
 		}
 
-		$tokens = $this->get_tokens( $user_id, array( 'environment_id' => $environment_id ) );
+		$token->set_gateway_id( $this->get_gateway()->get_id() );
+		$token->set_user_id( $user_id );
+		$token->set_environment( $environment_id );
 
-		if ( isset( $tokens[ $token->get_id() ] ) ) {
-			$tokens[ $token->get_id() ] = $token;
+		$saved = $token->save();
+
+		// if saved, update the local cache
+		if ( $saved ) {
+			$this->tokens[ $environment_id ][ $user_id ][ $token->get_id() ] = $token;
 		}
 
-		return $this->update_tokens( $user_id, $tokens, $environment_id );
+		return $saved;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -408,6 +408,9 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 					break;
 				}
 			}
+
+			// delete the legacy token data now that the token has been removed
+			$this->delete_legacy_token( $user_id, $token, $environment_id );
 		}
 
 		return $deleted;


### PR DESCRIPTION
# Summary

Removes references to the token handler from the base token object.

### Story: [CH 24992](https://app.clubhouse.io/skyverge/story/24992)
### Release: #362

## Details

The way we were getting the gateway/handler is a bit brittle, and either way the token object shouldn't need to be aware of the token handler. Its only job is to hold the token data, and perform crud operations for itself.

Updated [CH 24264](https://app.clubhouse.io/skyverge/story/24264/implement-add-legacy-tokens-to-customer-payment-tokens-to-filter-woocommerce-get-customer-payment-tokens) to handle setting the `migrated` flag on legacy tokens that was previously done via the token object.

## UI Changes

N/A

## QA

- [x] All integration tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version