### PR TITLE
Add the "Title" column to the table

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -253,13 +253,13 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		 *
 		 * Allow actors to modify the table headers.
 		 *
-		 * In 5.6.0, moved from SV_WC_Payment_Gateway_My_Payment_Methods::get_table_headers()
-		 * and renamed the `method` (previously `title`) and `expires` (previously `expiry`)
-		 * for consistency with core column keys.
+		 * In 5.6.0, moved from SV_WC_Payment_Gateway_My_Payment_Methods::get_table_headers() and
+		 * renamed the `expires` column (previously `expiry`) for consistency with core column keys.
 		 *
 		 * @since 4.0.0
 		 * @param array $headers table headers {
 		 *     @type string $method
+		 *     @type string $title
 		 *     @type string $details
 		 *     @type string $expires
 		 *     @type string $default
@@ -270,12 +270,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$columns = apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_headers', $columns, $this );
 
 		// backwards compatibility for 3rd parties using the filter with the old column keys
-		if ( array_key_exists( 'title', $columns ) ) {
-
-			$columns['method'] = $columns['title'];
-			unset( $columns['title'] );
-		}
-
 		if ( array_key_exists( 'expiry', $columns ) ) {
 
 			$columns['expires'] = $columns['expiry'];

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -239,8 +239,11 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function add_payment_methods_columns( $columns  = [] ) {
 
+		$title_column   = [ 'title' => __( 'Title', 'woocommerce-plugin-framework' ) ];
+		$columns        = SV_WC_Helper::array_insert_after( $columns, 'method', $title_column );
+
 		$details_column = [ 'details' => __( 'Details', 'woocommerce-plugin-framework' ) ];
-		$columns        = SV_WC_Helper::array_insert_after( $columns, 'method', $details_column );
+		$columns        = SV_WC_Helper::array_insert_after( $columns, 'title', $details_column );
 
 		$default_column = [ 'default' => __( 'Default?', 'woocommerce-plugin-framework' ) ];
 		$columns        = SV_WC_Helper::array_insert_after( $columns, 'expires', $default_column );


### PR DESCRIPTION
# Summary

This PR adds the Title column to the table (to be used by the edit functionality in subsequent stories).

### Story: [CH 30252](https://app.clubhouse.io/skyverge/story/30252/add-the-title-column-to-the-table)
### Release: #362

## UI Changes

- A Title column was added to the table: https://cloud.skyver.ge/bLumrj9k

## QA

### Setup

- Have a payment method saved

### Steps

1. Navigate to Payment Methods
    - [x] A Title column is displayed

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description