### PR TITLE
Move creation of terms and conditions link to render_terms_notice()

### DIFF
--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -201,7 +201,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 				/** translators: Placeholders: %1$s - opening HTML link tag pointing to the terms & conditions page, %2$s closing HTML link tag */
 				__( 'By submitting your payment, you agree to our %1$sterms and conditions%2$s.', 'woocommerce-plugin-framework' ),
 				'<a href="' . esc_url( get_permalink( wc_terms_and_conditions_page_id() ) ) . '" class="sv-wc-apple-pay-terms-and-conditions-link" target="_blank">',
-				'</a>',
+				'</a>'
 			);
 
 			/**

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -194,25 +194,24 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
 	 */
 	public function render_terms_notice() {
 
-		/** This filter is documented by WordPress in templates/checkout/terms.php */
+		/** This filter is documented by WooCommerce in templates/checkout/terms.php */
 		if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists( 'wc_terms_and_conditions_checkbox_enabled' ) && wc_terms_and_conditions_checkbox_enabled() ) {
 
 			$default_text = sprintf(
-				/** translators: Placeholders: %s - [terms] placeholder, will be replaced by terms link */
-				__( 'By submitting your payment, you agree to our %s.', 'woocommerce-plugin-framework' ),
-				'[terms]'
+				/** translators: Placeholders: %1$s - opening HTML link tag pointing to the terms & conditions page, %2$s closing HTML link tag */
+				__( 'By submitting your payment, you agree to our %1$sterms and conditions%2$s.', 'woocommerce-plugin-framework' ),
+				'<a href="' . esc_url( get_permalink( wc_terms_and_conditions_page_id() ) ) . '" class="sv-wc-apple-pay-terms-and-conditions-link" target="_blank">',
+				'</a>',
 			);
 
 			/**
-			 * Allows to filter the notice text, use the [terms] shortcode to insert a link to the terms & conditions page.
+			 * Allows to filter the text for the terms & conditions notice.
 			 *
 			 * @since 5.5.4
 			 *
 			 * @params string $default_text default notice text
 			 */
 			$text = apply_filters( 'sv_wc_apple_pay_terms_notice_text', $default_text );
-
-			$text = wc_replace_policy_page_link_placeholders( $text );
 
 			?>
 			<div class="sv-wc-apple-pay-terms woocommerce-terms-and-conditions-wrapper">


### PR DESCRIPTION
# Summary

This a follow up PR for https://github.com/skyverge/wc-plugin-framework/pull/392 that updates `render_terms_notice()` to create the terms and conditions link without using `wc_replace_policy_page_link_placeholders()`, allowing the framework full control over the content of the terms and conditions notice.

See https://github.com/skyverge/wc-plugins/pull/3451#issuecomment-576822224 for context.

### Story: [CH 22169](https://app.clubhouse.io/skyverge/story/22169/)

## QA

I copied and updated the steps from https://github.com/skyverge/wc-plugin-framework/pull/392 as it modifies the same feature, but maybe we just need to check that clicking the link in the Checkout page opens the terms page in a new tab.

### Setup

- Authorize.Net is set to use this branch of the Framework (update your composer.json to require `"skyverge/wc-plugin-framework": "dev-ch22169-update-terms-and-conditions-link"` and run `composer update`)
- Authorize.Net is configured to use `Lightbox` as the `Payment form type`
- Apple Pay is set up (Will has credentials)

### Cases

#### Terms page set and button on all pages

1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [x] The Apple Pay button is displayed
    - [x] The notice is displayed below the button
    - [x] Clicking the terms and conditions link opens the terms page in a new tab
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is displayed
    - [x] The notice is displayed below the button
    - [x] Clicking the terms and conditions link opens the terms page in a new tab
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
    - [x] The notice is displayed below the button
    - [x] Clicking the terms and conditions link opens the terms page in a new tab

#### Terms page set and button only on checkout

1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display only the checkout page
1. Navigate to a product page
    - [x] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is not displayed
    - [x] The notice is not displayed
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
    - [x] The notice is displayed below the button
    - [x] Clicking the terms and conditions link opens the terms page in a new tab

#### Terms page not set

1. Unset the terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [x] The Apple Pay button is displayed
    - [x] The notice is not displayed
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is displayed
    - [x] The notice is not displayed
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
    - [x] The notice is not displayed

#### Support to existing `woocommerce_checkout_show_terms` filter

1. Implement the `woocommerce_checkout_show_terms` filter to return false
1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [x] The Apple Pay button is displayed
    - [x] The notice is not displayed
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is displayed
    - [x] The notice is not displayed
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
    - [x] The notice is not displayed

#### New `sv_wc_apple_pay_terms_notice_text` filter

1. Implement the `sv_wc_apple_pay_terms_notice_text` to return a different text
    Use the following if you are in a hurry:
    ```php
    add_filter( 'sv_wc_apple_pay_terms_notice_text', function( $text ) {

        return sprintf(
            'By submitting your payment, you agree to %1$sgive me a pizza%2$s.',
            '<a href="' . esc_url( get_permalink( wc_terms_and_conditions_page_id() ) ) . '" target="_blank">',
            '</a>',
        );
    } );
    ```
1. Set up a terms page in WC Advanced settings
1. Configure Apple Pay to display the button on the product page, cart and checkout
1. Navigate to a product page
    - [x] The Apple Pay button is displayed
    - [x] The notice is displayed with your custom text below the button
    - [x] Clicking the link opens the terms page in a new tab
1. Add the product to cart
1. Navigate to the cart page
    - [x] The Apple Pay button is displayed
    - [x] The notice is displayed with your custom text below the button
    - [x] Clicking the link opens the terms page in a new tab
1. Proceed to checkout
    - [x] The Apple Pay button is displayed
    - [x] The notice is displayed with your custom text below the button
    - [x] Clicking the link opens the terms page in a new tab

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version