### PR TITLE
Inject Edit and Save buttons in the Actions column

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -95,6 +95,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles_scripts' ) );
 
 		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'add_payment_methods_list_item_id' ], 10, 2 );
+		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'add_payment_methods_list_item_edit_action' ], 10, 2 );
 
 		add_filter( 'woocommerce_account_payment_methods_columns', [ $this, 'add_payment_methods_columns' ] );
 
@@ -222,6 +223,38 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	public function add_payment_methods_list_item_id( $item, $token ) {
 
 		$item['token'] = $token->get_token();
+
+		return $item;
+	}
+
+
+	/**
+	 * Adds the Edit and Save buttons to the Actions column.
+	 *
+	 * @see wc_get_account_saved_payment_methods_list
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param array $item individual list item from woocommerce_saved_payment_methods_list
+	 * @param \WC_Payment_Token $token payment token associated with this method entry
+	 * @return array
+	 */
+	public function add_payment_methods_list_item_edit_action( $item, $token ) {
+
+		$new_actions = [
+			'edit' => [
+				'url'  => '#',
+				'name' => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
+			],
+			'save' => [
+				'url'  => '#',
+				'name' => esc_html__( 'Save', 'woocommerce-plugin-framework' ),
+			]
+		];
+
+		$item['actions'] = array_merge( $new_actions, $item['actions'] );
 
 		return $item;
 	}


### PR DESCRIPTION
# Summary

This PR adds the Edit and Save buttons to the Actions column.

### Story: [CH 30297](https://app.clubhouse.io/skyverge/story/30297/inject-edit-and-save-buttons-in-the-actions-column)
### Release: #362

## Details

Visibility control and functionality will be added in [CH 30299](https://app.clubhouse.io/skyverge/story/30299/update-edit-js).

## UI Changes

- The Actions column now displays Edit and Save buttons: https://cloud.skyver.ge/2NuBxyyQ

## QA

### Setup

- Have a payment method saved

### Steps

1. Navigate to Payment Methods
    - [x] The Actions column displays Edit and Save buttons

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description