### PR TITLE
Stored tokens should match tokenized payment methods retrieved through the Gateway's API

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -661,6 +661,11 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 				// persist locally after merging
 				$this->update_tokens( $user_id, $this->tokens[ $environment_id ][ $user_id ], $environment_id );
 
+				// remove local tokens not present in remote data
+				foreach ( array_diff_key( $tokens, $this->tokens[ $environment_id ][ $user_id ] ) as $key => $token ) {
+					$this->delete_token( $user_id, $token, $environment_id );
+				}
+
 			} catch( SV_WC_Plugin_Exception $e ) {
 
 				// communication or other error


### PR DESCRIPTION
# Summary

This PR restores a behavior from master that removes tokens stored locally if there are no longer available when we retrieve tokenized payment methods using the gateway's API.

### Story: [CH 30873](https://app.clubhouse.io/skyverge/story/30873)
### Release: #362

## Details

It looks like deleting a payment method from the new table does not remove that token from the legacy meta data nor from the gateway. There is not story for that yet.

## QA

### Setup

- Configure Authorize.Net in test mode

### Reproduce the problem

On master branch of Authorize.Net (remember to do `composer install`)

1. Save credit card `4012888818888` as a saved payment method
1. Save credit card `5424000000000015` as a saved payment method
1. Backup the user meta where tokens are stored:
    `wp user meta get {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test --format=json`
1. Delete saved payment method ending in `0015`

Switch to branch `authorize.net-switch-to-core-tokens` (remember to do `composer install`)

1. Make sure tokens will be migrated
    `wp user meta delete {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test_migrated`
1. Go to the Payment Methods page
    - [x] credit card ending in `8888` shows up as a framework token
1. Restore the old value of the user meta (note the json code is entered between single quotes):
    `wp user meta set {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test '{json}' --format=json`
1. Force another migration (the problem would occur on the initial migration too, but it was easier to reproduce this way):
    `wp user meta delete {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test_migrated`
1. Reload the Payment Methods page
    - [x] credit card ending in `0015` shows up but does not include information on the Details column or any of the other modifications made to framework tokens

### Test the fix

1. Delete both tokens from the Payment Methods page

Switch back to master branch of Authorize.Net (remember to do `composer install`)

1. Go to Payment Methods page (may need to delete saved payment methods again)
1. Save credit card `4012888818888` as a saved payment method
1. Save credit card `5424000000000015` as a saved payment method
1. Backup the user meta where tokens are stored:
    `wp user meta get {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test --format=json`
1. Delete saved payment method ending in `0015`

Switch to branch `authorize.net-switch-to-core-tokens` and update `composer.json` to use version `dev-ch30873/stored-tokens-should-match-remote-tokens` (this branch) of the framework (run `composer update`)

1. Make sure tokens will be migrated
    `wp user meta delete {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test_migrated`
1. Go to the Payment Methods page
    - [x] credit card ending in `8888` shows up as a framework token
1. Restore the old value of the user meta (note the json code is entered between single quotes):
    `wp user meta set {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test '{json}' --format=json`
1. Force migration:
    `wp user meta delete {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test_migrated`
1. Reload the Payment Methods page
    - [x] no additional saved payment methods show up on the table
