### PR TITLE
Add the "Title" column display

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -98,6 +98,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		add_filter( 'woocommerce_account_payment_methods_columns', [ $this, 'add_payment_methods_columns' ] );
 
+		add_action( 'woocommerce_account_payment_methods_column_title', [ $this, 'add_payment_method_title' ] );
 		add_action( 'woocommerce_account_payment_methods_column_details', [ $this, 'add_payment_method_details' ] );
 		add_action( 'woocommerce_account_payment_methods_column_default', [ $this, 'add_payment_method_default' ] );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -310,6 +310,10 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function add_payment_method_title( $method ) {
 
+		if ( $token = $this->get_token_by_id( $method ) ) {
+
+			echo $this->get_payment_method_title_html( $token );
+		}
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -299,6 +299,20 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
+	 * Adds the Title column content.
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param array $method payment method
+	 */
+	public function add_payment_method_title( $method ) {
+
+	}
+
+
+	/**
 	 * Adds the Details column content.
 	 *
 	 * @internal

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -98,7 +98,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		add_filter( 'woocommerce_account_payment_methods_columns', [ $this, 'add_payment_methods_columns' ] );
 
-		add_action( 'woocommerce_account_payment_methods_column_title', [ $this, 'add_payment_method_title' ] );
+		add_action( 'woocommerce_account_payment_methods_column_title',   [ $this, 'add_payment_method_title' ] );
 		add_action( 'woocommerce_account_payment_methods_column_details', [ $this, 'add_payment_method_details' ] );
 		add_action( 'woocommerce_account_payment_methods_column_default', [ $this, 'add_payment_method_default' ] );
 


### PR DESCRIPTION
# Summary

This PR adds the Title column content.

### Story: [CH 30255](https://app.clubhouse.io/skyverge/story/30255/add-the-title-column-display)
### Release: #362

## UI Changes

- The Title column now displays content (the default or set nickname): https://cloud.skyver.ge/RBud7O5y

## QA

### Setup

- Have a payment method saved

### Steps

1. Navigate to Payment Methods
    - [ ] The Title column displays the default or set nickname
1. Inspect the Title column
    - [ ] The Title column contains a hidden text input for the nickname

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description