### PR TITLE
Only listen to JS events for tokens belonging to the current plugin

### DIFF
--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
@@ -22,7 +22,6 @@ jQuery( document ).ready ($) ->
 		# @param [Object] args, with the properties:
 		#     id:         [String] plugin ID
 		#     slug:       [String] plugin slug or dasherized ID
-		#     gateway_id: [String] gateway ID
 		#     i18n:       [Object] localized text strings
 		#     ajax_url:   [String] URL for AJAX requests
 		#     ajax_nonce: [String] nonce for AJAX requests

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
@@ -22,6 +22,7 @@ jQuery( document ).ready ($) ->
 		# @param [Object] args, with the properties:
 		#     id:         [String] plugin ID
 		#     slug:       [String] plugin slug or dasherized ID
+		#     gateway_id: [String] gateway ID
 		#     i18n:       [Object] localized text strings
 		#     ajax_url:   [String] URL for AJAX requests
 		#     ajax_nonce: [String] nonce for AJAX requests
@@ -54,6 +55,13 @@ jQuery( document ).ready ($) ->
 			# handle the delete action
 			$( ".woocommerce-MyAccount-paymentMethods" ).on( 'click', ".woocommerce-PaymentMethod--actions .button.delete", ( event ) =>
 
+				button = $( event.currentTarget )
+				row    = button.parents( 'tr' )
+
+				# check if the method belongs to this plugin
+				if row.find( "input[name=plugin-id][value=#{@slug}]" ).length is 0
+					return
+
 				if $( event.currentTarget ).hasClass( 'disabled' ) or not confirm( @i18n.delete_ays )
 					event.preventDefault()
 
@@ -70,6 +78,10 @@ jQuery( document ).ready ($) ->
 		replace_method_column: =>
 
 			$( '.woocommerce-MyAccount-paymentMethods' ).find( 'tr' ).each ( index, element ) =>
+
+				# check if the method belongs to this plugin
+				if $( element ).find( "input[name=plugin-id][value=#{@slug}]" ).length is 0
+					return
 
 				# delete the Title header
 				$( element ).find( 'th.woocommerce-PaymentMethod--title' ).remove()
@@ -98,6 +110,10 @@ jQuery( document ).ready ($) ->
 			button = $( event.currentTarget )
 			row    = button.parents( 'tr' )
 
+			# check if the method belongs to this plugin
+			if row.find( "input[name=plugin-id][value=#{@slug}]" ).length is 0
+				return
+
 			row.find( 'div.view' ).hide()
 			row.find( 'div.edit' ).show()
 			row.addClass( 'editing' )
@@ -122,6 +138,10 @@ jQuery( document ).ready ($) ->
 
 			button = $( event.currentTarget )
 			row    = button.parents( 'tr' )
+
+			# check if the method belongs to this plugin
+			if row.find( "input[name=plugin-id][value=#{@slug}]" ).length is 0
+				return
 
 			this.block_ui()
 
@@ -175,6 +195,10 @@ jQuery( document ).ready ($) ->
 
 			button = $( event.currentTarget )
 			row    = button.parents( 'tr' )
+
+			# check if the method belongs to this plugin
+			if row.find( "input[name=plugin-id][value=#{@slug}]" ).length is 0
+				return
 
 			row.find( 'div.view' ).show()
 			row.find( 'div.edit' ).hide()

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.min.js
@@ -44,6 +44,12 @@
         })(this));
         $(".woocommerce-MyAccount-paymentMethods").on('click', ".woocommerce-PaymentMethod--actions .button.delete", (function(_this) {
           return function(event) {
+            var button, row;
+            button = $(event.currentTarget);
+            row = button.parents('tr');
+            if (row.find("input[name=plugin-id][value=" + _this.slug + "]").length === 0) {
+              return;
+            }
             if ($(event.currentTarget).hasClass('disabled') || !confirm(_this.i18n.delete_ays)) {
               return event.preventDefault();
             }
@@ -60,6 +66,9 @@
         return $('.woocommerce-MyAccount-paymentMethods').find('tr').each((function(_this) {
           return function(index, element) {
             var titleColumn;
+            if ($(element).find("input[name=plugin-id][value=" + _this.slug + "]").length === 0) {
+              return;
+            }
             $(element).find('th.woocommerce-PaymentMethod--title').remove();
             titleColumn = $(element).find('td.woocommerce-PaymentMethod--title');
             if (titleColumn.children().length > 0) {
@@ -75,6 +84,9 @@
         event.preventDefault();
         button = $(event.currentTarget);
         row = button.parents('tr');
+        if (row.find("input[name=plugin-id][value=" + this.slug + "]").length === 0) {
+          return;
+        }
         row.find('div.view').hide();
         row.find('div.edit').show();
         row.addClass('editing');
@@ -89,6 +101,9 @@
         event.preventDefault();
         button = $(event.currentTarget);
         row = button.parents('tr');
+        if (row.find("input[name=plugin-id][value=" + this.slug + "]").length === 0) {
+          return;
+        }
         this.block_ui();
         row.next('.error').remove();
         data = {
@@ -129,6 +144,9 @@
         event.preventDefault();
         button = $(event.currentTarget);
         row = button.parents('tr');
+        if (row.find("input[name=plugin-id][value=" + this.slug + "]").length === 0) {
+          return;
+        }
         row.find('div.view').show();
         row.find('div.edit').hide();
         row.removeClass('editing');

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -916,7 +916,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$html .= '<div class="edit" style="display:none;">';
 			$html .= '<input type="text" class="nickname" name="nickname" value="' . esc_html( $token->get_nickname() ) . '" placeholder="' . esc_attr( __( 'Nickname', 'woocommerce-plugin-framework' ) ) . '" />';
 			$html .= '<input type="hidden" name="token-id" value="' . esc_attr( $token->get_id() ) . '" />';
-			$html .= '<input type="hidden" name="gateway-id" value="' . esc_attr( $this->get_plugin()->get_gateway()->get_id() ) . '" />';
+			$html .= '<input type="hidden" name="plugin-id" value="' . esc_attr( $this->get_plugin()->get_id_dasherized() ) . '" />';
 		$html .= '</div>';
 
 		/**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -916,6 +916,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$html .= '<div class="edit" style="display:none;">';
 			$html .= '<input type="text" class="nickname" name="nickname" value="' . esc_html( $token->get_nickname() ) . '" placeholder="' . esc_attr( __( 'Nickname', 'woocommerce-plugin-framework' ) ) . '" />';
 			$html .= '<input type="hidden" name="token-id" value="' . esc_attr( $token->get_id() ) . '" />';
+			$html .= '<input type="hidden" name="gateway-id" value="' . esc_attr( $this->get_plugin()->get_gateway()->get_id() ) . '" />';
 		$html .= '</div>';
 
 		/**


### PR DESCRIPTION
# Summary

This PR updates the JS to only handle methods belonging to the current plugin.

### Story: [CH 30525](https://app.clubhouse.io/skyverge/story/30525/only-listen-to-js-events-for-tokens-belonging-to-the-current-gateway)
### Release: #362

## UI Changes

None.

## QA

### Setup

- Have at least 2 different FW gateway plugins enabled, with at least one supporting multiple gateways (for instance NETbilling)
- Have at least one payment method saved for each FW gateway
- Have at least one core payment method saved (recommended gateway: Stripe)

### Steps

1. Navigate to Payment Methods
    - [x] The "Method" column displays the nickname for all the FW methods
    - [x] The "Method" column displays core content for the core method (similar to "Visa ending in 4242")
1. Click "Edit" for one of the FW methods
    - [x] The "Method" column switches to a text input
    - [x] No changes for the other methods
1. Edit the nickname and click "Save"
    - [x] The "Method" column switches back to plain text and displays the new nickname
    - [x] No changes for the other methods
1. Click "Delete" for one of the FW methods
    - [x] The confirmation method is only displayed once
1. Repeat the previous steps for all FW methods

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description