### PR TITLE
Implement add_legacy_tokens_to_customer_payment_tokens() to filter 'woocommerce_get_customer_payment_tokens'

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -511,6 +511,19 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 	}
 
 
+	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Token::is_migrated()
+	 */
+	public function test_is_migrated() {
+
+		$token = $this->get_new_credit_card_token();
+
+		$token->set_migrated( true );
+
+		$this->assertTrue( $token->is_migrated() );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -123,7 +123,6 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 		$token = $this->get_handler()->get_token( 1, $token->get_id() );
 
 		$this->assertEquals( '02', $token->get_exp_month() );
->>>>>>> ch24992/remove-token-object-logic
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -27,32 +27,6 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 
 	/**
-	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::add_legacy_tokens_to_customer_payment_tokens()
-	 */
-	public function test_add_legacy_tokens_to_customer_payment_tokens_filter() {
-
-		$handler = new Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler( sv_wc_test_plugin()->get_gateway() );
-
-		// add fake user meta
-		update_user_meta( 1, $handler->get_user_meta_name(), [
-			'12345' => $this->get_legacy_token_data(),
-			'67890' => $this->get_legacy_token_data(),
-		] );
-
-		$tokens = \WC_Payment_Tokens::get_customer_tokens( 1, sv_wc_test_plugin()->get_gateway()->get_id() );
-
-		$this->assertCount( 2, $tokens );
-
-		$this->assertTrue( $handler->user_legacy_tokens_migrated( 1 ) );
-
-		// ensure the tokens aren't re-migrated
-		$tokens = \WC_Payment_Tokens::get_customer_tokens( 1, sv_wc_test_plugin()->get_gateway()->get_id() );
-
-		$this->assertCount( 2, $tokens );
-	}
-
-
-	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::add_token()
 	 */
 	public function test_add_token() {

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -27,6 +27,28 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 
 
 	/**
+	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::add_legacy_tokens_to_customer_payment_tokens()
+	 */
+	public function test_add_legacy_tokens_to_customer_payment_tokens_filter() {
+
+		#add_filter( 'woocommerce_get_customer_payment_tokens', [ $this->get_handler(), 'add_legacy_tokens_to_customer_payment_tokens' ], 10, 3 );
+
+		$user_id = 1;
+		$token   = uniqid( '', false );
+
+		// add fake user meta
+		update_user_meta( $user_id, $this->get_handler()->get_user_meta_name(), [
+			$token => $this->get_legacy_token_data(),
+			$token . '2' => $this->get_legacy_token_data() + [ 'migrated' => true ], // ensure a token marked as migrated isn't re-saved
+		] );
+
+		$tokens = \WC_Payment_Tokens::get_customer_tokens( $user_id );
+
+		$this->assertCount( 1, $tokens );
+	}
+
+
+	/**
 	 * @see Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler::delete_token()
 	 */
 	public function test_delete_token() {

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -31,18 +31,22 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 	 */
 	public function test_add_legacy_tokens_to_customer_payment_tokens_filter() {
 
-		$user_id = 1;
-		$token   = uniqid( '', false );
+		$handler = new Framework\SV_WC_Payment_Gateway_Payment_Tokens_Handler( sv_wc_test_plugin()->get_gateway() );
 
 		// add fake user meta
-		update_user_meta( $user_id, $this->get_handler()->get_user_meta_name(), [
-			$token => $this->get_legacy_token_data(),
-			$token . '2' => $this->get_legacy_token_data() + [ 'migrated' => true ], // ensure a token marked as migrated isn't re-saved
+		update_user_meta( 1, $handler->get_user_meta_name(), [
+			'12345' => $this->get_legacy_token_data(),
+			'67890' => $this->get_legacy_token_data() + [ 'migrated' => true ], // ensure a token marked as migrated isn't re-saved
 		] );
 
-		$tokens = \WC_Payment_Tokens::get_customer_tokens( $user_id );
+		$tokens = \WC_Payment_Tokens::get_customer_tokens( 1 );
 
 		$this->assertCount( 1, $tokens );
+
+		$legacy_tokens = get_user_meta( 1, $handler->get_user_meta_name(), true );
+		$token = $legacy_tokens[ '12345' ];
+
+		$this->assertArrayHasKey( 'migrated', $token );
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -36,17 +36,19 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\Tes
 		// add fake user meta
 		update_user_meta( 1, $handler->get_user_meta_name(), [
 			'12345' => $this->get_legacy_token_data(),
-			'67890' => $this->get_legacy_token_data() + [ 'migrated' => true ], // ensure a token marked as migrated isn't re-saved
+			'67890' => $this->get_legacy_token_data(),
 		] );
 
-		$tokens = \WC_Payment_Tokens::get_customer_tokens( 1 );
+		$tokens = \WC_Payment_Tokens::get_customer_tokens( 1, sv_wc_test_plugin()->get_gateway()->get_id() );
 
-		$this->assertCount( 1, $tokens );
+		$this->assertCount( 2, $tokens );
 
-		$legacy_tokens = get_user_meta( 1, $handler->get_user_meta_name(), true );
-		$token = $legacy_tokens[ '12345' ];
+		$this->assertTrue( $handler->user_legacy_tokens_migrated( 1 ) );
 
-		$this->assertArrayHasKey( 'migrated', $token );
+		// ensure the tokens aren't re-migrated
+		$tokens = \WC_Payment_Tokens::get_customer_tokens( 1, sv_wc_test_plugin()->get_gateway()->get_id() );
+
+		$this->assertCount( 2, $tokens );
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -558,13 +558,20 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	public function get_woocommerce_payment_token() {
 
-		if ( ! $this->token instanceof \WC_Payment_Token && $this->get_user_id() ) {
+		if ( ! $this->token instanceof \WC_Payment_Token && $this->get_user_id() && $this->get_gateway_id() ) {
 
 			// see if there is already a token with this ID saved for this customer and gateway
-			$saved_tokens = \WC_Payment_Tokens::get_customer_tokens( $this->get_user_id(), $this->get_gateway_id() );
+			// purposefully do not use \WC_Payment_Tokens::get_customer_tokens() here to avoid an infinite loop since we filter its results
+			$saved_tokens = \WC_Payment_Tokens::get_tokens(
+				[
+					'user_id'    => $this->get_user_id(),
+					'gateway_id' => $this->get_gateway_id(),
+				]
+			);;
 
 			foreach ( $saved_tokens as $saved_token ) {
 
+				// use a matching token if found in core tokens
 				if ( $saved_token->get_token() === $this->get_id() ) {
 					$this->token = $saved_token;
 					break;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -541,11 +541,36 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * @since 5.6.0-dev.1
 	 *
 	 * @param string $value environment to set
-	 * @return string
 	 */
 	public function set_environment( $value ) {
 
 		$this->data['environment'] = $value;
+	}
+
+
+	/**
+	 * Determines if this token's data has been migrated to core storage.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function is_migrated() {
+
+		return ! empty( $this->data['migrated'] );
+	}
+
+
+	/**
+	 * Sets if this token's data has been migrated to core storage.
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @param bool $value if this token's data has been migrated to core storage
+	 */
+	public function set_migrated( $value ) {
+
+		$this->data['migrated'] = (bool) $value;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -592,13 +592,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	public function get_woocommerce_payment_token() {
 
-		$token = null;
-
-		if ( $this->token instanceof \WC_Payment_Token ) {
-
-			$token = $this->token;
-
-		} else {
+		if ( ! $this->token instanceof \WC_Payment_Token && $this->get_user_id() ) {
 
 			// see if there is already a token with this ID saved for this customer and gateway
 			$saved_tokens = \WC_Payment_Tokens::get_customer_tokens( $this->get_user_id(), $this->get_gateway_id() );
@@ -606,13 +600,13 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			foreach ( $saved_tokens as $saved_token ) {
 
 				if ( $saved_token->get_token() === $this->get_id() ) {
-					$token = $saved_token;
+					$this->token = $saved_token;
 					break;
 				}
 			}
 		}
 
-		return $token;
+		return $this->token;
 	}
 
 
@@ -729,7 +723,11 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			}
 		}
 
-		return $token->save();
+		$result = $token->save();
+
+		$this->token = $token;
+
+		return $result;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -106,7 +106,11 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 				}
 
 				if ( $legacy_token->save() ) {
+
 					$tokens[] = $legacy_token->get_woocommerce_payment_token();
+
+					// mark the legacy token as migrated
+					$this->update_legacy_token( $customer_id, $legacy_token, null, true );
 				}
 			}
 		}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -769,9 +769,10 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 * @param int $user_id WP user ID
 	 * @param SV_WC_Payment_Gateway_Payment_Token $token token to update
 	 * @param string|null $environment_id optional environment ID, defaults to plugin current environment
+	 * @param bool $migrated whether the token was migrated to the new datastore
 	 * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure
 	 */
-	public function update_legacy_token( $user_id, $token, $environment_id = null ) {
+	public function update_legacy_token( $user_id, $token, $environment_id = null, $migrated = false ) {
 
 		$updated = false;
 
@@ -788,6 +789,10 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			$this->legacy_tokens[ $environment_id ][ $user_id ][ $token->get_id() ] = $token;
 
 			$legacy_tokens[ $token->get_id() ] = $token->to_datastore_format();
+
+			if ( $migrated ) {
+				$legacy_tokens[ $token->get_id() ]['migrated'] = true;
+			}
 
 			$updated = update_user_meta( $user_id, $this->get_user_meta_name( $environment_id ), $legacy_tokens );
 		}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -751,7 +751,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			// ensure the vital properties are set
 			$token->set_user_id( $user_id );
 			$token->set_gateway_id( $this->get_gateway()->get_id() );
-			// TODO: set the environment ID {CW 2019-12-17}
+			$token->set_environment( $environment_id );
 
 			$token_id = $token->save();
 


### PR DESCRIPTION
# Summary

~~Filters the result of `\WC_Payment_Tokens::get_customer_tokens()` to migrate and include our legacy tokens from user meta.~~

Switches to migrating legacy tokens within `::get_tokens()`

### Story: [CH 24264](https://app.clubhouse.io/skyverge/story/24264)
### Release: #362 

## Details

Currently, with the different touch points of both core and subscriptions on `\WC_Payment_Tokens::get_customer_tokens()`, we run into an infinite loop situation if we try and get clever with filtering and migrating tokens. This may be alleviated by the work we do in part 2 by revamping our UI, but for the backend portion it's not safe to filter that method and save at the same time.

## UI Changes

_N/A_

## QA

### Setup
- Install and configure NETBilling
- Save a payment method at checkout
- Update NETBilling's composer version to `dev-ch24264/filter-customer-tokens`

1. Visit the checkout page
   - [x] Your saved payment method is shown
   - [x] The legacy payment tokens have been migrated to core tables

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version