### PR TITLE
Add admin notes helper

### DIFF
--- a/woocommerce/admin/Notes_Helper.php
+++ b/woocommerce/admin/Notes_Helper.php
@@ -94,7 +94,6 @@ class Notes_Helper {
 			/** @var WooCommerce_Admin_Notes\DataStore $data_store */
 			$data_store = \WC_Data_Store::load( 'admin-note' );
 
-			// We already have this note? Then exit, we're done.
 			$note_ids = $data_store->get_notes_with_name( $name );
 
 		} catch ( \Exception $exception ) {}

--- a/woocommerce/admin/Notes_Helper.php
+++ b/woocommerce/admin/Notes_Helper.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_5_4\Admin;
+
+use Automattic\WooCommerce\Admin\Notes as WooCommerce_Admin_Notes;
+
+/**
+ * Helper class for WooCommerce enhanced admin notes.
+ *
+ * @since 5.6.0-dev
+ */
+class Notes_Helper {
+
+
+	/** Conditional methods *******************************************************************************************/
+
+
+	/**
+	 * Determines if any notes with the given name exist.
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param string $name note name
+	 * @return bool
+	 */
+	public static function note_with_name_exists( $name ) {
+
+		return ! empty( self::get_note_ids_with_name( $name ) );
+	}
+
+
+	/** Getter methods ************************************************************************************************/
+
+
+	/**
+	 * Gets a note with the given name.
+	 *
+	 * @since 5.5.5-dev
+	 *
+	 * @param string $name name of the note to get
+	 * @return WooCommerce_Admin_Notes\WC_Admin_Note|null
+	 */
+	public static function get_note_with_name( $name ) {
+
+		$note     = null;
+		$note_ids = self::get_note_ids_with_name( $name );
+
+		if ( ! empty( $note_ids ) ) {
+
+			$note_id = current( $note_ids );
+
+			$note = WooCommerce_Admin_Notes\WC_Admin_Notes::get_note( $note_id );
+		}
+
+		return $note ?: null;
+	}
+
+
+	/**
+	 * Gets all notes with the given name.
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param string $name note name
+	 * @return int[]
+	 */
+	public static function get_note_ids_with_name( $name ) {
+
+		$note_ids = [];
+
+		try {
+
+			/** @var WooCommerce_Admin_Notes\DataStore $data_store */
+			$data_store = \WC_Data_Store::load( 'admin-note' );
+
+			// We already have this note? Then exit, we're done.
+			$note_ids = $data_store->get_notes_with_name( $name );
+
+		} catch ( \Exception $exception ) {}
+
+		return $note_ids;
+	}
+
+
+}

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.6.0-dev
+ * Feature - Add support for WooCommerce Admin enhanced notes
 
 2020.01.20 - version 5.5.4
  * Tweak - Add a link to the site's terms and conditions page below Apple Pay buttons when available

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -24,6 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_5_4;
 
+use Automattic\WooCommerce\Admin\Loader;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_4\\SV_WC_Helper' ) ) :
@@ -941,6 +943,19 @@ class SV_WC_Helper {
 		global $current_screen;
 
 		return isset( $current_screen->$prop ) && $id === $current_screen->$prop;
+	}
+
+
+	/**
+	 * Determines if viewing an enhanced admin screen.
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @return bool
+	 */
+	public static function is_enhanced_admin_screen() {
+
+		return is_admin() && SV_WC_Plugin_Compatibility::is_enhanced_admin_available() && ( Loader::is_admin_page() || Loader::is_embed_page() );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -313,6 +313,19 @@ class SV_WC_Plugin_Compatibility {
 	}
 
 
+	/**
+	 * Determines whether the enhanced admin is available.
+	 *
+	 * This is either in WooCommerce 4.0+ or via the feature plugin.
+	 *
+	 * @return bool
+	 */
+	public static function is_enhanced_admin_available() {
+
+		return self::is_wc_version_gte( '4.0' ) || class_exists( '\Automattic\WooCommerce\Admin\FeaturePlugin' );
+	}
+
+
 	/** WordPress core ******************************************************/
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -421,7 +421,7 @@ abstract class SV_WC_Plugin {
 		// common utility methods
 		require_once( $framework_path . '/class-sv-wc-helper.php' );
 		require_once( $framework_path . '/Country_Helper.php' );
-		require_once( $framework_path . 'admin/Notes_Helper.php' );
+		require_once( $framework_path . '/admin/Notes_Helper.php' );
 
 		// backwards compatibility for older WC versions
 		require_once( $framework_path . '/class-sv-wc-plugin-compatibility.php' );

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -421,6 +421,7 @@ abstract class SV_WC_Plugin {
 		// common utility methods
 		require_once( $framework_path . '/class-sv-wc-helper.php' );
 		require_once( $framework_path . '/Country_Helper.php' );
+		require_once( $framework_path . 'admin/Notes_Helper.php' );
 
 		// backwards compatibility for older WC versions
 		require_once( $framework_path . '/class-sv-wc-plugin-compatibility.php' );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -747,7 +747,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	protected function add_gateway_not_configured_notices() {
 
-		$is_enahanced_admin_available = SV_WC_Plugin_Compatibility::is_enhanced_admin_available();
+		$is_enhanced_admin_available = SV_WC_Plugin_Compatibility::is_enhanced_admin_available();
 
 		foreach ( $this->get_gateways() as $gateway ) {
 
@@ -755,7 +755,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 			if ( $gateway->is_enabled() && ! $gateway->is_configured() && ! $gateway->inherit_settings() ) {
 
-				if ( $is_enahanced_admin_available ) {
+				if ( $is_enhanced_admin_available ) {
 
 					if ( $note = Admin\Notes_Helper::get_note_with_name( $note_name ) ) {
 
@@ -800,8 +800,8 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 					] );
 				}
 
-				// if all's well with this gateway, make sure and delete any previously added notes
-			} elseif ( $is_enahanced_admin_available && Admin\Notes_Helper::note_with_name_exists( $note_name ) ) {
+			// if all's well with this gateway, make sure and delete any previously added notes
+			} elseif ( $is_enhanced_admin_available && Admin\Notes_Helper::note_with_name_exists( $note_name ) ) {
 
 				WC_Admin_Notes::delete_notes_with_name( $note_name );
 			}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -24,6 +24,9 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_5_4;
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_5_4\\SV_WC_Payment_Gateway_Plugin' ) ) :
@@ -744,13 +747,63 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	protected function add_gateway_not_configured_notices() {
 
+		$is_enahanced_admin_available = SV_WC_Plugin_Compatibility::is_enhanced_admin_available();
+
 		foreach ( $this->get_gateways() as $gateway ) {
+
+			$note_name = $gateway->get_id_dasherized() . '-not-configured';
 
 			if ( $gateway->is_enabled() && ! $gateway->is_configured() && ! $gateway->inherit_settings() ) {
 
-				$this->get_admin_notice_handler()->add_admin_notice( $gateway->get_not_configured_error_message(), $gateway->get_id() . '-not-configured', [
-					'notice_class' => 'error',
-				] );
+				if ( $is_enahanced_admin_available ) {
+
+					if ( $note = Admin\Notes_Helper::get_note_with_name( $note_name ) ) {
+
+						// if on the problem gateway's configuration page, revive the existing note that may have been dismissed
+						if ( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() && $this->is_payment_gateway_configuration_page( $gateway->get_id() ) ) {
+							$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
+						}
+
+					} else {
+
+						$note = new WC_Admin_Note();
+
+						$note->set_name( $note_name );
+						$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_ERROR );
+						$note->set_source( $gateway->get_id_dasherized() );
+
+						$note->set_title( sprintf(
+							/* translators: Placeholders: %s - gateway name */
+							__( '%s is not configured', 'woocommerce-plugin-framework' ),
+							$gateway->get_method_title()
+						) );
+
+						$note->set_content( $gateway->get_not_configured_error_message() );
+					}
+
+					$note->set_actions( [] );
+
+					// add the action buttons if not on the gateway's configuration page
+					if ( ! $this->is_payment_gateway_configuration_page( $gateway->get_id() ) ) {
+						$note->add_action( 'configure', __( 'Configure', 'woocommerce-plugin-framework' ), $this->get_settings_url( $this->get_id() ), WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED, true );
+						$note->add_action( 'dismiss', __( 'Dismiss', 'woocommerce-plugin-framework' ) );
+					}
+
+					$note->save();
+				}
+
+				// if not an enhanced admin screen, output the legacy style notice
+				if ( ! SV_WC_Helper::is_enhanced_admin_screen() ) {
+
+					$this->get_admin_notice_handler()->add_admin_notice( $gateway->get_not_configured_error_message(), $gateway->get_id() . '-not-configured', [
+						'notice_class' => 'error',
+					] );
+				}
+
+				// if all's well with this gateway, make sure and delete any previously added notes
+			} elseif ( $is_enahanced_admin_available && Admin\Notes_Helper::note_with_name_exists( $note_name ) ) {
+
+				WC_Admin_Notes::delete_notes_with_name( $note_name );
 			}
 		}
 	}


### PR DESCRIPTION
# Summary

Add some base helpers for dealing with WooCommerce Admin notes.

### Story: [CH 31505](https://app.clubhouse.io/skyverge/story/31505)
### Release: #394 

## Details

Adds a base helper class for retrieving admin notes. This can be enhanced in the future with much more functionality as we define our approach to dealing with admin notes.

As an example for other plugins, we've implemented the gateway "misconfiguration" notice using these methods.

## UI Changes

The notice text doesn't change, but now appears in WC Admin: https://cloud.skyver.ge/04uKNZqD

## QA

- Ensure you're running WooCommerce 4.0
- Point Authorize.Net's composer to `dev-ch31505/admin-notes-helper`
- Clear all `authorize_net` options from your DB

1. Activate
    - [x] No error notice is shown
1. Go to the Credit Card gateway settings page
1. Enable the gateway, but don't fill in any settings
1. Save
    - [x] You should now see the enhanced admin note error
1. Reload the page
    - [x] The same error is displayed, but only once
1. Navigate to the Plugins page
    - [x] The same error is display, in classic form
1. Navigate to the Orders page
    - [x] The enhanced note is displayed with Configure and Dismiss buttons
1. Click Configured
    - [x] You're taking to the gateway settings page
1. Navigate back to the Orders page
1. Click dismiss
1. Reload the page
    - [x] The note is no longer displayed
1. Go to the Credit Card gateway settings page
    - [x] The note is displayed again
1. Expand the "W" notices tab at the top right of the enhanced UI
    - [x] The same classic version of the error notice is _not_ present

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version