### PR TITLE
Do not display Edit button for core token

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -244,18 +244,22 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function add_payment_methods_list_item_edit_action( $item, $token ) {
 
-		$new_actions = [
-			'edit' => [
-				'url'  => '#',
-				'name' => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
-			],
-			'save' => [
-				'url'  => '#',
-				'name' => esc_html__( 'Save', 'woocommerce-plugin-framework' ),
-			]
-		];
+		// add new actions for FW tokens
+		if ( ! empty( $this->tokens[ $token->get_token() ] ) ) {
 
-		$item['actions'] = array_merge( $new_actions, $item['actions'] );
+			$new_actions = [
+				'edit' => [
+					'url'  => '#',
+					'name' => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
+				],
+				'save' => [
+					'url'  => '#',
+					'name' => esc_html__( 'Save', 'woocommerce-plugin-framework' ),
+				]
+			];
+
+			$item['actions'] = array_merge( $new_actions, $item['actions'] );
+		}
 
 		return $item;
 	}


### PR DESCRIPTION
# Summary

This PR fixes the Actions column so it does not display the Edit/Save buttons for core tokens.

### Story: [CH 30401](https://app.clubhouse.io/skyverge/story/30401/do-not-display-edit-button-for-core-token)
### Release: #362

## UI Changes

- The Actions column only displays the Edit/Save buttons for FW tokens: https://cloud.skyver.ge/ApurNNO5

## QA

### Setup

- Have at least one FW payment method saved
- Have at least one core payment method saved (recommended gateway: Stripe)

### Steps

1. Navigate to Payment Methods
    - [x] The "Actions" column for the core token does not show the Edit button
    - [x] The "Actions" column for the FW token shows the Edit button

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description