### PR TITLE
Trigger 'change' event if field value is non-empty only

### DIFF
--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
@@ -150,9 +150,14 @@ jQuery( document ).ready ($) ->
 		#
 		# Returns nothing.
 		format_credit_card_inputs: ->
-			$( '.js-sv-wc-payment-gateway-credit-card-form-account-number' ).payment( 'formatCardNumber' ).change()
-			$( '.js-sv-wc-payment-gateway-credit-card-form-expiry' ).payment( 'formatCardExpiry' ).change()
-			$( '.js-sv-wc-payment-gateway-credit-card-form-csc' ).payment( 'formatCardCVC' ).change()
+			$card_number = $('.js-sv-wc-payment-gateway-credit-card-form-account-number').payment('formatCardNumber');
+			$expiry      = $('.js-sv-wc-payment-gateway-credit-card-form-expiry').payment('formatCardExpiry');
+			$csc         = $('.js-sv-wc-payment-gateway-credit-card-form-csc').payment('formatCardCVC');
+
+			# trigger a 'change' event for non empty fields only
+			$card_number.trigger( 'change') if $card_number.val().length > 0
+			$expiry.trigger( 'change') if $expiry.val().length > 0
+			$csc.trigger( 'change') if $csc.val().length > 0
 
 			# perform inline validation on credit card inputs
 			$( '.js-sv-wc-payment-gateway-credit-card-form-input' ).on( 'change paste keyup', => this.do_inline_credit_card_validation() )

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.min.js
@@ -122,9 +122,19 @@
       };
 
       SV_WC_Payment_Form_Handler.prototype.format_credit_card_inputs = function() {
-        $('.js-sv-wc-payment-gateway-credit-card-form-account-number').payment('formatCardNumber').change();
-        $('.js-sv-wc-payment-gateway-credit-card-form-expiry').payment('formatCardExpiry').change();
-        $('.js-sv-wc-payment-gateway-credit-card-form-csc').payment('formatCardCVC').change();
+        var $card_number, $csc, $expiry;
+        $card_number = $('.js-sv-wc-payment-gateway-credit-card-form-account-number').payment('formatCardNumber');
+        $expiry = $('.js-sv-wc-payment-gateway-credit-card-form-expiry').payment('formatCardExpiry');
+        $csc = $('.js-sv-wc-payment-gateway-credit-card-form-csc').payment('formatCardCVC');
+        if ($card_number.val().length > 0) {
+          $card_number.trigger('change');
+        }
+        if ($expiry.val().length > 0) {
+          $expiry.trigger('change');
+        }
+        if ($csc.val().length > 0) {
+          $csc.trigger('change');
+        }
         return $('.js-sv-wc-payment-gateway-credit-card-form-input').on('change paste keyup', (function(_this) {
           return function() {
             return _this.do_inline_credit_card_validation();


### PR DESCRIPTION
# Summary

This PR avoids triggering a `change` event on empty credit card fields so that WooCommerce's field validation is not triggered before the user has entered any data.

### Story: [CH 1234](https://app.clubhouse.io/skyverge/story/8279/payment-fields-are-validated-before-the-customer-has-entered-any-data)
### Release: TBD

## Details

This fix is only useful on WC 3.9, because on WC 3.8 or older, the `checkout.js` script also triggers `change` events when the page loads, causing fields to be marked as invalid before the user has interacted with them.

## UI Changes

Credit card fields are no longer marked as invalid on page load.

- Before: https://share.getcloudapp.com/nOum9qnO
- After: https://share.getcloudapp.com/DOuvmbDD

## QA

### Setup

1. Update Authorize.Net's `composer.json` to use version `dev-ch8279/payment-fields-are-validated-too-early` of the framework
1. Activate and configure Authorize.Net

### Steps

#### Fields are not marked as invalid on page load

1. Set Authorize.Net environment to Production (othwerwise fields will be pre-filled with valid test data)
1. Go to the checkout page
    - [x] Card Number, Expiration, and Card Security Code fields are not marked as invalid

#### Format

1. Set Authorize.Net environment to Test
1. Go to the checkout page
1. Enter `4242424242424242` as the value of the Card Number field
    - [x] The field is formated as `4242 4242 4242 4242`
    - [x] The Visa logo is shown
1. Enter `1224` as the value of the Expiration field
    - [x] The field is formated as `12 / 24`
1. Enter `123` as the value of the Card Security Code field
1. Click the Place Order button
1. The order is processed successfully

#### Fields are marked as invalid if changed to be empty

1. Set Authorize.Net environment to Test
1. Go to the checkout page
1. Delete the value in the Card Number field
    - [x] The Card Number field is marked as invalid
1. Delete the value in the Expiration field
    - [x] The Expiration field is marked as invalid
1. Delete the value in the Card Security Code field
    - [x] The Card Security Code field is marked as invalid
1. Click the Place Order button
    - [x] The "Card security code is missing" error message is shown
    - [x] The "Card number is missing" error message is shown
    - [x] The "Card expiration date is invalid" error message is shown

#### Validation on submit

While I was expecting fields to be marked as invalid on blur, I found out thaat the current behavior is to detect invalid data on submit.

1. Set Authorize.Net environment to Test
1. Go to the checkout page
1. Enter "4242" as the value of the Card Number field
1. Enter "12 / 333" as the value of the Expiration field
1. Enter "2466" as value if the Card Security Code field
1. Click the Place Order button
    - [x] The "Card number is invalid (wrong length)" error message is shown
    - [x] The "Card number is invalid" error message is shown
    - [x] The "Card expiration date is invalid" error message is shown

## Open questions

If the above looks good, we may want to release this as 5.5.2 and leave https://github.com/skyverge/wc-plugin-framework/pull/385 for a future release. Does that sound right?

I'll update the changelog once we decide how to merge and release.

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description
