### PR TITLE
Deprecate unused filter handlers in Subscriptions integration

### DIFF
--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -114,7 +114,6 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		/* My Payment Methods */
 
 		add_filter( 'wc_' . $this->get_gateway()->get_plugin()->get_id() . '_my_payment_methods_table_headers', array( $this, 'add_my_payment_methods_table_header' ), 10, 2 );
-		add_filter( 'wc_' . $this->get_gateway()->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data', array( $this, 'add_my_payment_methods_table_body_row_data' ), 10, 3 );
 
 		add_filter( 'woocommerce_account_payment_methods_column_subscriptions', [ $this, 'add_payment_method_subscriptions' ] );
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -753,7 +753,10 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Disables the "Delete" My Payment Methods method action button if there is an associated subscription.
 	 *
+	 * TODO: remove this method by version 6.0.0 or by 2021-02-20 {WV 2020-02-20}
+	 *
 	 * @since 4.3.0
+	 * @deprecated since 5.6.0-dev
 	 *
 	 * @param array $actions the token actions
 	 * @param SV_WC_Payment_Gateway_Payment_Token the token object
@@ -762,24 +765,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 */
 	public function disable_my_payment_methods_table_method_delete( $actions, $token, $handler ) {
 
-		$disable_delete = false;
-
-		$subscriptions = $this->get_payment_token_subscriptions( get_current_user_id(), $token );
-
-		// Check each subscription for the ability to change the payment method
-		foreach ( $subscriptions as $subscription ) {
-
-			if ( $subscription->can_be_updated_to( 'new-payment-method' ) ) {
-				$disable_delete = true;
-				break;
-			}
-		}
-
-		// if at least one can be changed, no deleting for you!
-		if ( isset( $actions['delete'] ) && $disable_delete ) {
-			$actions['delete']['class'] = array_merge( (array) $actions['delete']['class'], array( 'disabled' ) );
-			$actions['delete']['tip']   = __( 'This payment method is tied to a subscription and cannot be deleted. Please switch the subscription to another method first.', 'woocommerce-plugin-framework' );
-		}
+		wc_deprecated_function( __METHOD__, '5.6.0-dev' );
 
 		return $actions;
 	}

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -721,7 +721,11 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Add a subscriptions header to the My Payment Methods table.
 	 *
+	 * TODO: remove this method by version 6.0.0 or by 2021-02-20 {WV 2020-02-20}
+	 *
 	 * @since 4.3.0
+	 * @deprecated 5.6.0-dev
+	 *
 	 * @param array $method the table row data
 	 * @param \SV_WC_Payment_Gateway_Payment_Token $token the payment token
 	 * @param \SV_WC_Payment_Gateway_My_Payment_Methods the my payment methods instance
@@ -729,21 +733,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 */
 	public function add_my_payment_methods_table_body_row_data( $method, $token, $handler ) {
 
-		// If the subscription data has already been added or this method is for a different gateway, bail
-		if ( isset( $method['subscriptions'] ) || str_replace( '_', '-', $token->get_type() ) !== $this->get_gateway()->get_payment_type() ) {
-			return $method;
-		}
-
-		$subscription_ids = array();
-
-		// Build a link for each subscription
-		foreach ( $this->get_payment_token_subscriptions( get_current_user_id(), $token ) as $subscription ) {
-			$subscription_ids[] = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $subscription->get_view_order_url() ), esc_attr( sprintf( _x( '#%s', 'hash before order number', 'woocommerce-plugin-framework' ), $subscription->get_order_number() ) ) );
-		}
-
-		if ( ! empty( $subscription_ids ) ) {
-			$method['subscriptions'] = implode( ', ', $subscription_ids );
-		}
+		wc_deprecated_function( __METHOD__, '5.6.0-dev' );
 
 		return $method;
 	}
@@ -755,7 +745,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * TODO: remove this method by version 6.0.0 or by 2021-02-20 {WV 2020-02-20}
 	 *
 	 * @since 4.3.0
-	 * @deprecated since 5.6.0-dev
+	 * @deprecated 5.6.0-dev
 	 *
 	 * @param array $actions the token actions
 	 * @param SV_WC_Payment_Gateway_Payment_Token the token object

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -723,6 +723,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 *
 	 * TODO: remove this method by version 6.0.0 or by 2021-02-20 {WV 2020-02-20}
 	 *
+	 * @internal
+	 *
 	 * @since 4.3.0
 	 * @deprecated 5.6.0-dev
 	 *
@@ -743,6 +745,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * Disables the "Delete" My Payment Methods method action button if there is an associated subscription.
 	 *
 	 * TODO: remove this method by version 6.0.0 or by 2021-02-20 {WV 2020-02-20}
+	 *
+	 * @internal
 	 *
 	 * @since 4.3.0
 	 * @deprecated 5.6.0-dev

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -115,7 +115,6 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 		add_filter( 'wc_' . $this->get_gateway()->get_plugin()->get_id() . '_my_payment_methods_table_headers', array( $this, 'add_my_payment_methods_table_header' ), 10, 2 );
 		add_filter( 'wc_' . $this->get_gateway()->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data', array( $this, 'add_my_payment_methods_table_body_row_data' ), 10, 3 );
-		add_filter( 'wc_' . $this->get_gateway()->get_plugin()->get_id() . '_my_payment_methods_table_method_actions', array( $this, 'disable_my_payment_methods_table_method_delete' ), 10, 3 );
 
 		add_filter( 'woocommerce_account_payment_methods_column_subscriptions', [ $this, 'add_payment_method_subscriptions' ] );
 


### PR DESCRIPTION
# Summary

This PR deprecates two filter handlers no longer need in the Payment Gateway Subscriptions integration.

### Story: [CH 30224](https://app.clubhouse.io/skyverge/story/30224/deprecate-unused-filter-handlers-in-subscriptions-integration)
### Release: #362 

## Details

- We use core filters to generate the content for the Subscriptions column now
- Subscriptions will take care of removing the Delete button when a token shouldn't be deleted

## QA

### Setup

- Configure NETBilling to use `dev-ch30224-deprecate-unused-filter-handlers-in-subscriptions` version of the plugin framework (this branch)
- Activate Subscriptions and create a simple subscription product

### Steps

### Check that the Subscriptions column continues to work

1. Add the subscription product to the cart and go to the Checkout page
1. Purchase the subscription using a new credit card and make sure to save the payment method to your account
1. Go to MyAccount > Payment Methods
    - [x] The payment method is shown
    - [x] The Subscriptions column is shown
    - [x] There is a link to the subscription order