### PR TITLE
Deprecate get my payment methods table body row method

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -753,43 +753,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		wc_deprecated_function( __METHOD__, '5.6.0-dev' );
 
-		$deprecated_filter = 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data';
-
-		if ( has_filter( $deprecated_filter ) ) {
-
-			wc_deprecated_function( "The filter {$deprecated_filter}", '5.6.0-dev', 'WooCommerce core actions and filters to add new columns and filter their content' );
-
-			$method = array(
-				'title'   => $this->get_payment_method_title_html( $token ),
-				'default' => $this->get_payment_method_default_html( $token->is_default(), $token ),
-				'details' => $this->get_payment_method_details_html( $token ),
-				'actions' => $this->get_payment_method_actions_html( $token ),
-			);
-
-			// add the expiration date if applicable
-			if ( $token->get_exp_month() && $token->get_exp_year() ) {
-				$method['expiry'] = $this->get_payment_method_expiry_html( $token );
-			}
-
-			/**
-			 * My Payment Methods Table Body Row Data Filter.
-			 *
-			 * TODO: remove this filter by version 6.0.0 or by 2021-02-24 {FN 2020-02-21}
-			 *
-			 * @since 4.0.0
-			 * @deprecated 5.6.0-dev
-			 *
-			 * @param array $methods {
-			 *     @type string $title payment method title
-			 *     @type string $expiry payment method expiry
-			 *     @type string $actions actions for payment method
-			 * }
-			 * @param array $token simple array of SV_WC_Payment_Gateway_Payment_Token objects
-			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
-			 */
-			return apply_filters( $deprecated_filter, $method, $token, $this );
-		}
-
 		return [];
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -741,6 +741,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	/**
 	 * Gets the payment method data for a given token.
 	 *
+	 * TODO: remove this method by version 6.0.0 or by 2021-02-24 {FN 2020-02-21}
+	 *
 	 * @since 4.0.0
 	 * @deprecated 5.6.0-dev
 	 *
@@ -751,34 +753,44 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		wc_deprecated_function( __METHOD__, '5.6.0-dev' );
 
-		$method = array(
-			'title'   => $this->get_payment_method_title_html( $token ),
-			'default' => $this->get_payment_method_default_html( $token->is_default(), $token ),
-			'details' => $this->get_payment_method_details_html( $token ),
-			'actions' => $this->get_payment_method_actions_html( $token ),
-		);
+		$deprecated_filter = 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data';
 
-		// add the expiration date if applicable
-		if ( $token->get_exp_month() && $token->get_exp_year() ) {
-			$method['expiry'] = $this->get_payment_method_expiry_html( $token );
+		if ( has_filter( $deprecated_filter ) ) {
+
+			wc_deprecated_function( "The filter {$deprecated_filter}", '5.6.0-dev', 'WooCommerce core actions and filters to add new columns and filter their content' );
+
+			$method = array(
+				'title'   => $this->get_payment_method_title_html( $token ),
+				'default' => $this->get_payment_method_default_html( $token->is_default(), $token ),
+				'details' => $this->get_payment_method_details_html( $token ),
+				'actions' => $this->get_payment_method_actions_html( $token ),
+			);
+
+			// add the expiration date if applicable
+			if ( $token->get_exp_month() && $token->get_exp_year() ) {
+				$method['expiry'] = $this->get_payment_method_expiry_html( $token );
+			}
+
+			/**
+			 * My Payment Methods Table Body Row Data Filter.
+			 *
+			 * TODO: remove this filter by version 6.0.0 or by 2021-02-24 {FN 2020-02-21}
+			 *
+			 * @since 4.0.0
+			 * @deprecated 5.6.0-dev
+			 *
+			 * @param array $methods {
+			 *     @type string $title payment method title
+			 *     @type string $expiry payment method expiry
+			 *     @type string $actions actions for payment method
+			 * }
+			 * @param array $token simple array of SV_WC_Payment_Gateway_Payment_Token objects
+			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
+			 */
+			return apply_filters( $deprecated_filter, $method, $token, $this );
 		}
 
-		/**
-		 * My Payment Methods Table Body Row Data Filter.
-		 *
-		 * Allow actors to modify the table body row data.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param array $methods {
-		 *     @type string $title payment method title
-		 *     @type string $expiry payment method expiry
-		 *     @type string $actions actions for payment method
-		 * }
-		 * @param array $token simple array of SV_WC_Payment_Gateway_Payment_Token objects
-		 * @param SV_WC_Payment_Gateway_My_Payment_Methods $this instance
-		 */
-		return apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data', $method, $token, $this );
+		return [];
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -739,14 +739,17 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
-	 * Return the payment method data for a given token
+	 * Gets the payment method data for a given token.
 	 *
 	 * @since 4.0.0
+	 * @deprecated 5.6.0-dev
 	 *
 	 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
 	 * @return array payment method data suitable for HTML output
 	 */
 	protected function get_table_body_row_data( $token ) {
+
+		wc_deprecated_function( __METHOD__, '5.6.0-dev' );
 
 		$method = array(
 			'title'   => $this->get_payment_method_title_html( $token ),


### PR DESCRIPTION
### Summary

Deprecates `get_table_body_row_data()` and related filter. 

#### Story: [Ch30579](https://app.clubhouse.io/skyverge/story/30579/remove-wc-plugin-id-my-payment-methods-table-body-row-data-filter)

## Details

I deprecated this method like others in the same class. Some similar filters have been removed as well. Being a framework and not a user-facing plugin, perhaps we don't need to deprecate filters when it is not possible to map them to other hooks. Also, I don't think we should use the hook deprecator from the fw, but rather leave that choice to individual child implementations (plugins) that may choose to do so. 

### QA

- [ ]  The method `get_table_body_row_data()` triggers a deprecation warning when invoked
- [ ]  The filter `'wc_' . $this->get_plugin()->get_id() . '_my_payment_methods_table_body_row_data'` is no longer applicable

