### PR TITLE
Delete legacy tokens and remote tokens when an associated core token is deleted

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -494,31 +494,37 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 	 *
 	 * @since 5.6.0-dev
 	 *
-	 * @param int $token_id the ID of a core token
+	 * @param int $core_token_id the ID of a core token
 	 * @param \WC_Payment_Token $core_token the core token object
 	 */
-	public function payment_token_deleted( $token_id, $core_token ) {
+	public function payment_token_deleted( $core_token_id, $core_token ) {
 
-		$token = $core_token instanceof \WC_Payment_Token ? $this->get_token_by_id( $core_token->get_token() ) : null;
+		$token_id = null;
 
-		if ( $token instanceof SV_WC_Payment_Gateway_Payment_Token ) {
+		// find out if the core token belongs to one of the gateways from this plugin
+		foreach ( $this->get_plugin()->get_gateways() as $gateway ) {
 
-			// confirm the token was deleted from the Payment Methods screen
-			if ( (int) $token_id === (int) get_query_var( 'delete-payment-method' ) ) {
+			if ( $gateway->get_id() === $core_token->get_gateway_id() ) {
 
-				$user_id = get_current_user_id();
-				$gateway = $this->get_plugin()->get_gateway_from_token( $user_id, $token );
-
-				/**
-				 * Fires after a new payment method is deleted by a customer.
-				 *
-				 * @since 5.0.0
-				 *
-				 * @param string $token_id ID of the deleted token
-				 * @param int $user_id user ID
-				 */
-				do_action( 'wc_payment_gateway_' . $gateway->get_id() . '_payment_method_deleted', $token, $user_id );
+				$token_id = $core_token->get_token();
+				break;
 			}
+		}
+
+		// confirm this is one of the plugin's tokens and that the token was deleted from the Payment Methods screen
+		if ( $token_id && (int) $core_token_id === (int) get_query_var( 'delete-payment-method' ) ) {
+
+			$user_id = get_current_user_id();
+
+			/**
+			 * Fires after a new payment method is deleted by a customer.
+			 *
+			 * @since 5.0.0
+			 *
+			 * @param string $token_id ID of the deleted token
+			 * @param int $user_id user ID
+			 */
+			do_action( 'wc_payment_gateway_' . $core_token->get_gateway_id() . '_payment_method_deleted', $token_id, $user_id );
 		}
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -502,6 +502,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods {
 		$token_id = null;
 
 		// find out if the core token belongs to one of the gateways from this plugin
+		// we can't use get_token_by_id() here because the FW token and associated core token were already deleted
 		foreach ( $this->get_plugin()->get_gateways() as $gateway ) {
 
 			if ( $gateway->get_id() === $core_token->get_gateway_id() ) {

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -63,6 +63,8 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 		$this->gateway = $gateway;
 
 		$this->environment_id = $gateway->get_environment();
+
+		$this->add_payment_token_deleted_action();
 	}
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -348,20 +348,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 		// for direct gateways that allow it, attempt to delete the token from the endpoint
 		if ( $this->get_gateway()->get_api()->supports_remove_tokenized_payment_method() ) {
 
-			try {
-
-				$response = $this->get_gateway()->get_api()->remove_tokenized_payment_method( $token->get_id(), $this->get_gateway()->get_customer_id( $user_id, array( 'environment_id' => $environment_id ) ) );
-
-				if ( ! $response->transaction_approved() && ! $this->should_delete_token( $token, $response ) ) {
-					return false;
-				}
-
-			} catch( SV_WC_Plugin_Exception $e ) {
-
-				if ( $this->get_gateway()->debug_log() ) {
-					$this->get_gateway()->get_plugin()->log( $e->getMessage(), $this->get_gateway()->get_id() );
-				}
-
+			if ( ! $this->remove_token_from_gateway( $user_id, $token ) ) {
 				return false;
 			}
 		}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -406,7 +406,14 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 		$this->clear_transient( $user_id );
 
 		$is_default = $token->is_default();
-		$deleted    = $token->delete();
+
+		// no need to respond to woocommerce_payment_token_deleted, we will remove remote and legacy data here
+		$this->remove_payment_token_deleted_action();
+
+		$deleted = $token->delete();
+
+		// restore action callback for woocommerce_payment_token_deleted
+		$this->add_payment_token_deleted_action();
 
 		if ( $deleted ) {
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -1206,6 +1206,17 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 
 	/**
+	 * Removes the callback action for woocommerce_payment_token_deleted.
+	 *
+	 * @since 5.6.0-dev
+	 */
+	private function remove_payment_token_deleted_action() {
+
+		remove_action( 'woocommerce_payment_token_deleted', [ $this, 'payment_token_deleted' ], 10, 2 );
+	}
+
+
+	/**
 	 * Deletes remote token data and legacy token data when the corresponding core token is deleted.
 	 *
 	 * @internal

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -1194,6 +1194,21 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	}
 
 
+	/**
+	 * Deletes remote token data and legacy token data when the corresponding core token is deleted.
+	 *
+	 * @internal
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param int $token_id the ID of a core token
+	 * @param \WC_Payment_Token $core_token the core token object
+	 */
+	public function payment_token_deleted() {
+
+	}
+
+
 }
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -348,7 +348,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 		// for direct gateways that allow it, attempt to delete the token from the endpoint
 		if ( $this->get_gateway()->get_api()->supports_remove_tokenized_payment_method() ) {
 
-			if ( ! $this->remove_token_from_gateway( $user_id, $token ) ) {
+			if ( ! $this->remove_token_from_gateway( $user_id, $environment_id, $token ) ) {
 				return false;
 			}
 		}
@@ -365,10 +365,11 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 * @since 5.6.0-dev
 	 *
 	 * @param int $user_id user identifier
+	 * @param string $environment_id environment id
 	 * @param SV_WC_Payment_Gateway_Payment_Token $token the payment token to remove
 	 * @return bool
 	 */
-	private function remove_token_from_gateway( $user_id, $token ) {
+	private function remove_token_from_gateway( $user_id, $environment_id, $token ) {
 
 		// remove a token's local data unless an exception occurs or we choose to keep loca data based on the API response
 		$remove_local_data = true;
@@ -1269,7 +1270,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 			$environment_id = $token->get_environment();
 
 			// for direct gateways that allow it, attempt to delete the token from the endpoint
-			if ( ! $this->get_gateway()->get_api()->supports_remove_tokenized_payment_method() || $this->remove_token_from_gateway( $user_id, $token ) ) {
+			if ( ! $this->get_gateway()->get_api()->supports_remove_tokenized_payment_method() || $this->remove_token_from_gateway( $user_id, $environment_id, $token ) ) {
 
 				// clear tokens transient
 				$this->clear_transient( $user_id );

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -1195,6 +1195,17 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 
 	/**
+	 * Add the callback action for woocommerce_payment_token_deleted.
+	 *
+	 * @since 5.6.0-dev
+	 */
+	private function add_payment_token_deleted_action() {
+
+		add_action( 'woocommerce_payment_token_deleted', [ $this, 'payment_token_deleted' ], 10, 2 );
+	}
+
+
+	/**
 	 * Deletes remote token data and legacy token data when the corresponding core token is deleted.
 	 *
 	 * @internal

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -1228,7 +1228,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 
 	/**
-	 * Add the callback action for woocommerce_payment_token_deleted.
+	 * Adds the callback action for woocommerce_payment_token_deleted.
 	 *
 	 * @since 5.6.0-dev
 	 */


### PR DESCRIPTION
# Summary

This PR removes local and remote token data when a core token is deleted directly. For example, when a user deletes a payment method from the Payment Methods page.

### Story: [CH 31230](https://app.clubhouse.io/skyverge/story/31230)
### Release: #362

## Details

Also, as a result of the changes in this PR, `payment_method_deleted()` was no longer able to retrieve a framework token object and couldn't determine whether the deleted token was a framework token or not.

This PR updates that method to use information available in core token object to decide whether the 'wc_payment_gateway_{gateway_id}_payment_method_deleted' filter should be triggered or not.

## QA

### Setup

- Configure master version of Authorize.Net in test mode

### Steps

1. Add  credit card `4012888818888` as a saved payment method
1. Confirm that the token was stored as user meta:
    `wp user meta get {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test --format=json`
1. Confirm that a the tokens transient for the credit card gateway includes the token:
    `wp transient list --search="wc_sv_tokens*"`
1. Make sure tokens will be migrated when you install the next version of Authorize.Net:
    `wp user meta delete {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test_migrated`

Switch to branch `authorize.net-switch-to-core-tokens` and update `composer.json` to use version `dev-ch31230/delete-legacy-and-remote-token-data` (this branch) of the framework (run composer update)

1. Go to the Payment Methods page
1. Delete credit card ending in `8888`
1. Confirm that the token is no longer stored in user meta:
    `wp user meta get {user_id} _wc_authorize_net_cim_credit_card_payment_tokens_test --format=json`
    - [x] The token is not stored in user meta
1. Confirm that a the tokens transient for the credit card gateway **does not** include the token:
    `wp transient list --search="wc_sv_tokens*"`
    - [x] The token is not included
1. Delete the transient or wait until it expires to force the framework to load tokens again
    - [x] The deleted token is not created again
