### PR TITLE
  Add the "Default" column display

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -97,6 +97,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		add_filter( 'woocommerce_account_payment_methods_columns', [ $this, 'add_payment_methods_columns' ] );
 
 		add_action( 'woocommerce_account_payment_methods_column_details', [ $this, 'add_payment_method_details' ] );
+		add_action( 'woocommerce_account_payment_methods_column_default', [ $this, 'add_payment_method_default' ] );
 
 		// render the My Payment Methods section
 		// TODO: merge our payment methods data into the core table and remove this in a future version {CW 2016-05-17}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -72,6 +72,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		// save a payment method via AJAX
 		add_action( 'wp_ajax_wc_' . $this->get_plugin()->get_id() . '_save_payment_method', array( $this, 'ajax_save_payment_method' ) );
+
+		add_action( 'woocommerce_payment_token_set_default', [ $this, 'clear_payment_methods_transient' ], 10, 2 );
 	}
 
 
@@ -177,6 +179,24 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$this->has_tokens = ! empty( $this->tokens );
 
 		return $this->tokens;
+	}
+
+
+	/**
+	 * Clear the tokens transient after making a method the default,
+	 * so that the correct payment method shows as default.
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param int $token_id token ID
+	 * @param \WC_Payment_Token $token core token object
+	 */
+	public function clear_payment_methods_transient( $token_id, $token ) {
+
+		$gateway = $this->get_plugin()->get_gateway( $token->get_gateway_id() );
+		$gateway->get_payment_tokens_handler()->clear_transient( get_current_user_id() );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -293,6 +293,24 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
+	 * Adds the Default column content.
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param array $method payment method
+	 */
+	public function add_payment_method_default( $method ) {
+
+		if ( $token = $this->get_token_by_id( $method ) ) {
+
+			echo $this->get_payment_method_default_html( $token );
+		}
+	}
+
+
+	/**
 	 * Render the payment methods table.
 	 *
 	 * @since 4.0.0


### PR DESCRIPTION
# Summary

This PR adds the content for the Default column.

### Story: [CH 30036](https://app.clubhouse.io/skyverge/story/30036/add-the-default-column-display)
### Release: #362

## Details

For each payment gateway and customer, we set a transient with their saved payment methods. We already clear that transient when adding, updating or deleting a method, but we also need to clear it when setting a method as the default. Otherwise, the Default column displays outdated information.
 
## UI Changes

- Default column content: https://cloud.skyver.ge/Qwu7YYdv - the style will be covered in [CH 30043](https://app.clubhouse.io/skyverge/story/30043/update-default-column-css)

## QA

### Setup

- Have at least 2 saved payment methods and at least from 2 different payment gateways (I've used Intuit and saved a couple of credit cards and an e-check account)

### Steps

1. Navigate to Payment Methods
    - [x] The `Default?` column shows `Default` on one of the payment methods
1. Make another payment method the default
    - [x] The `Default?` column shows `Default` on the correct payment method
    - [x] The `Default?` column does not show `Default` on any other payment methods

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description