### PR TITLE
Prevent uncaught error in User Profile page when Subscriptions is active

### DIFF
--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -139,11 +139,13 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
-	 * Disables Subscription's default payment token change notice if the current request is not a frontend request.
+	 * Disables Subscription's default payment token change notice if wc_add_notice() is not defined
+	 *
+	 * This prevents an uncaught error from being triggered when tokens are retrieved and saved in the user profile page.
 	 *
 	 * @internal
 	 *
-	 * @see \WooCommerce::is_request()
+	 * @see \WCS_My_Account_Payment_Methods::display_default_payment_token_change_notice()
 	 *
 	 * @since 5.6.0-dev
 	 */

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -76,6 +76,9 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 			'subscription_payment_method_change_admin',
 		) );
 
+		// disable default payment token change notice if wc_add_notice() is not available
+		add_action( 'admin_init', [ $this, 'disable_default_payment_token_change_notice' ] );
+
 		// force tokenization when needed
 		add_filter( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_tokenization_forced', array( $this, 'maybe_force_tokenization' ) );
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -134,6 +134,19 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		}
 	}
 
+
+	/**
+	 * Disables Subscription's default payment token change notice if the current request is not a frontend request.
+	 *
+	 * @see \WooCommerce::is_request()
+	 *
+	 * @since 5.6.0-dev
+	 */
+	public function disable_default_payment_token_change_notice() {
+
+	}
+
+
 	/**
 	 * Force tokenization for subscriptions, this can be forced either during checkout
 	 * or when the payment method for a subscription is being changed

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -141,6 +141,8 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	/**
 	 * Disables Subscription's default payment token change notice if the current request is not a frontend request.
 	 *
+	 * @internal
+	 *
 	 * @see \WooCommerce::is_request()
 	 *
 	 * @since 5.6.0-dev

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -144,6 +144,9 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 */
 	public function disable_default_payment_token_change_notice() {
 
+		if ( ! function_exists( 'wc_add_notice' ) ) {
+			remove_action( 'woocommerce_payment_token_set_default', [ 'WCS_My_Account_Payment_Methods', 'display_default_payment_token_change_notice' ], 10, 2 );
+		}
 	}
 
 


### PR DESCRIPTION
# Summary

This PR disables the notice that Subscriptions shows when a token is set as default and there are other tokens from the save gateway that are associated to subscriptions, if the `wc_add_notice()` function is not defined.

Disabling the notice prevents an `Uncaught Error: Call to undefined function wc_add_notice()` error from being triggered in the User Profile page.

### Story: [CH 30782](https://app.clubhouse.io/skyverge/story/30782/prevent-uncaught-error-in-user-profile-page-when-subscriptions-is-active)
### Release: #362

## QA

We should be able to test having at least two tokens of the same gateway for any of our gateways. I found that scenario was easier to reproduce using Authorize.Net, even considering the necessary modification to `WC_Authorize_Net_CIM_Payment_Profile`.

### Setup

- Update `WC_Authorize_Net_CIM_Payment_Profile::__construct` to wrap all but the last line inside `if ( is_array( $data ) ) { }`
- Configure Subscriptions and create a subscription product
- Configure Authorize.Net Credit Card gateway using the version of the framewrok in the epic branch (`v5.6.0.x-dev`) (without these modifications)

### Steps

#### Reproduce the error

1. Purchase the subscription product using credit card number `4007000000027`
1. Purchase another product using credit card number `4012888818888` and save the payment method to your account
1. Go to the User Profile page of the user that placed the orders
    - [x] `Uncaught Error: Call to undefined function wc_add_notice()` is triggered while trying to render the Tokens Editor

#### Fix the error

1. Update Authorize.Net to use version `dev-ch30782-prevent-uncaught-error-in-user-profile-page` of the framework
1. Go to the User Profile page of the user that placed the orders
    - [x] No `Uncaught Error: Call to undefined function wc_add_notice()` is triggered
1. Change the expiration date or set the other token as default and save
    - [x] No `Uncaught Error: Call to undefined function wc_add_notice()` is triggered
    - [x] Modifications are saved successfully