### PR TITLE
Prevent js error on my account > payment methods screen

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2020.nn.nn - version x.y.z-dev.1
+ * Fix - Fix a JavaScript error when instantiating a class that hasn't been loaded
+
 2020.01.09 - version 5.5.2
  * Fix - `SV_WC_Payment_Gateway_Apple_Pay::process_payment()` now throws an exception if the result returned by the processing gateway doesn't indicate whether the transaction was successful or not
  * Fix - Update `SV_WC_Payment_Gateway_Direct::process_payment()` to cover for and edge case in which `SV_WC_Payment_Gateway_Direct::do_transaction()` fails without throwing an exception

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -217,36 +217,40 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function render_js() {
 
-		$args = array(
-			'id'              => $this->get_plugin()->get_id(),
-			'slug'            => $this->get_plugin()->get_id_dasherized(),
-			'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
-			'ajax_url'        => admin_url( 'admin-ajax.php' ),
-			'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
-			'i18n'            => array(
-				'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
-				'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
-				'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
-				'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
-			),
-		);
+        if ( $this->has_tokens ) {
 
-		/**
-		 * Filters the payment gateway payment methods JavaScript args.
-		 *
-		 * @since 5.1.0
-		 *
-		 * @param array $args arguments
-		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
-		 */
-		$args = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this );
+            $args = array(
+                'id' => $this->get_plugin()->get_id(),
+                'slug' => $this->get_plugin()->get_id_dasherized(),
+                'has_core_tokens' => (bool)wc_get_customer_saved_methods_list(get_current_user_id()),
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'ajax_nonce' => wp_create_nonce('wc_' . $this->get_plugin()->get_id() . '_save_payment_method'),
+                'i18n' => array(
+                    'edit_button' => esc_html__('Edit', 'woocommerce-plugin-framework'),
+                    'cancel_button' => esc_html__('Cancel', 'woocommerce-plugin-framework'),
+                    'save_error' => esc_html__('Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework'),
+                    'delete_ays' => esc_html__('Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework'),
+                ),
+            );
 
-		wc_enqueue_js( sprintf(
-			'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
-			esc_js( $this->get_plugin()->get_id() ),
-			esc_js( $this->get_js_handler_class() ),
-			json_encode( $args )
-		) );
+            /**
+             * Filters the payment gateway payment methods JavaScript args.
+             *
+             * @param array $args arguments
+             * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
+             * @since 5.1.0
+             *
+             */
+            $args = apply_filters('wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this);
+
+            wc_enqueue_js(sprintf(
+                'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
+                esc_js($this->get_plugin()->get_id()),
+                esc_js($this->get_js_handler_class()),
+                json_encode($args)
+            ));
+            
+        }
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -205,7 +205,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 			 */
 			do_action( 'wc_' . $this->get_plugin()->get_id() . '_after_my_payment_method_table', $this );
-
 		}
 	}
 
@@ -220,36 +219,35 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
         if ( $this->has_tokens ) {
 
             $args = array(
-                'id' => $this->get_plugin()->get_id(),
-                'slug' => $this->get_plugin()->get_id_dasherized(),
-                'has_core_tokens' => (bool)wc_get_customer_saved_methods_list(get_current_user_id()),
-                'ajax_url' => admin_url('admin-ajax.php'),
-                'ajax_nonce' => wp_create_nonce('wc_' . $this->get_plugin()->get_id() . '_save_payment_method'),
-                'i18n' => array(
-                    'edit_button' => esc_html__('Edit', 'woocommerce-plugin-framework'),
-                    'cancel_button' => esc_html__('Cancel', 'woocommerce-plugin-framework'),
-                    'save_error' => esc_html__('Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework'),
-                    'delete_ays' => esc_html__('Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework'),
+                'id'              => $this->get_plugin()->get_id(),
+                'slug'            => $this->get_plugin()->get_id_dasherized(),
+                'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
+                'ajax_url'        => admin_url( 'admin-ajax.php' ),
+                'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
+                'i18n'            => array(
+                    'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
+                    'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
+                    'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
+                    'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
                 ),
             );
 
             /**
              * Filters the payment gateway payment methods JavaScript args.
              *
+			 * @since 5.1.0
+			 *
              * @param array $args arguments
              * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
-             * @since 5.1.0
-             *
              */
-            $args = apply_filters('wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this);
+            $args = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this );
 
-            wc_enqueue_js(sprintf(
+            wc_enqueue_js( sprintf(
                 'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
-                esc_js($this->get_plugin()->get_id()),
-                esc_js($this->get_js_handler_class()),
-                json_encode($args)
-            ));
-            
+                esc_js( $this->get_plugin()->get_id() ),
+                esc_js( $this->get_js_handler_class() ),
+                json_encode( $args )
+            ) );
         }
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -216,39 +216,39 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function render_js() {
 
-        if ( $this->has_tokens ) {
+		if ( $this->has_tokens ) {
 
-            $args = array(
-                'id'              => $this->get_plugin()->get_id(),
-                'slug'            => $this->get_plugin()->get_id_dasherized(),
-                'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
-                'ajax_url'        => admin_url( 'admin-ajax.php' ),
-                'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
-                'i18n'            => array(
-                    'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
-                    'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
-                    'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
-                    'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
-                ),
-            );
+			$args = array(
+				'id'              => $this->get_plugin()->get_id(),
+				'slug'            => $this->get_plugin()->get_id_dasherized(),
+				'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
+				'ajax_url'        => admin_url( 'admin-ajax.php' ),
+				'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
+				'i18n'            => array(
+					'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
+					'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
+					'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
+					'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
+				),
+			);
 
-            /**
-             * Filters the payment gateway payment methods JavaScript args.
-             *
+			/**
+			 * Filters the payment gateway payment methods JavaScript args.
+			 *
 			 * @since 5.1.0
 			 *
-             * @param array $args arguments
-             * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
-             */
-            $args = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this );
+			 * @param array $args arguments
+			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
+			 */
+			$args = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this );
 
-            wc_enqueue_js( sprintf(
-                'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
-                esc_js( $this->get_plugin()->get_id() ),
-                esc_js( $this->get_js_handler_class() ),
-                json_encode( $args )
-            ) );
-        }
+			wc_enqueue_js( sprintf(
+				'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
+				esc_js( $this->get_plugin()->get_id() ),
+				esc_js( $this->get_js_handler_class() ),
+				json_encode( $args )
+			) );
+		}
 	}
 
 


### PR DESCRIPTION
This PR includes the changes from https://github.com/skyverge/wc-plugin-framework/pull/369, added on top of `v5.5.2` to be released in version `v5.5.3` of the framework.

Sine `v5.6.0` doesn't have a release date and the token migration modifications are not ready yet, it makes sense to release this fix separately.