### PR TITLE
Add the "Subscriptions" column display

### DIFF
--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -670,7 +670,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 *
 	 * TODO: Ask Subscriptions developers whether they would be interested in start adding the column to the payment methods table themselves {WV 2020-02-19}
 	 *
-	 * @since x.y.z
+	 * @since 5.6.0-dev
 	 *
 	 * @param array $method payment method
 	 */
@@ -690,7 +690,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Gets the HTML code for the list of subscriptions orders associated with the given token.
 	 *
-	 * @since x.y.z
+	 * @since 5.6.0-dev
 	 *
 	 * @param SV_WC_Payment_Gateway_Payment_Token $token the payment token
 	 * @return string

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -670,6 +670,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 *
 	 * TODO: Ask Subscriptions developers whether they would be interested in start adding the column to the payment methods table themselves {WV 2020-02-19}
 	 *
+	 * @internal
+	 *
 	 * @since 5.6.0-dev
 	 *
 	 * @param array $method payment method

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -668,6 +668,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 *
 	 * This method only generates output for tokens created by the framework.
 	 *
+	 * TODO: Ask Subscriptions developers whether they would be interested in start adding the column to the payment methods table themselves {WV 2020-02-19}
+	 *
 	 * @since x.y.z
 	 *
 	 * @param array $method payment method

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -674,6 +674,14 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 */
 	public function add_payment_method_subscriptions( $method ) {
 
+		if ( isset( $method['token'] ) ) {
+
+			$token = $this->get_gateway()->get_payment_tokens_handler()->get_token( get_current_user_id(), $method['token'] );
+
+			if ( $token instanceof SV_WC_Payment_Gateway_Payment_Token ) {
+				echo $this->get_payment_method_subscriptions_html( $token );
+			}
+		}
 	}
 
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -662,6 +662,20 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
+	 * Displays a list of subscriptions orders assocaited with the current token.
+	 *
+	 * This method only generates output for tokens created by the framework.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $method payment method
+	 */
+	public function add_payment_method_subscriptions( $method ) {
+
+	}
+
+
+	/**
 	 * Add a subscriptions header to the My Payment Methods table.
 	 *
 	 * @since 4.3.0

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -678,6 +678,37 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
+	 * Gets the HTML code for the list of subscriptions orders associated with the given token.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param SV_WC_Payment_Gateway_Payment_Token $token the payment token
+	 * @return string
+	 */
+	private function get_payment_method_subscriptions_html( $token ) {
+
+		$html = '';
+
+		// make sure the token belongs to this gateway
+		if ( $token->get_gateway_id() === $this->get_gateway()->get_id() ) {
+
+			$subscription_ids = array();
+
+			// build a link for each subscription
+			foreach ( $this->get_payment_token_subscriptions( get_current_user_id(), $token ) as $subscription ) {
+				$subscription_ids[] = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $subscription->get_view_order_url() ), esc_attr( sprintf( _x( '#%s', 'hash before order number', 'woocommerce-plugin-framework' ), $subscription->get_order_number() ) ) );
+			}
+
+			if ( ! empty( $subscription_ids ) ) {
+				$html = implode( ', ', $subscription_ids );
+			}
+		}
+
+		return $html;
+	}
+
+
+	/**
 	 * Add a subscriptions header to the My Payment Methods table.
 	 *
 	 * @since 4.3.0

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -117,6 +117,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		add_filter( 'wc_' . $this->get_gateway()->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data', array( $this, 'add_my_payment_methods_table_body_row_data' ), 10, 3 );
 		add_filter( 'wc_' . $this->get_gateway()->get_plugin()->get_id() . '_my_payment_methods_table_method_actions', array( $this, 'disable_my_payment_methods_table_method_delete' ), 10, 3 );
 
+		add_filter( 'woocommerce_account_payment_methods_column_subscriptions', [ $this, 'add_payment_method_subscriptions' ] );
+
 		/* Admin Change Payment Method support */
 
 		// framework defaults - payment_token and customer_id

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -664,7 +664,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
-	 * Displays a list of subscriptions orders assocaited with the current token.
+	 * Displays a list of subscriptions orders associated with the current token.
 	 *
 	 * This method only generates output for tokens created by the framework.
 	 *

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -72,7 +72,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 * A factory method to build and return a payment token object for the gateway.
 	 * Child implementations can override this method to return a custom payment token.
 	 *
-	 * From version x.y.z, this method can accept a core \WC_Payment_Token type as the second argument to read data from.
+	 * From version 5.6.0-dev, this method can accept a core \WC_Payment_Token type as the second argument to read data from.
 	 *
 	 * @since 4.3.0
 	 *
@@ -671,7 +671,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	/**
 	 * Gets token objects from the legacy user meta data store.
 	 *
-	 * @since x.y.z
+	 * @since 5.6.0-dev
 	 *
 	 * @param int $user_id WordPress user ID
 	 * @param null|string $environment_id desired environment ID


### PR DESCRIPTION
# Summary

This PR updates the Subscriptions integration to show a list of subscription orders next to framework tokens that are associated with one or more subscriptions.

### Story: [CH 30217](https://app.clubhouse.io/skyverge/story/30217)
### Release: #362 

## Details

There are some methods and filters that we will no longer use. Those will be deprecated [CH 30224](https://app.clubhouse.io/skyverge/story/30224/deprecate-unused-filter-handlers-in-subscriptions-integration).

## UI Changes

The Subscriptions column is visible in WooCommerce's payment methods table: https://cloud.skyver.ge/Z4u5J5nD

## QA

### Setup

- Configure NETBilling to use `dev-` version of the plugin framework (this branch)
- Activate Subscriptions and create a simple subscription product

### Steps

### Purchase a subscription with a new credit card

1. Add the subscription product to the cart and go to the Checkout page
1. Purchase the subscription using a new credit card and make sure to save the payment method to your account
1. Go to MyAccount > Payment Methods
    - [x] The payment method is shown
    - [x] The Subscriptions column is shown
    - [x] There is a link to the subscription order

### Purchase a subscription with a saved payment method

1. Add the subscription product to the cart and go to the Checkout page
1. Purchase the subscription using the saved payment method
1. Go to MyAccount > Payment Methods
    - [ ] The payment method is shown
    - [ ] The Subscriptions column is shown
    - [ ] There are links to two subscription orders