### PR TITLE
Add extra columns to the table

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -198,7 +198,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 *
 		 * Allow actors to modify the table headers.
 		 *
-		 * In 5.6.0, moved from SV_WC_Payment_Gateway_My_Payment_Methods::get_table_headers().
+		 * In 5.6.0, moved from SV_WC_Payment_Gateway_My_Payment_Methods::get_table_headers()
+		 * and renamed the `method` (previously `title`) and `expires` (previously `expiry`)
+		 * for consistency with core column keys.
 		 *
 		 * @since 4.0.0
 		 * @param array $headers table headers {
@@ -210,7 +212,19 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * }
 		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
-		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $columns, $this );
+		$columns = apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $columns, $this );
+
+		// backwards compatibility for 3rd parties using the filter with the old column keys
+		if ( array_key_exists( 'title', $columns ) ) {
+			$columns['method'] = $columns['title'];
+			unset( $columns['title'] );
+		}
+		if ( array_key_exists( 'expiry', $columns ) ) {
+			$columns['expires'] = $columns['expiry'];
+			unset( $columns['expiry'] );
+		}
+
+		return $columns;
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -202,9 +202,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 *
 		 * @since 4.0.0
 		 * @param array $headers table headers {
-		 *     @type string $title
+		 *     @type string $method
 		 *     @type string $details
-		 *     @type string $expiry
+		 *     @type string $expires
 		 *     @type string $default
 		 *     @type string $actions
 		 * }

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -187,13 +187,11 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function add_payment_methods_columns( $columns  = [] ) {
 
-		$headers = [
-			'title'   => __( 'Method', 'woocommerce-plugin-framework' ),
-			'details' => __( 'Details', 'woocommerce-plugin-framework' ),
-			'expiry'  => __( 'Expires', 'woocommerce-plugin-framework' ),
-			'default' => __( 'Default?', 'woocommerce-plugin-framework' ),
-			'actions' => __( 'Actions', 'woocommerce-plugin-framework' ),
-		];
+		$details_column = [ 'details' => __( 'Details', 'woocommerce-plugin-framework' ) ];
+		$columns        = SV_WC_Helper::array_insert_after( $columns, 'method', $details_column );
+
+		$default_column = [ 'default' => __( 'Default?', 'woocommerce-plugin-framework' ) ];
+		$columns        = SV_WC_Helper::array_insert_after( $columns, 'expires', $default_column );
 
 		/**
 		 * My Payment Methods Table Headers Filter.
@@ -212,7 +210,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 * }
 		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
 		 */
-		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $headers, $this );
+		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $columns, $this );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -92,6 +92,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		// styles/scripts
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles_scripts' ) );
 
+		add_filter( 'woocommerce_account_payment_methods_columns', [ $this, 'add_payment_methods_columns' ] );
+
 		// render the My Payment Methods section
 		// TODO: merge our payment methods data into the core table and remove this in a future version {CW 2016-05-17}
 		add_action( 'woocommerce_after_account_payment_methods', array( $this, 'render' ) );
@@ -170,6 +172,47 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$this->has_tokens = ! empty( $this->tokens );
 
 		return $this->tokens;
+	}
+
+
+	/**
+	 * Adds columns to the payment methods table.
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param array of table columns in key => Title format
+	 * @return array of table columns in key => Title format
+	 */
+	public function add_payment_methods_columns( $columns  = [] ) {
+
+		$headers = [
+			'title'   => __( 'Method', 'woocommerce-plugin-framework' ),
+			'details' => __( 'Details', 'woocommerce-plugin-framework' ),
+			'expiry'  => __( 'Expires', 'woocommerce-plugin-framework' ),
+			'default' => __( 'Default?', 'woocommerce-plugin-framework' ),
+			'actions' => __( 'Actions', 'woocommerce-plugin-framework' ),
+		];
+
+		/**
+		 * My Payment Methods Table Headers Filter.
+		 *
+		 * Allow actors to modify the table headers.
+		 *
+		 * In 5.6.0, moved from SV_WC_Payment_Gateway_My_Payment_Methods::get_table_headers().
+		 *
+		 * @since 4.0.0
+		 * @param array $headers table headers {
+		 *     @type string $title
+		 *     @type string $details
+		 *     @type string $expiry
+		 *     @type string $default
+		 *     @type string $actions
+		 * }
+		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+		 */
+		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $headers, $this );
 	}
 
 
@@ -414,35 +457,20 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
-	 * Return the table headers
+	 * Returns the table headers.
+	 *
+	 * TODO: remove this method by version 6.0.0 or by 2021-02-17 {DM 2020-02-17}
 	 *
 	 * @since 4.0.0
+	 * @deprecated 5.6.0-dev
+	 *
 	 * @return array of table headers in key => Title format
 	 */
 	protected function get_table_headers() {
 
-		$headers = array(
-			'title'   => __( 'Method', 'woocommerce-plugin-framework' ),
-			'details' => __( 'Details', 'woocommerce-plugin-framework' ),
-			'expiry'  => __( 'Expires', 'woocommerce-plugin-framework' ),
-			'default' => __( 'Default?', 'woocommerce-plugin-framework' ),
-			'actions' => __( 'Actions', 'woocommerce-plugin-framework' ),
-		);
+		wc_deprecated_function( __METHOD__, '5.6.0-dev', 'SV_WC_Payment_Gateway_My_Payment_Methods::add_payment_methods_columns' );
 
-		/**
-		 * My Payment Methods Table Headers Filter.
-		 *
-		 * Allow actors to modify the table headers.
-		 *
-		 * @since 4.0.0
-		 * @param array $headers table headers {
-		 *     @type string $title
-		 *     @type string $expiry
-		 *     @type string $actions
-		 * }
-		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
-		 */
-		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $headers, $this );
+		return $this->add_payment_methods_columns();
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -216,10 +216,13 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		// backwards compatibility for 3rd parties using the filter with the old column keys
 		if ( array_key_exists( 'title', $columns ) ) {
+
 			$columns['method'] = $columns['title'];
 			unset( $columns['title'] );
 		}
+
 		if ( array_key_exists( 'expiry', $columns ) ) {
+
 			$columns['expires'] = $columns['expiry'];
 			unset( $columns['expiry'] );
 		}


### PR DESCRIPTION
# Summary

This PR adds the new columns to the core table.

### Story: [CH 30016](https://app.clubhouse.io/skyverge/story/30016/add-extra-columns-to-the-table)
### Release: #362

## Details

To avoid duplicating code, I've deprecated the `get_table_headers` method with the callback as the replacement. After we are done with the UI changes, we can verify if we can remove it.

The style for the Details and Default column headers (that handles mobile/desktop differences) will be covered by [CH 30026](https://app.clubhouse.io/skyverge/story/30026/update-details-column-css) and [CH 30043](https://app.clubhouse.io/skyverge/story/30043/update-default-column-css).

## UI Changes

- New columns were added to the table: https://cloud.skyver.ge/o0uDBeLm

## QA

### Steps

1. Navigate to the Payment Methods page
    - [ ] The table has 5 columns: `Method`, `Details`, `Expires`, `Default?` and `Actions`

### Filter

1. Activate Subscriptions (it implements the `'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers'` filter)
1. Navigate to the Payment Methods page
    - [ ] The table has 6 columns: `Method`, `Details`, `Expires`, `Default?`, `Subscriptions` and `Actions` (https://cloud.skyver.ge/xQuge7Ry)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description