### PR TITLE
Clear admin notes on deactivation

### DIFF
--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -25,6 +25,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_0\Plugin;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_6_0\Admin\Notes_Helper;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_0\SV_WC_Payment_Gateway_Plugin;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_0\SV_WC_Plugin;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_0\SV_WC_Plugin_Compatibility;
 
@@ -196,7 +197,17 @@ class Lifecycle {
 
 		// if the enhanced admin is available, delete all of this plugin's notes on deactivation
 		if ( SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
+
 			Notes_Helper::delete_notes_with_source( $this->get_plugin()->get_id_dasherized() );
+
+			// if this is a gateway plugin, also delete the plugin's individual gateway notes
+			if ( $this->get_plugin() instanceof SV_WC_Payment_Gateway_Plugin ) {
+
+				foreach ( $this->get_plugin()->get_gateways() as $gateway ) {
+
+					Notes_Helper::delete_notes_with_source( $gateway->get_id_dasherized() );
+				}
+			}
 		}
 
 		$this->deactivate();
@@ -644,7 +655,7 @@ class Lifecycle {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @return SV_WC_Plugin
+	 * @return SV_WC_Plugin|SV_WC_Payment_Gateway_Plugin
 	 */
 	protected function get_plugin() {
 

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -204,7 +204,6 @@ class Lifecycle {
 			if ( $this->get_plugin() instanceof SV_WC_Payment_Gateway_Plugin ) {
 
 				foreach ( $this->get_plugin()->get_gateways() as $gateway ) {
-
 					Notes_Helper::delete_notes_with_source( $gateway->get_id_dasherized() );
 				}
 			}

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -24,7 +24,9 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_0\Plugin;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_0\Admin\Notes_Helper;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_0\SV_WC_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_0\SV_WC_Plugin_Compatibility;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -191,6 +193,11 @@ class Lifecycle {
 	 * @since 5.2.0
 	 */
 	public function handle_deactivation() {
+
+		// if the enhanced admin is available, delete all of this plugin's notes on deactivation
+		if ( SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
+			Notes_Helper::delete_notes_with_source( $this->get_plugin()->get_id_dasherized() );
+		}
 
 		$this->deactivate();
 

--- a/woocommerce/admin/Notes_Helper.php
+++ b/woocommerce/admin/Notes_Helper.php
@@ -106,6 +106,26 @@ class Notes_Helper {
 	}
 
 
+	/**
+	 * Gets all note IDs from the given source.
+	 *
+	 * @since 5.6.1-dev
+	 *
+	 * @param string $source note source
+	 * @return int[]
+	 */
+	public static function get_note_ids_with_source( $source ) {
+		global $wpdb;
+
+		return $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT note_id FROM {$wpdb->prefix}wc_admin_notes WHERE source = %s ORDER BY note_id ASC",
+				$source
+			)
+		);
+	}
+
+
 }
 
 endif;

--- a/woocommerce/admin/Notes_Helper.php
+++ b/woocommerce/admin/Notes_Helper.php
@@ -25,6 +25,10 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_6_0\Admin;
 
 use Automattic\WooCommerce\Admin\Notes as WooCommerce_Admin_Notes;
 
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_0\\Admin\\Notes_Helper' ) ) :
+
 /**
  * Helper class for WooCommerce enhanced admin notes.
  *
@@ -103,3 +107,5 @@ class Notes_Helper {
 
 
 }
+
+endif;

--- a/woocommerce/admin/Notes_Helper.php
+++ b/woocommerce/admin/Notes_Helper.php
@@ -126,6 +126,24 @@ class Notes_Helper {
 	}
 
 
+	/**
+	 * Deletes all notes from the given source.
+	 *
+	 * @since 5.6.1-dev
+	 *
+	 * @param string $source source name
+	 */
+	public static function delete_notes_with_source( $source ) {
+
+		foreach ( self::get_note_ids_with_source( $source ) as $note_id ) {
+
+			if ( $note = WooCommerce_Admin_Notes\WC_Admin_Notes::get_note( $note_id ) ) {
+				$note->delete();
+			}
+		}
+	}
+
+
 }
 
 endif;

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.6.1-dev
+ * Fix - Delete enhanced admin notes on plugin deactivation
 
 2020.03.04 - version 5.6.0
  * Feature - Add support for WooCommerce Admin enhanced notes


### PR DESCRIPTION
# Summary

Adds a deactivation routine for deleting admin notes that the plugin may have added.

### Story: [CH 31714](https://app.clubhouse.io/skyverge/story/31714/plugins-should-clear-their-admin-notes-upon-deactivation-8)
### Release: #434 

## Details

Since notes persist in the database and will appear in the enhanced admin regardless of plugin status, this routine deletes all notes from the plugin's source name on deactivation. Also deletes any individual gateway notes added by gateway plugins.

## UI Changes

None

## QA

- Running WC 4.0 RC 2
- Activate, enable, and configure any [in-progress plugin's](https://github.com/skyverge/wc-plugins/pulls?q=is%3Aopen+is%3Apr+label%3Ablocked+label%3Awc-compat) gateways

### Steps
1. Update the plugin's composer to `dev-ch31714/clear-admin-notes-on-deactivation`
1. Deactivate the plugin
    - [x] No notices or errors
1. Activate the plugin again
1. Remove some credential from one of the gateways, but leave it enabled
    - [x] The configuration admin error note is displayed
1. Deactivate the plugin
1. Navigate to any enhanced WooCommerce page
    - [x] The note is not persisted
1. Activate the plugin again
1. Navigate to any enhanced WooCommerce page
    - [x] The note returns
1. Reconfigure the gateways
    - [x] The note is gone

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version