### PR TITLE
Update the framework payment token to store all metadata

### DIFF
--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -79,6 +79,7 @@ class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPT
 		return [
 			'nickname'     => [ 'nickname', 'personal card', 'get_nickname' ],
 			'billing_hash' => [ 'billing_hash', 'a5df', 'get_billing_hash' ],
+			'account_type' => [ 'account_type', 'savings', 'get_account_type' ],
 		];
 	}
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -675,9 +675,9 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 				$this->data[ $framework_key ] = $value;
 
-			} elseif ( array_key_exists( $core_key, $this->meta_data ) ) {
+			} elseif ( ! isset( $this->data[ $core_key ] ) ) {
 
-				$this->data[ $this->meta_data[ $core_key ] ] = $value;
+				$this->data[ $core_key ] = $value;
 			}
 		}
 	}

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -64,15 +64,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	];
 
 	/**
-	 * @var array key-value array to map WooCommerce core token meta data to framework token `$data` keys
-	 */
-	private $meta_data = [
-		'nickname'     => 'nickname',
-		'billing_hash' => 'billing_hash',
-		'environment'  => 'environment',
-	];
-
-	/**
 	 * @var null|\WC_Payment_Token WooCommerce core token corresponding to the framework token, if set
 	 */
 	private $token;


### PR DESCRIPTION
# Summary

This PR updates the framework token to copy all metadata from the core token into the `$data` property, instead of copying only known meta data keys.

### Story: [CH 31272](https://app.clubhouse.io/skyverge/story/31272)
### Release: #362

## QA

### Setup

- Configure branch `authorize.net-switch-to-core-tokens` of Authorize.Net and set `composer.json` to use version `dev-ch31272/store-all-meta-data-in-token` of the framework

### Steps

The `account_type` meta data is not currently copied in `v5.6.0`, we can test this PR by confirming it's copied now. Run the following on `wp shell` (one line at the time is best):

```php
$core_token = new WC_Payment_Token_ECheck();

$core_token->add_meta_data( 'account_type', 'savings' );

$profile = wc_authorize_net_cim()->get_gateway()->get_payment_tokens_handler()->build_token( '1234', $core_token )

$profile->get_account_type()
```

- [x] The last line return `savings`