### PR TITLE
Remove field validation classes on form load

### DIFF
--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
@@ -122,6 +122,8 @@ jQuery( document ).ready ($) ->
 		# during the updated_checkout event as otherwise the reference to
 		# the checkout fields becomes stale (somehow ¯\_(ツ)_/¯)
 		#
+		# This ensures payment fields are not marked as "invalid" before the customer has interacted with them.
+		#
 		# Returns nothing.
 		set_payment_fields: ->
 

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
@@ -124,7 +124,20 @@ jQuery( document ).ready ($) ->
 		#
 		# Returns nothing.
 		set_payment_fields: ->
+
 			@payment_fields = $( ".payment_method_#{ @id }" )
+
+			$required_fields = @payment_fields.find( '.validate-required .input-text' )
+
+			$required_fields.each( ( i, input ) =>
+
+				# if any of the required fields have a value, bail this loop and proceed with WooCommerce validation
+				if $( input ).val()
+					return false
+
+				# otherwise remove all validation result classes from the inputs, since the form is freshly loaded
+				$( input ).trigger( 'input' )
+			)
 
 
 		# Public: Validate Payment data when order is placed

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.min.js
@@ -104,7 +104,17 @@
       };
 
       SV_WC_Payment_Form_Handler.prototype.set_payment_fields = function() {
-        return this.payment_fields = $(".payment_method_" + this.id);
+        var $required_fields;
+        this.payment_fields = $(".payment_method_" + this.id);
+        $required_fields = this.payment_fields.find('.validate-required .input-text');
+        return $required_fields.each((function(_this) {
+          return function(i, input) {
+            if ($(input).val()) {
+              return false;
+            }
+            return $(input).trigger('input');
+          };
+        })(this));
       };
 
       SV_WC_Payment_Form_Handler.prototype.validate_payment_data = function() {


### PR DESCRIPTION
# Summary

Ensures payment gateway form fields are not validated on page load.

### Story: [CH 30845](https://app.clubhouse.io/skyverge/story/30845)
### Release: #394 

## Details

We issued a fix for this, but it only applied to WooCommerce v3.9+ because some changes in checkout.js allowed us to correct for it, and previous versions didn't. However, Woo has since rolled back those enabling changes so the fix is no longer valid as of WooCommerce v3.9.2.

## UI Changes

None

## QA

- Update Authorize.Net's composer to point to this branch

- [x] Story acceptance criteria confirmed