### PR TITLE
Namespace the payment methods JS handler class to avoid conflicts

### DIFF
--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
@@ -12,7 +12,7 @@ jQuery( document ).ready ($) ->
 	# The My Payment Methods handler.
 	#
 	# @since 5.1.0
-	class window.SV_WC_Payment_Methods_Handler
+	class window.SV_WC_Payment_Methods_Handler_v5_5_4
 
 
 		# Constructs the class.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -119,15 +119,15 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 
 	/**
-	 * Enqueue frontend CSS/JS
+	 * Enqueues frontend scripts and styles.
 	 *
 	 * @since 4.0.0
 	 */
 	public function maybe_enqueue_styles_scripts() {
 
-		$handle = 'sv-wc-payment-gateway-my-payment-methods';
+		$handle  = 'sv-wc-payment-gateway-my-payment-methods-v5_5_4';
 
-		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', array( 'dashicons' ), SV_WC_Plugin::VERSION );
+		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', [ 'dashicons' ], SV_WC_Plugin::VERSION );
 
 		wp_enqueue_script( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', [ 'jquery' ], SV_WC_Plugin::VERSION );
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -586,7 +586,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	protected function get_js_handler_class() {
 
-		return 'SV_WC_Payment_Methods_Handler';
+		return 'SV_WC_Payment_Methods_Handler_v5_5_4';
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -125,7 +125,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function maybe_enqueue_styles_scripts() {
 
-		$handle  = 'sv-wc-payment-gateway-my-payment-methods-v5_5_4';
+		$js_class = 'SV_WC_Payment_Methods_Handler_v5_5_4';
+		$handle   = strtolower( str_replace( '_', '-', $js_class ) );
 
 		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', [ 'dashicons' ], SV_WC_Plugin::VERSION );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -55,6 +55,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	/** @var bool true if there are tokens */
 	protected $has_tokens;
 
+	/** @var string the base name of the matching JS handler class used in frontend */
+	private $js_handler_base_class_name = 'SV_WC_Payment_Methods_Handler';
+
 
 	/**
 	 * Sets up the class.
@@ -125,7 +128,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	public function maybe_enqueue_styles_scripts() {
 
-		$js_class = 'SV_WC_Payment_Methods_Handler_v5_5_4';
+		$js_class = sprintf( '%s_v5_5_4', $this->js_handler_base_class_name );
 		$handle   = strtolower( str_replace( '_', '-', $js_class ) );
 
 		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', [ 'dashicons' ], SV_WC_Plugin::VERSION );
@@ -587,7 +590,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 */
 	protected function get_js_handler_class() {
 
-		return 'SV_WC_Payment_Methods_Handler_v5_5_4';
+		return sprintf( '%s_v5_5_4', $this->js_handler_base_class_name );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -133,7 +133,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 
 		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/sv-wc-payment-gateway-my-payment-methods.min.css', [ 'dashicons' ], SV_WC_Plugin::VERSION );
 
-		wp_enqueue_script( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', [ 'jquery' ], SV_WC_Plugin::VERSION );
+		wp_enqueue_script( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/sv-wc-payment-gateway-my-payment-methods.min.js', [ 'jquery' ], SV_WC_Plugin::VERSION );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -95,7 +95,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$this->load_tokens();
 
 		// styles/scripts
-		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles_scripts' ) );
+		add_action( 'wp_enqueue_scripts', [ $this, 'maybe_enqueue_styles_scripts' ] );
 
 		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'add_payment_methods_list_item_id' ], 10, 2 );
 		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'add_payment_methods_list_item_edit_action' ], 10, 2 );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -131,7 +131,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$js_class = sprintf( '%s_v5_5_4', $this->js_handler_base_class_name );
 		$handle   = strtolower( str_replace( '_', '-', $js_class ) );
 
-		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', [ 'dashicons' ], SV_WC_Plugin::VERSION );
+		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/sv-wc-payment-gateway-my-payment-methods.min.css', [ 'dashicons' ], SV_WC_Plugin::VERSION );
 
 		wp_enqueue_script( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', [ 'jquery' ], SV_WC_Plugin::VERSION );
 	}


### PR DESCRIPTION
## Summary

On installations that use multiple frameworked gateways simultaneously, the same JS handlers in `window.SV_WC_Payment_Methods_Handler` might overwrite each other - therefore we could make these names unique to match the current version of the framework to avoid collisions.

#### Story: [ch30772](https://app.clubhouse.io/skyverge/story/30772/namespace-the-js-handler-class)

## Additional details

I went for `SV_WC_Payment_Methods_Handler_v5_5_4` and matched this to the script handle used by WordPress to enqueue js and css files.

## QA

- [ ] Scripts and styles are enqueued properly