### PR TITLE
Add token ID to core methods list item data

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -190,7 +190,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function add_payment_methods_list_item_id( $item, $token ) {
 
-		$item['id'] = $token->get_id();
+		$item['id'] = $token->get_token();
 
 		return $item;
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -92,6 +92,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		// styles/scripts
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles_scripts' ) );
 
+		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'add_payment_methods_list_item_id' ], 10, 2 );
+
 		// render the My Payment Methods section
 		// TODO: merge our payment methods data into the core table and remove this in a future version {CW 2016-05-17}
 		add_action( 'woocommerce_after_account_payment_methods', array( $this, 'render' ) );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -174,6 +174,24 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
+	 * Adds the token ID to the token data array.
+	 *
+	 * @see wc_get_account_saved_payment_methods_list
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @paramarray $item individual list item from woocommerce_saved_payment_methods_list
+	 * @param \WC_Payment_Token $token payment token associated with this method entry
+	 * @return array
+	 */
+	public function add_payment_methods_list_item_id( $item, $token ) {
+
+	}
+
+
+	/**
 	 * Render the payment methods table.
 	 *
 	 * @since 4.0.0

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -184,12 +184,15 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 *
 	 * @since 5.6.0-dev
 	 *
-	 * @paramarray $item individual list item from woocommerce_saved_payment_methods_list
+	 * @param array $item individual list item from woocommerce_saved_payment_methods_list
 	 * @param \WC_Payment_Token $token payment token associated with this method entry
 	 * @return array
 	 */
 	public function add_payment_methods_list_item_id( $item, $token ) {
 
+		$item['id'] = $token->get_id();
+
+		return $item;
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds the token ID to the token data returned by `wc_get_account_saved_payment_methods_list` and used to populate the table.

### Story: [CH 30030](https://app.clubhouse.io/skyverge/story/30030/add-token-id-to-core-methods-list-item-data)
### Release: #362

## Details

I've used `get_token` instead of `get_id` because that is what we are using as the array key (https://skyverge.slack.com/archives/CTHBHPAUS/p1581988345009300).

## UI Changes

None.

## QA

No functionality to test, just code review.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description