### PR TITLE
Add control methods

### DIFF
--- a/tests/unit/Settings_API/ControlTest.php
+++ b/tests/unit/Settings_API/ControlTest.php
@@ -3,6 +3,7 @@
 namespace Settings_API;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Control;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Exception;
 
 define( 'ABSPATH', true );
 
@@ -14,6 +15,7 @@ class ControlTest extends \Codeception\Test\Unit {
 	 */
 	protected function _before() {
 
+		require_once( 'woocommerce/class-sv-wc-plugin-exception.php' );
 		require_once( 'woocommerce/Settings_API/Control.php' );
 	}
 
@@ -27,6 +29,163 @@ class ControlTest extends \Codeception\Test\Unit {
 
 
 	/** Test methods **************************************************************************************************/
+
+
+	/** @see Control::get_setting_id() */
+	public function test_get_setting_id() {
+
+		$control = new Control();
+		$control->set_setting_id( 'setting' );
+
+		$this->assertSame( 'setting', $control->get_setting_id() );
+	}
+
+
+	/** @see Control::get_type() */
+	public function test_get_type() {
+
+		$control = new Control();
+		$control->set_type( 'this-type' );
+
+		$this->assertSame( 'this-type', $control->get_type() );
+	}
+
+
+	/** @see Control::get_name() */
+	public function test_get_name() {
+
+		$control = new Control();
+		$control->set_name( 'Control name' );
+
+		$this->assertSame( 'Control name', $control->get_name() );
+	}
+
+
+	/** @see Control::get_description() */
+	public function test_get_description() {
+
+		$control = new Control();
+		$control->set_description( 'Control description' );
+
+		$this->assertSame( 'Control description', $control->get_description() );
+	}
+
+
+	/** @see Control::get_options() */
+	public function test_get_options() {
+
+		$options = [
+			'option-1' => 'Option 1',
+			'option-2' => 'Option 2',
+		];
+
+		$control = new Control();
+		$control->set_options( $options );
+
+		$this->assertSame( $options, $control->get_options() );
+	}
+
+
+	/**
+	 * @see Control::set_setting_id()
+	 *
+	 * @param mixed $value value to pass to the method
+	 * @param string $expected expected value
+	 * @param bool $exception whether an exception is expected
+	 * @throws SV_WC_Plugin_Exception
+	 *
+	 * @dataProvider provider_set_setting_id
+	 */
+	public function test_set_setting_id( $value, $expected, $exception = false ) {
+
+		if ( $exception ) {
+			$this->expectException( SV_WC_Plugin_Exception::class );
+		}
+
+		$control = new Control();
+		$control->set_setting_id( $value );
+
+		$this->assertSame( $expected, $control->get_setting_id() );
+	}
+
+
+	/** @see test_set_setting_id() */
+	public function provider_set_setting_id() {
+
+		return [
+			[ 'yes', 'yes' ],
+			[ '', '' ],
+			[ false, '', true ],
+		];
+	}
+
+
+	/**
+	 * @see Control::set_name()
+	 *
+	 * @param mixed $value value to pass to the method
+	 * @param string $expected expected value
+	 * @param bool $exception whether an exception is expected
+	 * @throws SV_WC_Plugin_Exception
+	 *
+	 * @dataProvider provider_set_name
+	 */
+	public function test_set_name( $value, $expected, $exception = false ) {
+
+		if ( $exception ) {
+			$this->expectException( SV_WC_Plugin_Exception::class );
+		}
+
+		$control = new Control();
+		$control->set_name( $value );
+
+		$this->assertSame( $expected, $control->get_name() );
+	}
+
+
+	/** @see test_set_name() */
+	public function provider_set_name() {
+
+		return [
+			[ 'name', 'name' ],
+			[ '', '' ],
+			[ false, '', true ],
+		];
+	}
+
+
+	/**
+	 * @see Control::set_description()
+	 *
+	 * @param mixed $value value to pass to the method
+	 * @param string $expected expected value
+	 * @param bool $exception whether an exception is expected
+	 * @throws SV_WC_Plugin_Exception
+	 *
+	 * @dataProvider provider_set_name
+	 */
+	public function test_set_description( $value, $expected, $exception = false ) {
+
+		if ( $exception ) {
+			$this->expectException( SV_WC_Plugin_Exception::class );
+		}
+
+		$control = new Control();
+		$control->set_description( $value );
+
+		$this->assertSame( $expected, $control->get_description() );
+	}
+
+
+	/** @see test_set_description() */
+	public function provider_set_description() {
+
+		return [
+			[ 'description', 'description' ],
+			[ '', '' ],
+			[ false, '', true ],
+		];
+	}
 
 
 }

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -24,6 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Exception;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Settings_API\\Control' ) ) :
@@ -119,6 +121,91 @@ class Control {
 	public function get_options() {
 
 		return $this->options;
+	}
+
+
+	/** Setter methods ************************************************************************************************/
+
+
+	/**
+	 * Sets the setting ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $value setting ID to set
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function set_setting_id( $value ) {
+
+		if ( ! is_string( $value ) ) {
+			throw new SV_WC_Plugin_Exception( 'Setting ID value must be a string' );
+		}
+
+		$this->setting_id = $value;
+	}
+
+
+	/**
+	 * Sets the setting ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $value setting ID to set
+	 */
+	public function set_type( $value ) {
+
+		// TODO: add validation and throw an exception
+
+		$this->type = $value;
+	}
+
+
+	/**
+	 * Sets the name.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $value control name to set
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function set_name( $value ) {
+
+		if ( ! is_string( $value ) ) {
+			throw new SV_WC_Plugin_Exception( 'Control name value must be a string' );
+		}
+
+		$this->name = $value;
+	}
+
+
+	/**
+	 * Sets the description.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $value control description to set
+	 * @throws SV_WC_Plugin_Exception
+	 */
+	public function set_description( $value ) {
+
+		if ( ! is_string( $value ) ) {
+			throw new SV_WC_Plugin_Exception( 'Control description value must be a string' );
+		}
+
+		$this->description = $value;
+	}
+
+
+	/**
+	 * Sets the options.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $options options to set
+	 */
+	public function set_options( array $options ) {
+
+		$this->options = $options;
 	}
 
 

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -35,6 +35,23 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Settings
  */
 class Control {
 
+
+	/** @var string|null the setting ID to which this control belongs */
+	protected $setting_id;
+
+	/** @var string|null the control type */
+	protected $type;
+
+	/** @var string the control name */
+	protected $name = '';
+
+	/** @var string the control description */
+	protected $description = '';
+
+	/** @var array the control options, as $option => $label  */
+	protected $options = [];
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -52,6 +52,76 @@ class Control {
 	protected $options = [];
 
 
+	/** Getter methods ************************************************************************************************/
+
+
+	/**
+	 * The setting ID to which this control belongs.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return null|string
+	 */
+	public function get_setting_id() {
+
+		return $this->setting_id;
+	}
+
+
+	/**
+	 * Gets the control type.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return null|string
+	 */
+	public function get_type() {
+
+		return $this->type;
+	}
+
+
+	/**
+	 * Gets the control name.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+
+		return $this->name;
+	}
+
+
+	/**
+	 * Gets the control description.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+
+		return $this->description;
+	}
+
+
+	/**
+	 * Gets the control options.
+	 *
+	 * As $option => $label for display.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	public function get_options() {
+
+		return $this->options;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -205,6 +205,8 @@ class Control {
 	 */
 	public function set_options( array $options ) {
 
+		// TODO: add validation and throw an exception
+
 		$this->options = $options;
 	}
 

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -183,7 +183,7 @@ class Control {
 
 
 	/**
-	 * Sets the setting ID.
+	 * Sets the type.
 	 *
 	 * @since x.y.z
 	 *


### PR DESCRIPTION
# Summary

Adds properties, getter, and setter methods to Control object.

### Story: [CH 32600](https://app.clubhouse.io/skyverge/story/32600/add-properties-getters-and-setters-to-settings-api-control-class)
### Release: #436 

## QA

- [x] Unit tests pass