### PR TITLE
Catch an error when saving a token

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -676,6 +676,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 * @since 5.6.0-dev.1
 	 *
 	 * @return int ID of the token saved as returned by {@see \WC_Payment_Token::save()}
+	 * @throws SV_WC_Payment_Gateway_Exception when saving the parent token hits an error
 	 */
 	public function save() {
 
@@ -725,10 +726,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		} catch ( \Exception $e ) {
 
-			$this->token = null;
-
-			// TODO probably this exception should be logged to the gateway log {FN 2020-02-25}
-			$saved = $token->get_id();
+			throw new SV_WC_Payment_Gateway_Exception( $e->getMessage() );
 		}
 
 		return $saved;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -726,7 +726,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		} catch ( \Exception $e ) {
 
-			throw new SV_WC_Payment_Gateway_Exception( $e->getMessage() );
+			throw new SV_WC_Payment_Gateway_Exception( 'Could not save payment token. ' . $e->getMessage() );
 		}
 
 		return $saved;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -214,8 +214,14 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			$existing_tokens = $this->get_tokens( $user_id, array( 'environment_id' => $environment_id ) );
 
 			foreach ( $existing_tokens as $existing_token ) {
+
 				$existing_token->set_default( false );
-				$existing_token->save();
+
+				try {
+					$existing_token->save();
+				} catch ( SV_WC_Payment_Gateway_Exception $e ) {
+					$this->get_gateway()->get_plugin()->log( $e->getMessage() );
+				}
 			}
 
 			$this->tokens[ $environment_id ][ $user_id ] = $existing_tokens;
@@ -225,7 +231,12 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 		$token->set_user_id( $user_id );
 		$token->set_environment( $environment_id );
 
-		$saved = $token->save();
+		try {
+			$saved = $token->save();
+		} catch ( SV_WC_Payment_Gateway_Exception $e ) {
+			$saved = false;
+			$this->get_gateway()->get_plugin()->log( $e->getMessage() );
+		}
 
 		// if saved, update the local cache
 		if ( $saved ) {
@@ -286,7 +297,12 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 		$token->set_user_id( $user_id );
 		$token->set_environment( $environment_id );
 
-		$saved = $token->save();
+		try {
+			$saved = $token->save();
+		} catch ( SV_WC_Payment_Gateway_Exception $e ) {
+			$saved = false;
+			$this->get_gateway()->get_plugin()->log( $e->getMessage() );
+		}
 
 		// if saved, update the local cache
 		if ( $saved ) {
@@ -406,7 +422,12 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 					// set the first as default and bail
 					$existing_token->set_default( true );
-					$existing_token->save();
+
+					try {
+						$existing_token->save();
+					} catch ( SV_WC_Payment_Gateway_Exception $e ) {
+						$this->get_gateway()->get_plugin()->log( $e->getMessage() );
+					}
 
 					// update the local cache
 					$this->tokens[ $environment_id ][ $user_id ][ $existing_token->get_id() ] = $existing_token;
@@ -582,16 +603,24 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 						$legacy_token->set_user_id( $user_id );
 						$legacy_token->set_environment( $environment_id );
 
-						if ( $legacy_token->save() ) {
+						try {
 
-							$tokens[ $legacy_token->get_id() ] = $legacy_token;
+							if ( $legacy_token->save() ) {
 
-							$migrated_tokens++;
+								$tokens[ $legacy_token->get_id() ] = $legacy_token;
 
-							$legacy_token->set_migrated( true );
+								$migrated_tokens++;
 
-							$this->update_legacy_token( $user_id, $legacy_token );
+								$legacy_token->set_migrated( true );
+
+								$this->update_legacy_token( $user_id, $legacy_token );
+							}
+
+						} catch ( SV_WC_Payment_Gateway_Exception $e ) {
+
+							$this->get_gateway()->get_plugin()->log( $e->getMessage() );
 						}
+
 					}
 				}
 
@@ -736,7 +765,12 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			$token->set_gateway_id( $this->get_gateway()->get_id() );
 			$token->set_environment( $environment_id );
 
-			$token_id = $token->save();
+			try {
+				$token_id = $token->save();
+			} catch ( SV_WC_Payment_Gateway_Exception $e ) {
+				$token_id = 0;
+				$this->get_gateway()->get_plugin()->log( $e->getMessage() );
+			}
 
 			if ( $token_id ) {
 				$updated_tokens[] = $token_id;


### PR DESCRIPTION
## Summary

When `WC_Data::save()` triggers an Exception, the framework token wrapper should catch it and log the message.

#### Story [ch30727](https://app.clubhouse.io/skyverge/story/30727/catch-potential-exception-when-saving-a-token)

## Additional details

There is no access to the gateway handler and thus the gateway/plugin/logger from the token object context. Therefore I thought we could normalize exceptions thrown by WC into the framework one for gateways, and catch that from other places where the framework tries to save a token.

## Acceptance

- [ ] Exceptions shouldn't halt plugin/framework. 
- [ ] Exception messages should be logged.