### PR TITLE
Restore load_tokens() call upon initializing payment methods

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -91,6 +91,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 			return;
 		}
 
+		// initializes tokens as WooCommerce core tokens
+		$this->load_tokens();
+
 		// styles/scripts
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles_scripts' ) );
 
@@ -131,10 +134,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
-	 * Get the the available tokens for each plugin gateway and combine them
+	 * Gets the the available tokens for each plugin gateway and combine them.
 	 *
-	 * Tokens are also separated into Credit Card and eCheck-specific class members
-	 * for convenience.
+	 * Tokens are also separated into Credit Card and eCheck-specific class members for convenience.
 	 *
 	 * @since 4.0.0
 	 */

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -728,7 +728,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			$this->token = null;
 
 			// TODO probably this exception should be logged to the gateway log {FN 2020-02-25}
-			$saved = 0;
+			$saved = $token->get_id();
 		}
 
 		return $saved;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -592,7 +592,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 					'user_id'    => $this->get_user_id(),
 					'gateway_id' => $this->get_gateway_id(),
 				]
-			);;
+			);
 
 			foreach ( $saved_tokens as $saved_token ) {
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -713,10 +713,22 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			}
 		}
 
-		$saved = $token->save();
+		$token->apply_changes();
 
-		if ( $saved ) {
-			$this->token = $token;
+		try {
+
+			$saved = $token->save();
+
+			if ( $saved ) {
+				$this->token = $token;
+			}
+
+		} catch ( \Exception $e ) {
+
+			$this->token = null;
+
+			// TODO probably this exception should be logged to the gateway log {FN 2020-02-25}
+			$saved = 0;
 		}
 
 		return $saved;


### PR DESCRIPTION
## Summary

Restores `load_tokens()` from the `init()` method in the My Payment Methods handler.

#### Story: [ch24264](https://app.clubhouse.io/skyverge/story/24264/implement-add-legacy-tokens-to-customer-payment-tokens-to-filter-woocommerce-get-customer-payment-tokens) (look in the comments too)

## Additional details

As @wvega pointed out, this helps initializing and maybe migrating any additional tokens before they reach WooCommerce internals to output the tokens table which we now filter too.

## QA

- [ ] If you have existing tokens which have not been migrated when opening the My Payments Method, these should be migrated now with the changes proposed in PR (tested with Cybersource). 