### PR TITLE
Make token migration status filterable

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -557,15 +557,23 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	public function is_migrated() {
 
-		/**
-		 * Filters the migration status of a token.
-		 *
-		 * @since 5.6.0-dev
-		 *
-		 * @param bool $migrated this would be set to true if a migration occurred
-		 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
-		 */
-		return (bool) apply_filters( 'wc_' . $this->get_gateway_id() . '_migrated_token', ! empty( $this->data['migrated'] ), $this );
+		$gateway_id  = $this->get_gateway_id();
+		$is_migrated = ! empty( $this->data['migrated'] );
+
+		if ( '' !== $gateway_id ) {
+
+			/**
+			 * Filters the migration status of a token.
+			 *
+			 * @since 5.6.0-dev
+			 *
+			 * @param bool $migrated this would be set to true if a migration occurred
+			 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
+			 */
+			$is_migrated = (bool) apply_filters( "wc_{$gateway_id}_migrated_token", ! empty( $this->data['migrated'] ), $this );
+		}
+
+		return $is_migrated;
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -557,7 +557,15 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	 */
 	public function is_migrated() {
 
-		return ! empty( $this->data['migrated'] );
+		/**
+		 * Filters the migration status of a token.
+		 *
+		 * @since 5.6.0-dev
+		 *
+		 * @param bool $migrated this would be set to true if a migration occurred
+		 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
+		 */
+		return (bool) apply_filters( 'wc_' . $this->get_gateway_id() . '_migrated_token', ! empty( $this->data['migrated'] ), $this );
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -567,10 +567,10 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			 *
 			 * @since 5.6.0-dev
 			 *
-			 * @param bool $migrated this would be set to true if a migration occurred
+			 * @param bool $is_migrated this would be set to true if a migration occurred
 			 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
 			 */
-			$is_migrated = (bool) apply_filters( "wc_payment_gateway_{$gateway_id}_migrated_token", ! empty( $this->data['migrated'] ), $this );
+			$is_migrated = (bool) apply_filters( "wc_payment_gateway_{$gateway_id}_migrated_token", $is_migrated, $this );
 		}
 
 		return $is_migrated;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -570,7 +570,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			 * @param bool $migrated this would be set to true if a migration occurred
 			 * @param SV_WC_Payment_Gateway_Payment_Token $token the token object
 			 */
-			$is_migrated = (bool) apply_filters( "wc_{$gateway_id}_migrated_token", ! empty( $this->data['migrated'] ), $this );
+			$is_migrated = (bool) apply_filters( "wc_payment_gateway_{$gateway_id}_migrated_token", ! empty( $this->data['migrated'] ), $this );
 		}
 
 		return $is_migrated;

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -1167,7 +1167,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 		 * @param int $user_id user ID
 		 * @param string $environment_id the gateway environment the tokens are related to
 		 */
-		return (bool) apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_user_legacy_tokens_migrated', $migrated, $user_id, $environment_id );
+		return (bool) apply_filters( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_user_legacy_tokens_migrated', $migrated, $user_id, $environment_id );
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -1156,7 +1156,18 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			$environment_id = $this->get_environment_id();
 		}
 
-		return 'yes' === get_user_meta( $user_id, $this->get_user_meta_name( $environment_id ) . '_migrated', true );
+		$migrated = 'yes' === get_user_meta( $user_id, $this->get_user_meta_name( $environment_id ) . '_migrated', true );
+
+		/**
+		 * Filters whether a user's legacy tokens have been migrated.
+		 *
+		 * @since 5.6.0-dev
+		 *
+		 * @param bool $migrated whether the tokens have been migrated
+		 * @param int $user_id user ID
+		 * @param string $environment_id the gateway environment the tokens are related to
+		 */
+		return (bool) apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_user_legacy_tokens_migrated', $migrated, $user_id, $environment_id );
 	}
 
 


### PR DESCRIPTION
## Summary

This PR adds 2 filters to methods that signal whether an user or an individual token have been migrated to core tokens. 

#### Story: [ch30918](https://app.clubhouse.io/skyverge/story/30918/make-sure-migration-status-of-tokens-users-can-be-filtered)

## Additional details

These filters could be handy during debug, to force re-run migrations (also selectively, since params give context), or our testing while implementing the framework's new version in our plugins.

## QA

- [x] When filtering `wc_payment_gateway_' . $this->get_gateway()->get_id() . '_user_legacy_tokens_migrated` and returning false it should be possible to force looping all customer tokens to be migrated
- [x] When filtering `wc_payment_gateway_{$gateway_id}_migrated_token` it should be possible to return false and force migrating again a token while looping legacy ones