### PR TITLE
Apple Pay allows customers to checkout without accepting the terms and conditions [9]

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.5.4
- * Tweak - Render terms notice before Apple Pay buttons
+ * Tweak - Add terms notice before Apple Pay buttons
 
 2020.01.13 - version 5.5.3
  * Fix - Fix a JavaScript error when instantiating a class that hasn't been loaded

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.5.4
- * Tweak - Add terms notice below Apple Pay buttons
+ * Tweak - Add a link to the site's terms and conditions page below Apple Pay buttons when available
 
 2020.01.13 - version 5.5.3
  * Fix - Fix a JavaScript error when instantiating a class that hasn't been loaded

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.5.4
- * Tweak - Add terms notice before Apple Pay buttons
+ * Tweak - Add terms notice below Apple Pay buttons
 
 2020.01.13 - version 5.5.3
  * Fix - Fix a JavaScript error when instantiating a class that hasn't been loaded

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.5.4
-
+ * Tweak - Render terms notice before Apple Pay buttons
 
 2020.01.13 - version 5.5.3
  * Fix - Fix a JavaScript error when instantiating a class that hasn't been loaded

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -206,6 +206,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 			 * Allows to filter the notice text, use the [terms] shortcode to insert a link to the terms & conditions page.
 			 *
 			 * @since 5.5.4
+			 *
 			 * @params string $default_text default notice text
 			 */
 			$text = apply_filters( 'sv_wc_apple_pay_terms_notice_text', $default_text );

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -343,13 +343,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 		<div class="sv-wc-apply-pay-checkout">
 
 			<?php
-
-				/** translators: Phrase that preceeds the Apple Pay logo, i.e. "Pay with [logo]" */
-				$button_text = __( 'Pay with', 'woocommerce-plugin-framework' );
-
 				$this->render_button();
 				$this->render_terms_notice();
-
 			?>
 
 			<span class="divider">

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -314,7 +314,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 			add_action( 'woocommerce_review_order_before_payment', [ $this, 'render_terms_notice' ] );
 		} else {
 			add_action( 'woocommerce_before_checkout_form', [ $this, 'render_checkout_button' ], 15 );
-			add_action( 'woocommerce_before_checkout_form', [ $this, 'render_terms_notice' ], 15 );
 		}
 	}
 
@@ -330,10 +329,15 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 		<div class="sv-wc-apply-pay-checkout">
 
-			<?php /** translators: Phrase that preceeds the Apple Pay logo, i.e. "Pay with [logo]" */
-			$button_text = __( 'Pay with', 'woocommerce-plugin-framework' );
+			<?php
 
-			$this->render_button(); ?>
+				/** translators: Phrase that preceeds the Apple Pay logo, i.e. "Pay with [logo]" */
+				$button_text = __( 'Pay with', 'woocommerce-plugin-framework' );
+
+				$this->render_button();
+				$this->render_terms_notice();
+
+			?>
 
 			<span class="divider">
 				<?php /** translators: "or" as in "Pay with Apple Pay [or] regular checkout" */

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -198,8 +198,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 		if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists( 'wc_terms_and_conditions_checkbox_enabled' ) && wc_terms_and_conditions_checkbox_enabled() ) {
 
 			$default_text = sprintf(
-				/** translators: Placeholders: %1$s - [terms] placeholder, will be replaced by terms link */
-				__( 'By submitting your payment, you agree to our %1$s.', 'woocommerce-plugin-framework' ),
+				/** translators: Placeholders: %s - [terms] placeholder, will be replaced by terms link */
+				__( 'By submitting your payment, you agree to our %s.', 'woocommerce-plugin-framework' ),
 				'[terms]'
 			);
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -184,6 +184,33 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 
 	/**
+	 * Renders a notice informing the customer that by purchasing they are accepting the website's terms and conditions.
+	 *
+	 * Only displayed if a Terms and conditions page is configured.
+	 *
+	 * @since 5.5.3
+	 */
+	public function render_terms_notice() {
+
+		if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists( 'wc_terms_and_conditions_checkbox_enabled' ) && wc_terms_and_conditions_checkbox_enabled() ) {
+
+			/** translators: Placeholders: %1$s - [terms] placeholder, will be replaced by terms link */
+			$default_text = __( 'By submitting your payment, you agree to the website %1$s.', 'woocommerce-plugin-framework' );
+
+			$text = apply_filters( 'sv_wc_apple_pay_terms_notice', $default_text );
+
+			$text = wc_replace_policy_page_link_placeholders( sprintf( $text, '[terms]' ) );
+
+			?>
+			<div class="woocommerce-terms-and-conditions-wrapper">
+				<p><?php echo wp_kses_post( $text ); ?></p>
+			</div>
+			<?php
+		}
+	}
+
+
+	/**
 	 * Initializes Apple Pay on the single product page.
 	 *
 	 * @since 4.7.0
@@ -219,7 +246,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new SV_WC_Apple_Pay_Product_Handler(%s);', json_encode( $args ) ) );
 
-		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'render_button' ) );
+		add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'render_terms_notice' ] );
+		add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'render_button' ] );
 	}
 
 
@@ -256,7 +284,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new SV_WC_Apple_Pay_Cart_Handler(%s);', json_encode( $args ) ) );
 
-		add_action( 'woocommerce_proceed_to_checkout', array( $this, 'render_button' ) );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'render_terms_notice' ] );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'render_button' ] );
 	}
 
 
@@ -281,9 +310,11 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new SV_WC_Apple_Pay_Checkout_Handler(%s);', json_encode( $args ) ) );
 
 		if ( $this->get_plugin()->is_plugin_active( 'woocommerce-checkout-add-ons.php' ) ) {
-			add_action( 'woocommerce_review_order_before_payment', array( $this, 'render_button' ) );
+			add_action( 'woocommerce_review_order_before_payment', [ $this, 'render_terms_notice' ] );
+			add_action( 'woocommerce_review_order_before_payment', [ $this, 'render_button' ] );
 		} else {
-			add_action( 'woocommerce_before_checkout_form', array( $this, 'render_checkout_button' ), 15 );
+			add_action( 'woocommerce_before_checkout_form', [ $this, 'render_terms_notice' ], 15 );
+			add_action( 'woocommerce_before_checkout_form', [ $this, 'render_checkout_button' ], 15 );
 		}
 	}
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -194,6 +194,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 	 */
 	public function render_terms_notice() {
 
+		/** This filter is documented by WordPress in templates/checkout/terms.php */
 		if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists( 'wc_terms_and_conditions_checkbox_enabled' ) && wc_terms_and_conditions_checkbox_enabled() ) {
 
 			$default_text = sprintf(

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -215,7 +215,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 			$text = wc_replace_policy_page_link_placeholders( $text );
 
 			?>
-			<div class="woocommerce-terms-and-conditions-wrapper">
+			<div class="sv-wc-apple-pay-terms woocommerce-terms-and-conditions-wrapper">
 				<p><small><?php echo wp_kses_post( $text ); ?></small></p>
 			</div>
 			<?php

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -195,7 +195,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 		if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists( 'wc_terms_and_conditions_checkbox_enabled' ) && wc_terms_and_conditions_checkbox_enabled() ) {
 
 			/** translators: Placeholders: %1$s - [terms] placeholder, will be replaced by terms link */
-			$default_text = __( 'By submitting your payment, you agree to the website %1$s.', 'woocommerce-plugin-framework' );
+			$default_text = __( 'By submitting your payment, you agree to our %1$s.', 'woocommerce-plugin-framework' );
 
 			$text = apply_filters( 'sv_wc_apple_pay_terms_notice', $default_text );
 
@@ -203,7 +203,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 			?>
 			<div class="woocommerce-terms-and-conditions-wrapper">
-				<p><?php echo wp_kses_post( $text ); ?></p>
+				<p><small><?php echo wp_kses_post( $text ); ?></small></p>
 			</div>
 			<?php
 		}
@@ -246,8 +246,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new SV_WC_Apple_Pay_Product_Handler(%s);', json_encode( $args ) ) );
 
-		add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'render_terms_notice' ] );
 		add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'render_button' ] );
+		add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'render_terms_notice' ] );
 	}
 
 
@@ -284,8 +284,8 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 
 		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new SV_WC_Apple_Pay_Cart_Handler(%s);', json_encode( $args ) ) );
 
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'render_terms_notice' ] );
 		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'render_button' ] );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'render_terms_notice' ] );
 	}
 
 
@@ -310,11 +310,11 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new SV_WC_Apple_Pay_Checkout_Handler(%s);', json_encode( $args ) ) );
 
 		if ( $this->get_plugin()->is_plugin_active( 'woocommerce-checkout-add-ons.php' ) ) {
-			add_action( 'woocommerce_review_order_before_payment', [ $this, 'render_terms_notice' ] );
 			add_action( 'woocommerce_review_order_before_payment', [ $this, 'render_button' ] );
+			add_action( 'woocommerce_review_order_before_payment', [ $this, 'render_terms_notice' ] );
 		} else {
-			add_action( 'woocommerce_before_checkout_form', [ $this, 'render_terms_notice' ], 15 );
 			add_action( 'woocommerce_before_checkout_form', [ $this, 'render_checkout_button' ], 15 );
+			add_action( 'woocommerce_before_checkout_form', [ $this, 'render_terms_notice' ], 15 );
 		}
 	}
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -188,18 +188,29 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 	 *
 	 * Only displayed if a Terms and conditions page is configured.
 	 *
-	 * @since 5.5.3
+	 * @internal
+	 *
+	 * @since 5.5.4
 	 */
 	public function render_terms_notice() {
 
 		if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists( 'wc_terms_and_conditions_checkbox_enabled' ) && wc_terms_and_conditions_checkbox_enabled() ) {
 
-			/** translators: Placeholders: %1$s - [terms] placeholder, will be replaced by terms link */
-			$default_text = __( 'By submitting your payment, you agree to our %1$s.', 'woocommerce-plugin-framework' );
+			$default_text = sprintf(
+				/** translators: Placeholders: %1$s - [terms] placeholder, will be replaced by terms link */
+				__( 'By submitting your payment, you agree to our %1$s.', 'woocommerce-plugin-framework' ),
+				'[terms]'
+			);
 
-			$text = apply_filters( 'sv_wc_apple_pay_terms_notice', $default_text );
+			/**
+			 * Allows to filter the notice text, use the [terms] shortcode to insert a link to the terms & conditions page.
+			 *
+			 * @since 5.5.4
+			 * @params string $default_text default notice text
+			 */
+			$text = apply_filters( 'sv_wc_apple_pay_terms_notice_text', $default_text );
 
-			$text = wc_replace_policy_page_link_placeholders( sprintf( $text, '[terms]' ) );
+			$text = wc_replace_policy_page_link_placeholders( $text );
 
 			?>
 			<div class="woocommerce-terms-and-conditions-wrapper">

--- a/woocommerce/payment-gateway/assets/css/frontend/sv-wc-payment-gateway-apple-pay.css
+++ b/woocommerce/payment-gateway/assets/css/frontend/sv-wc-payment-gateway-apple-pay.css
@@ -5,6 +5,10 @@
 	margin: 0 0 1em 0;
 }
 
+.sv-wc-apple-pay-terms {
+	display: none;
+}
+
 @supports ( -webkit-appearance: -apple-pay-button ) {
 
 	.sv-wc-apple-pay-button {

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
@@ -27,11 +27,13 @@ jQuery( document ).ready ($) ->
 			@payment_request = args.payment_request
 
 			@buttons = '.sv-wc-apple-pay-button'
+			@terms   = '.sv-wc-apple-pay-terms'
 
 			if this.is_available()
 
 				if @payment_request
 					$( @buttons ).show()
+					$( @terms ).show()
 
 				this.init()
 
@@ -306,6 +308,7 @@ jQuery( document ).ready ($) ->
 			this.get_payment_request( data ).then ( response ) =>
 
 				$( @buttons ).show()
+				$( @terms ).show()
 
 				@payment_request = $.parseJSON( response )
 
@@ -316,6 +319,7 @@ jQuery( document ).ready ($) ->
 				console.error '[Apple Pay] Could not build payment request. ' + response.message
 
 				$( @buttons ).hide()
+				$( @terms ).hide()
 
 				this.unblock_ui()
 
@@ -414,6 +418,7 @@ jQuery( document ).ready ($) ->
 			super( args )
 
 			@buttons = '.sv-wc-apply-pay-checkout'
+			@terms   = '.sv-wc-apply-pay-terms'
 
 
 		attach_update_events: =>

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
@@ -418,7 +418,6 @@ jQuery( document ).ready ($) ->
 			super( args )
 
 			@buttons = '.sv-wc-apply-pay-checkout'
-			@terms   = '.sv-wc-apply-pay-terms'
 
 
 		attach_update_events: =>

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.min.js
@@ -31,9 +31,11 @@
         this.params = sv_wc_apple_pay_params;
         this.payment_request = args.payment_request;
         this.buttons = '.sv-wc-apple-pay-button';
+        this.terms = '.sv-wc-apple-pay-terms';
         if (this.is_available()) {
           if (this.payment_request) {
             $(this.buttons).show();
+            $(this.terms).show();
           }
           this.init();
           this.attach_update_events();
@@ -255,6 +257,7 @@
         return this.get_payment_request(data).then((function(_this) {
           return function(response) {
             $(_this.buttons).show();
+            $(_this.terms).show();
             _this.payment_request = $.parseJSON(response);
             return _this.unblock_ui();
           };
@@ -262,6 +265,7 @@
           return function(response) {
             console.error('[Apple Pay] Could not build payment request. ' + response.message);
             $(_this.buttons).hide();
+            $(_this.terms).hide();
             return _this.unblock_ui();
           };
         })(this));
@@ -343,6 +347,7 @@
         this.ui_element = $('form.woocommerce-checkout');
         SV_WC_Apple_Pay_Checkout_Handler.__super__.constructor.call(this, args);
         this.buttons = '.sv-wc-apply-pay-checkout';
+        this.terms = '.sv-wc-apply-pay-terms';
       }
 
       SV_WC_Apple_Pay_Checkout_Handler.prototype.attach_update_events = function() {

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.min.js
@@ -347,7 +347,6 @@
         this.ui_element = $('form.woocommerce-checkout');
         SV_WC_Apple_Pay_Checkout_Handler.__super__.constructor.call(this, args);
         this.buttons = '.sv-wc-apply-pay-checkout';
-        this.terms = '.sv-wc-apply-pay-terms';
       }
 
       SV_WC_Apple_Pay_Checkout_Handler.prototype.attach_update_events = function() {


### PR DESCRIPTION
# Summary

This PR adds a terms notice below the Apple Pay buttons if a terms page is configured.

### Story: [CH 22169](https://app.clubhouse.io/skyverge/story/22169/apple-pay-allows-customers-to-checkout-without-accepting-the-terms-and-conditions-9)

### Release: #391 

## Details

- I've preserved the functionality of the `woocommerce_checkout_show_terms` filter. If the filter returns false, the terms' notice is not displayed on any page
- I've added a filter to allow customizing the text.

## UI Changes

- New terms notice below the Apple Pay button on the product page: http://cloud.skyver.ge/9054f14bc541
- New terms notice below the Apple Pay button on the cart:
http://cloud.skyver.ge/a3f9326bec2c
- New terms notice below the Apple Pay button on the checkout page: http://cloud.skyver.ge/40c6b6657897

## QA

### Setup

- Authorize.Net is set to use this branch of the Framework (update your composer.json to require `"skyverge/wc-plugin-framework": "dev-ch22169-terms-notice-apple-pay"` and run `composer update`)
- Authorize.Net is configured to use `Lightbox` as the `Payment form type`
- Apple Pay is set up (a tricky thing to do, I am using Will's credentials and domain)

### Cases

#### Terms page set and button on all pages

1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [x] The Apple Pay button is displayed
       - [x] The notice is displayed below the button
          - [x] The notice links to the terms page
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is displayed
       - [x] The notice is displayed below the button
          - [x] The notice links to the terms page
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
       - [x] The notice is displayed below the button
          - [x] The notice links to the terms page

#### Terms page set and button only on checkout

1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display only the checkout page
1. Navigate to a product page
    - [x] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
       - [x] The notice is displayed below the button
          - [x] The notice links to the terms page

#### Terms page not set

1. Unset the terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [ ] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Add the product to cart
1. Navigate to the cart page
    - [ ] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Proceed to checkout
    - [ ] The Apple Pay button is not displayed
    - [x] The notice is not displayed

#### Support to existing `woocommerce_checkout_show_terms` filter

1. Implement the `woocommerce_checkout_show_terms` to return false
1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [ ] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Add the product to cart
1. Navigate to the cart page
    - [ ] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Proceed to checkout
    - [ ] The Apple Pay button is not displayed
    - [x] The notice is not displayed

#### New `sv_wc_apple_pay_terms_notice` filter

1. Implement the `sv_wc_apple_pay_terms_notice_text` to return a different text (use `[terms]` to insert the link to the terms page)
1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [x] The Apple Pay button is displayed
       - [x] The notice is displayed with your custom text below the button
          - [x] The notice links to the terms page
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is displayed
       - [x] The notice is displayed with your custom text below the button
          - [x] The notice links to the terms page
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
       - [x] The notice is displayed with your custom text below the button
          - [x] The notice links to the terms page

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description