### PR TITLE
Fix changing the ID of a token using the Tokens Editor creates a copy of the token

### DIFF
--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -169,8 +169,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 			$token_id          = $data['id'];
 			$original_token_id = isset( $data['original_id'] ) ? $data['original_id'] : '';
 
-			unset( $data['id'] );
-			unset( $data['original_id'] );
+			unset( $data['id'], $data['original_id'] );
 
 			if ( ! $token_id ) {
 				continue;

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -166,7 +166,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 		foreach ( $tokens as $data ) {
 
-			$token_id          = $data['id'];
+			$token_id          = isset( $data['id'] ) ? $data['id'] : '';
 			$original_token_id = isset( $data['original_id'] ) ? $data['original_id'] : '';
 
 			unset( $data['id'], $data['original_id'] );

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -336,6 +336,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 	 * @param SV_WC_Payment_Gateway_Payment_Token the payment token object to update
 	 * @param string $token_id the token ID
 	 * @param array $data the token data
+	 * @return SV_WC_Payment_Gateway_Payment_Token
 	 */
 	protected function update_token( $token, $token_id, $data ) {
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -186,6 +186,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 				$token = $original_token_id ? $this->get_gateway()->get_payment_tokens_handler()->get_token( $user_id, $original_token_id ) : null;
 
+				// update the token props if a token with the original ID already exists to avoid creating another core token in SV_WC_Payment_Gateway_Payment_Token::save()
 				if ( $token instanceof SV_WC_Payment_Gateway_Payment_Token ) {
 					$built_tokens[ $token_id ] = $this->set_token_props( $token, $token_id, $data );
 				} else {

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -310,7 +310,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 
 	/**
-	 * Build a token object from data saved in the admin.
+	 * Builds a token object from data saved in the admin.
 	 *
 	 * This method allows concrete gateways to add special token data.
 	 * See Authorize.net CIM for an example.

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -161,7 +161,8 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 		$tokens = ( isset( $_POST[ $this->get_input_name() ] ) ) ? $_POST[ $this->get_input_name() ] : array();
 
-		$built_tokens = array();
+		$default_token_id = SV_WC_Helper::get_posted_value( $this->get_input_name() . '_default' );
+		$built_tokens     = [];
 
 		foreach ( $tokens as $data ) {
 
@@ -180,7 +181,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 			}
 
 			// Set the default method
-			$data['default'] = $token_id === SV_WC_Helper::get_posted_value( $this->get_input_name() . '_default' );
+			$data['default'] = $token_id === $default_token_id || $original_token_id === $default_token_id;
 
 			if ( $data = $this->validate_token_data( $token_id, $data ) ) {
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -165,9 +165,11 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 		foreach ( $tokens as $data ) {
 
-			$token_id = $data['id'];
+			$token_id          = $data['id'];
+			$original_token_id = isset( $data['original_id'] ) ? $data['original_id'] : '';
 
 			unset( $data['id'] );
+			unset( $data['original_id'] );
 
 			if ( ! $token_id ) {
 				continue;
@@ -181,7 +183,14 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 			$data['default'] = $token_id === SV_WC_Helper::get_posted_value( $this->get_input_name() . '_default' );
 
 			if ( $data = $this->validate_token_data( $token_id, $data ) ) {
-				$built_tokens[ $token_id ] = $this->build_token( $user_id, $token_id, $data );
+
+				$token = $original_token_id ? $this->get_gateway()->get_payment_tokens_handler()->get_token( $user_id, $original_token_id ) : null;
+
+				if ( $token instanceof SV_WC_Payment_Gateway_Payment_Token ) {
+					$built_tokens[ $token_id ] = $this->update_token( $token, $token_id, $data );
+				} else {
+					$built_tokens[ $token_id ] = $this->build_token( $user_id, $token_id, $data );
+				}
 			}
 		}
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -159,7 +159,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 	 */
 	public function save( $user_id ) {
 
-		$tokens = ( isset( $_POST[ $this->get_input_name() ] ) ) ? $_POST[ $this->get_input_name() ] : array();
+		$tokens = ( isset( $_POST[ $this->get_input_name() ] ) ) ? $_POST[ $this->get_input_name() ] : [];
 
 		$default_token_id = SV_WC_Helper::get_posted_value( $this->get_input_name() . '_default' );
 		$built_tokens     = [];

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -319,6 +319,32 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 
 	/**
+	 * Updates a token object with data saved in the admin.
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param SV_WC_Payment_Gateway_Payment_Token the payment token object to update
+	 * @param string $token_id the token ID
+	 * @param array $data the token data
+	 */
+	protected function update_token( $token, $token_id, $data ) {
+
+		unset( $data['type'] );
+
+		foreach ( $data as $key => $value ) {
+
+			if ( is_callable( [ $token, "set_{$key}" ] ) ) {
+				$token->{"set_{$key}"}( $value );
+			}
+		}
+
+		$token->set_id( $token_id );
+
+		return $token;
+	}
+
+
+	/**
 	 * Update the user's token data.
 	 *
 	 * @since 4.3.0

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -187,7 +187,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 				$token = $original_token_id ? $this->get_gateway()->get_payment_tokens_handler()->get_token( $user_id, $original_token_id ) : null;
 
 				if ( $token instanceof SV_WC_Payment_Gateway_Payment_Token ) {
-					$built_tokens[ $token_id ] = $this->update_token( $token, $token_id, $data );
+					$built_tokens[ $token_id ] = $this->set_token_props( $token, $token_id, $data );
 				} else {
 					$built_tokens[ $token_id ] = $this->build_token( $user_id, $token_id, $data );
 				}
@@ -337,7 +337,7 @@ class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 	 * @param array $data the token data
 	 * @return SV_WC_Payment_Gateway_Payment_Token
 	 */
-	protected function update_token( $token, $token_id, $data ) {
+	protected function set_token_props( $token, $token_id, $data ) {
 
 		unset( $data['type'] );
 

--- a/woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php
+++ b/woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php
@@ -76,6 +76,7 @@
 
 	<?php endforeach; ?>
 
+	<input name="<?php echo esc_attr( $token_input_name ); ?>[original_id]" value="<?php echo esc_attr( $token['id'] ); ?>" type="hidden" />
 	<input name="<?php echo esc_attr( $token_input_name ); ?>[type]" value="<?php echo esc_attr( $type ); ?>" type="hidden" />
 
 	<td class="token-default token-attribute">

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -734,8 +734,6 @@ class SV_WC_Payment_Gateway_Payment_Token {
 			}
 		}
 
-		$token->apply_changes();
-
 		try {
 
 			$saved = $token->save();

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -138,6 +138,19 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
+	 * Sets the payment token string.
+	 *
+	 * @since 5.6.0-dev
+	 *
+	 * @param string $id payment token string
+	 */
+	public function set_id( $id ) {
+
+		$this->id = (string) $id;
+	}
+
+
+	/**
 	 * Gets the gateway ID for the token.
 	 *
 	 * @since 5.6.0-dev.1

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -279,7 +279,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 
 	/**
-	 * Updates a single token by persisting it to user meta
+	 * Updates a single token by persisting its data as a core token.
 	 *
 	 * @since since 4.0.0
 	 *


### PR DESCRIPTION
# Summary

This PR updates the Token Editor to update existing tokens without creating new token records on the database.

### Story: [CH 31591](https://app.clubhouse.io/skyverge/story/31591)
### Release: #362

## Details

Using build_token() to create tokens with the modified data works in most cases, because the Framework token normally updates the associated core token record instead of creating a new one. However, if the ID of the the Framework token changes, it can no longer find the associated core token record and ends up creating a new one in the database.

This PR uses build_token() to store data for new tokens only and uses setter methods to apply modifications to the Framework token object for existing ones.

## QA

### Setup

- Configure CyberSource from `cybersource-switch-to-core-tokens` branch
- Update `composer.json` to use version `dev-ch31591/prevent-duplicate-tokens-on-tokens-editor` of the framework (this branch)
- Save a payment method

### Steps

1. Go to the User Profile page for the user that saved the payment method
    - [x] The token editor includes the saved payment
1. Change the Token ID of the payment method and click Save
    - [x] The token editor includes the saved payment with the new ID
    - [x] No extra saved payment methods were added to the table
1. Change the Card Type, Last Four, Expiration, and Default values for the saved payment method
1. Click Save
    - [x] The token editor includes the saved payment with the modified values
    - [x] No extra saved payment methods were added to the table
1. Click Add New to add a new saved payment method and enter values for all the fields
1. Click Save
    - [x] The new payment method was saved correctly

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
