### PR TITLE
Handle deprecated filter hooks

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,7 @@
 
 2020.nn.nn - version 5.6.0-dev
  * Tweak - Migrate payment tokens to be compatible with WooCommerce core payment tokens
+ * Dev - Deprecate some filter hooks in the payment methods table
 
 2020.01.20 - version 5.5.4
  * Tweak - Add a link to the site's terms and conditions page below Apple Pay buttons when available

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -471,6 +471,7 @@ abstract class SV_WC_Plugin {
 		$deprecated_hooks   = [];
 		$deprecated_filters = [
 			/** @see SV_WC_Payment_Gateway_My_Payment_Methods handler - once migrated to WC core tokens UI, we removed these and have no replacement */
+			// TODO: remove deprecated hooks handling by version 6.0.0 or by 2021-02-25 {FN 2020-02-25}
 			"wc_{$plugin_id}_my_payment_methods_table_html",
 			"wc_{$plugin_id}_my_payment_methods_table_head_html",
 			"wc_{$plugin_id}_my_payment_methods_table_title",

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -461,7 +461,7 @@ abstract class SV_WC_Plugin {
 	 * @see SV_WC_Plugin::init_hook_deprecator()
 	 * @see SV_WC_Plugin::get_deprecated_hooks()
 	 *
-	 * @since 5.6.0-dev.1
+	 * @since 5.6.0-dev
 	 *
 	 * @return array associative array
 	 */

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -221,7 +221,7 @@ abstract class SV_WC_Plugin {
 	 */
 	protected function init_hook_deprecator() {
 
-		$this->hook_deprecator = new SV_WC_Hook_Deprecator( $this->get_plugin_name(), $this->get_deprecated_hooks() );
+		$this->hook_deprecator = new SV_WC_Hook_Deprecator( $this->get_plugin_name(), array_merge( $this->get_framework_deprecated_hooks(), $this->get_deprecated_hooks() ) );
 	}
 
 
@@ -456,8 +456,48 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Return deprecated/removed hooks. Implementing classes should override this
-	 * and return an array of deprecated/removed hooks in the following format:
+	 * Gets a list of framework deprecated/removed hooks.
+	 *
+	 * @see SV_WC_Plugin::init_hook_deprecator()
+	 * @see SV_WC_Plugin::get_deprecated_hooks()
+	 *
+	 * @since 5.6.0-dev.1
+	 *
+	 * @return array associative array
+	 */
+	private function get_framework_deprecated_hooks() {
+
+		$plugin_id          = $this->get_id();
+		$deprecated_hooks   = [];
+		$deprecated_filters = [
+			/** @see SV_WC_Payment_Gateway_My_Payment_Methods handler - once migrated to WC core tokens UI, we removed these and have no replacement */
+			"wc_{$plugin_id}_my_payment_methods_table_html",
+			"wc_{$plugin_id}_my_payment_methods_table_head_html",
+			"wc_{$plugin_id}_my_payment_methods_table_title",
+			"wc_{$plugin_id}_my_payment_methods_table_title_html",
+			"wc_{$plugin_id}_my_payment_methods_table_row_html",
+			"wc_{$plugin_id}_my_payment_methods_table_body_html",
+			"wc_{$plugin_id}_my_payment_methods_table_body_row_data",
+			"wc_{$plugin_id}_my_payment_methods_table_method_expiry_html",
+			"wc_{$plugin_id}_my_payment_methods_table_actions_html",
+		];
+
+		foreach ( $deprecated_filters as $deprecated_filter ) {
+			$deprecated_hooks[ $deprecated_filter ] = [
+				'removed'     => true,
+				'replacement' => false,
+				'version'     => '5.6.0-dev'
+			];
+		}
+
+		return $deprecated_hooks;
+	}
+
+
+	/**
+	 * Gets a list of the plugin's deprecated/removed hooks.
+	 *
+	 * Implementing classes should override this and return an array of deprecated/removed hooks in the following format:
 	 *
 	 * $old_hook_name = array {
 	 *   @type string $version version the hook was deprecated/removed in
@@ -467,12 +507,13 @@ abstract class SV_WC_Plugin {
 	 * }
 	 *
 	 * @since 4.3.0
+	 *
 	 * @return array
 	 */
 	protected function get_deprecated_hooks() {
 
 		// stub method
-		return array();
+		return [];
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -1152,7 +1152,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 			if ( has_filter( $deprecated_filter ) ) {
 
-				wc_deprecated_function( $deprecated_filter, '5.6.0-dev', 'WooCommerce core actions and filters' );
+				wc_deprecated_function( $deprecated_filter . ' filter hook', '5.6.0-dev', 'WooCommerce core actions and filters' );
 			}
 		}
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -91,6 +91,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			return;
 		}
 
+		$this->handle_deprecated_hooks();
+
 		// styles/scripts
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles_scripts' ) );
 
@@ -1119,6 +1121,40 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		global $wp;
 
 		return is_user_logged_in() && is_account_page() && isset( $wp->query_vars['payment-methods'] );
+	}
+
+
+	/**
+	 * Handles deprecated hooks.
+	 *
+	 * TODO: remove deprecated hooks handling by version 6.0.0 or by 2021-02-25 {FN 2020-02-25}
+	 *
+	 * @since 5.6.0-dev
+	 */
+	private function handle_deprecated_hooks() {
+
+		$plugin_id          = $this->get_plugin()->get_id();
+		$deprecated_filters = [
+			'my_payment_methods_table_html',
+			'my_payment_methods_table_head_html',
+			'my_payment_methods_table_title',
+			'my_payment_methods_table_title_html',
+			'my_payment_methods_table_row_html',
+			'my_payment_methods_table_body_html',
+			'my_payment_methods_table_body_row_data',
+			'my_payment_methods_table_method_expiry_html',
+			'my_payment_methods_table_actions_html',
+		];
+
+		foreach ( $deprecated_filters as $deprecated_filter ) {
+
+			$deprecated_filter = 'wc_' . $plugin_id . '_' . $deprecated_filter;
+
+			if ( has_filter( $deprecated_filter ) ) {
+
+				wc_deprecated_function( $deprecated_filter, '5.6.0-dev', 'WooCommerce core actions and filters' );
+			}
+		}
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -91,8 +91,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			return;
 		}
 
-		$this->handle_deprecated_hooks();
-
 		// styles/scripts
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles_scripts' ) );
 
@@ -1121,40 +1119,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		global $wp;
 
 		return is_user_logged_in() && is_account_page() && isset( $wp->query_vars['payment-methods'] );
-	}
-
-
-	/**
-	 * Handles deprecated hooks.
-	 *
-	 * TODO: remove deprecated hooks handling by version 6.0.0 or by 2021-02-25 {FN 2020-02-25}
-	 *
-	 * @since 5.6.0-dev
-	 */
-	private function handle_deprecated_hooks() {
-
-		$plugin_id          = $this->get_plugin()->get_id();
-		$deprecated_filters = [
-			'my_payment_methods_table_html',
-			'my_payment_methods_table_head_html',
-			'my_payment_methods_table_title',
-			'my_payment_methods_table_title_html',
-			'my_payment_methods_table_row_html',
-			'my_payment_methods_table_body_html',
-			'my_payment_methods_table_body_row_data',
-			'my_payment_methods_table_method_expiry_html',
-			'my_payment_methods_table_actions_html',
-		];
-
-		foreach ( $deprecated_filters as $deprecated_filter ) {
-
-			$deprecated_filter = 'wc_' . $plugin_id . '_' . $deprecated_filter;
-
-			if ( has_filter( $deprecated_filter ) ) {
-
-				wc_deprecated_function( $deprecated_filter . ' filter hook', '5.6.0-dev', 'WooCommerce core actions and filters' );
-			}
-		}
 	}
 
 


### PR DESCRIPTION
### Summary

Handles deprecated hooks that have no direct replacement.

#### Story: [ch30656](https://app.clubhouse.io/skyverge/story/30656/handle-deprecated-filters-actions)

### Additional details

Instead of duplicating this across all plugins, we can deprecate some hooks directly in the plugin. But there's likely no need to use the hooks deprecator: when the payment methods handler is initialized, it could look if third party code is trying to apply certain filters/actions, and then raise a deprecation notice accordingly.

### UI changes

None.

### QA

- [x] If you try to use any of the deprecated filters, it should trigger a notice. 