### PR TITLE
Add the "Details" column display

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -255,6 +255,20 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
+	 * Adds the Details column content.
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param array $method payment method
+	 */
+	public function add_payment_method_details( $method ) {
+
+	}
+
+
+	/**
 	 * Render the payment methods table.
 	 *
 	 * @since 4.0.0

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -266,8 +266,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	private function get_token_by_id( $method ) {
 
-		if ( ! empty( $method['id'] ) && ! empty( $this->tokens[ $method['id'] ] ) ) {
-			return $this->tokens[ $method['id'] ];
+		if ( ! empty( $method['token'] ) && ! empty( $this->tokens[ $method['token'] ] ) ) {
+			return $this->tokens[ $method['token'] ];
 		}
 
 		return null;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -282,7 +282,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 * @since 5.6.0-dev
 	 *
 	 * @param array $method payment method
-	 * @return array|string
 	 */
 	public function add_payment_method_details( $method ) {
 
@@ -292,7 +291,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			$content = $this->get_payment_method_details_html( $token );
 		}
 
-		return $content;
+		echo $content;
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -282,12 +282,17 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 * @since 5.6.0-dev
 	 *
 	 * @param array $method payment method
+	 * @return array|string
 	 */
 	public function add_payment_method_details( $method ) {
 
-		if ( $token = $this->get_token_by_id( $method ) ) {
+		$content = '';
 
+		if ( $token = $this->get_token_by_id( $method ) ) {
+			$content = $this->get_payment_method_details_html( $token );
 		}
+
+		return $content;
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -285,13 +285,10 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function add_payment_method_details( $method ) {
 
-		$content = '';
-
 		if ( $token = $this->get_token_by_id( $method ) ) {
-			$content = $this->get_payment_method_details_html( $token );
-		}
 
-		echo $content;
+			echo $this->get_payment_method_details_html( $token );
+		}
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -257,6 +257,24 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
+	 * Gets FW token object from payment method token ID.
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param array $method payment method data array
+	 * @return SV_WC_Payment_Gateway_Payment_Token|null
+	 */
+	private function get_token_by_id( $method ) {
+
+		if ( ! empty( $method['id'] ) && ! empty( $this->tokens[ $method['id'] ] ) ) {
+			return $this->tokens[ $method['id'] ];
+		}
+
+		return null;
+	}
+
+
+	/**
 	 * Adds the Details column content.
 	 *
 	 * @internal
@@ -267,6 +285,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function add_payment_method_details( $method ) {
 
+		if ( $token = $this->get_token_by_id( $method ) ) {
+
+		}
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -96,6 +96,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		add_filter( 'woocommerce_account_payment_methods_columns', [ $this, 'add_payment_methods_columns' ] );
 
+		add_action( 'woocommerce_account_payment_methods_column_details', [ $this, 'add_payment_method_details' ] );
+
 		// render the My Payment Methods section
 		// TODO: merge our payment methods data into the core table and remove this in a future version {CW 2016-05-17}
 		add_action( 'woocommerce_after_account_payment_methods', array( $this, 'render' ) );


### PR DESCRIPTION
# Summary

This PR adds the Details column content.

### Story: [CH 30014](https://app.clubhouse.io/skyverge/story/30014/add-the-details-column-display)
### Release: #362 

## Details

I've extracted the code to get the token from the `id` key in the method data array because it will be used for multiple columns.

## UI Changes

- Details column content: https://cloud.skyver.ge/DOu8Nged

## QA

### Setup

- Have a saved credit card
- Have a saved e-check (Authorize.Net, Intuit, and NetBilling support tokenization for e-checks)

### Steps

1. Navigate to Payment Methods
    - [ ] The Details column content displays the payment methods' information (card type/e-check logo and last 4 digits)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description