### PR TITLE
Add properties, getters and setters to `Settings_API\Setting` class

### DIFF
--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -93,6 +93,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_is_multi()
+	 *
+	 * @param bool $input input value
+	 * @param bool $expected expected return value
+	 *
+	 * @dataProvider provider_set_is_multi
+	 */
+	public function test_set_is_multi( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_is_multi( $input );
+		$this->assertEquals( $expected, $setting->is_is_multi() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -153,6 +169,20 @@ class SettingTest extends \Codeception\Test\Unit {
 		return [
 			[ 'Use this setting to configure it', 'Use this setting to configure it' ],
 			[ '', '' ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_is_multi()
+	 *
+	 * @return array
+	 */
+	public function provider_set_is_multi() {
+
+		return [
+			[ true, true ],
+			[ false, false ],
 		];
 	}
 

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -141,6 +141,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_value()
+	 *
+	 * @param array $input input value
+	 * @param array $expected expected return value
+	 *
+	 * @dataProvider provider_set_value
+	 */
+	public function test_set_value( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_value( $input );
+		$this->assertEquals( $expected, $setting->get_value() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -227,7 +243,7 @@ class SettingTest extends \Codeception\Test\Unit {
 	public function provider_set_options() {
 
 		return [
-			[ [ 'string 1', 'string 2' ], [ 'string 1', 'string 2' ] ],
+			[ [ 'example 1', 'example 2' ], [ 'example 1', 'example 2' ] ],
 			[ [ -1, 1, 2 ], [ -1, 1, 2 ] ],
 			[ [ 1.5, 2.5, -3 ], [ 1.5, 2.5, -3 ] ],
 			[ [ true, false ], [ true, false ] ],
@@ -243,7 +259,26 @@ class SettingTest extends \Codeception\Test\Unit {
 	public function provider_set_default() {
 
 		return [
-			[ 'string', 'string' ],
+			[ 'example', 'example' ],
+			[ 'example.com', 'example.com' ],
+			[ 'test@example.com', 'test@example.com' ],
+			[ 1, 1 ],
+			[ 0.5, 0.5 ],
+			[ false, false ],
+			[ '', '' ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_value()
+	 *
+	 * @return array
+	 */
+	public function provider_set_value() {
+
+		return [
+			[ 'example', 'example' ],
 			[ 'example.com', 'example.com' ],
 			[ 'test@example.com', 'test@example.com' ],
 			[ 1, 1 ],

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -42,6 +42,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_id( $input );
+
 		$this->assertEquals( $expected, $setting->get_id() );
 	}
 
@@ -58,6 +59,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_type( $input );
+
 		$this->assertEquals( $expected, $setting->get_type() );
 	}
 
@@ -74,6 +76,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_name( $input );
+
 		$this->assertEquals( $expected, $setting->get_name() );
 	}
 
@@ -90,6 +93,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_description( $input );
+
 		$this->assertEquals( $expected, $setting->get_description() );
 	}
 
@@ -106,6 +110,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_is_multi( $input );
+
 		$this->assertEquals( $expected, $setting->is_is_multi() );
 	}
 
@@ -122,6 +127,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_options( $input );
+
 		$this->assertEquals( $expected, $setting->get_options() );
 	}
 
@@ -138,6 +144,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_default( $input );
+
 		$this->assertEquals( $expected, $setting->get_default() );
 	}
 
@@ -154,6 +161,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_value( $input );
+
 		$this->assertEquals( $expected, $setting->get_value() );
 	}
 
@@ -170,6 +178,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		$setting = new Setting();
 		$setting->set_control( $input );
+
 		$this->assertEquals( $expected, $setting->get_control() );
 	}
 

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -77,6 +77,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_description()
+	 *
+	 * @param string $input input description
+	 * @param string $expected expected return description
+	 *
+	 * @dataProvider provider_set_description
+	 */
+	public function test_set_description( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_description( $input );
+		$this->assertEquals( $expected, $setting->get_description() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -122,6 +138,20 @@ class SettingTest extends \Codeception\Test\Unit {
 
 		return [
 			[ 'My Setting', 'My Setting' ],
+			[ '', '' ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_description()
+	 *
+	 * @return array
+	 */
+	public function provider_set_description() {
+
+		return [
+			[ 'Use this setting to configure it', 'Use this setting to configure it' ],
 			[ '', '' ],
 		];
 	}

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -125,6 +125,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_default()
+	 *
+	 * @param array $input input default value
+	 * @param array $expected expected return default value
+	 *
+	 * @dataProvider provider_set_default
+	 */
+	public function test_set_default( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_default( $input );
+		$this->assertEquals( $expected, $setting->get_default() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -215,6 +231,25 @@ class SettingTest extends \Codeception\Test\Unit {
 			[ [ -1, 1, 2 ], [ -1, 1, 2 ] ],
 			[ [ 1.5, 2.5, -3 ], [ 1.5, 2.5, -3 ] ],
 			[ [ true, false ], [ true, false ] ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_default()
+	 *
+	 * @return array
+	 */
+	public function provider_set_default() {
+
+		return [
+			[ 'string', 'string' ],
+			[ 'example.com', 'example.com' ],
+			[ 'test@example.com', 'test@example.com' ],
+			[ 1, 1 ],
+			[ 0.5, 0.5 ],
+			[ false, false ],
+			[ '', '' ],
 		];
 	}
 

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -109,6 +109,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_options()
+	 *
+	 * @param array $input input options
+	 * @param array $expected expected return options
+	 *
+	 * @dataProvider provider_set_options
+	 */
+	public function test_set_options( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_options( $input );
+		$this->assertEquals( $expected, $setting->get_options() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -183,6 +199,22 @@ class SettingTest extends \Codeception\Test\Unit {
 		return [
 			[ true, true ],
 			[ false, false ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_options()
+	 *
+	 * @return array
+	 */
+	public function provider_set_options() {
+
+		return [
+			[ [ 'string 1', 'string 2' ], [ 'string 1', 'string 2' ] ],
+			[ [ -1, 1, 2 ], [ -1, 1, 2 ] ],
+			[ [ 1.5, 2.5, -3 ], [ 1.5, 2.5, -3 ] ],
+			[ [ true, false ], [ true, false ] ],
 		];
 	}
 

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -29,4 +29,37 @@ class SettingTest extends \Codeception\Test\Unit {
 	/** Test methods **************************************************************************************************/
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_id()
+	 *
+	 * @param string $input input ID
+	 * @param string $expected expected return ID
+	 *
+	 * @dataProvider provider_set_id
+	 */
+	public function test_set_id( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_id( $input );
+		$this->assertEquals( $expected, $setting->get_id() );
+	}
+
+
+	/** Provider methods **********************************************************************************************/
+
+
+	/**
+	 * Provider for test_set_id()
+	 *
+	 * @return array
+	 */
+	public function provider_set_id() {
+
+		return [
+			[ 'my-setting', 'my-setting' ],
+			[ '', '' ],
+		];
+	}
+
+
 }

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -61,6 +61,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_name()
+	 *
+	 * @param string $input input name
+	 * @param string $expected expected return name
+	 *
+	 * @dataProvider provider_set_name
+	 */
+	public function test_set_name( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_name( $input );
+		$this->assertEquals( $expected, $setting->get_name() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -92,6 +108,21 @@ class SettingTest extends \Codeception\Test\Unit {
 			[ 'integer', 'integer' ],
 			[ 'float', 'float' ],
 			[ 'boolean', 'boolean' ],
+			[ '', '' ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_name()
+	 *
+	 * @return array
+	 */
+	public function provider_set_name() {
+
+		return [
+			[ 'My Setting', 'My Setting' ],
+			[ '', '' ],
 		];
 	}
 

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -2,6 +2,7 @@
 
 namespace Settings_API;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Control;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
 
 define( 'ABSPATH', true );
@@ -157,6 +158,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_control()
+	 *
+	 * @param array $input input control
+	 * @param array $expected expected return control
+	 *
+	 * @dataProvider provider_set_control
+	 */
+	public function test_set_control( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_control( $input );
+		$this->assertEquals( $expected, $setting->get_control() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -285,6 +302,23 @@ class SettingTest extends \Codeception\Test\Unit {
 			[ 0.5, 0.5 ],
 			[ false, false ],
 			[ '', '' ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_control()
+	 *
+	 * @return array
+	 */
+	public function provider_set_control() {
+
+		require_once( 'woocommerce/Settings_API/Control.php' );
+
+		$control = new Control();
+
+		return [
+			[ $control, $control ],
 		];
 	}
 

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -45,6 +45,22 @@ class SettingTest extends \Codeception\Test\Unit {
 	}
 
 
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting::set_type()
+	 *
+	 * @param string $input input type
+	 * @param string $expected expected return type
+	 *
+	 * @dataProvider provider_set_type
+	 */
+	public function test_set_type( $input, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_type( $input );
+		$this->assertEquals( $expected, $setting->get_type() );
+	}
+
+
 	/** Provider methods **********************************************************************************************/
 
 
@@ -58,6 +74,24 @@ class SettingTest extends \Codeception\Test\Unit {
 		return [
 			[ 'my-setting', 'my-setting' ],
 			[ '', '' ],
+		];
+	}
+
+
+	/**
+	 * Provider for test_set_type()
+	 *
+	 * @return array
+	 */
+	public function provider_set_type() {
+
+		return [
+			[ 'string', 'string' ],
+			[ 'url', 'url' ],
+			[ 'email', 'email' ],
+			[ 'integer', 'integer' ],
+			[ 'float', 'float' ],
+			[ 'boolean', 'boolean' ],
 		];
 	}
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -54,6 +54,9 @@ class Setting {
 	/** @var array valid setting options */
 	protected $options = [];
 
+	/** @var int|float|string|bool|array setting default value */
+	protected $default;
+
 
 }
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -39,6 +39,9 @@ class Setting {
 	/** @var string unique setting ID */
 	protected $id;
 
+	/** @var string setting type */
+	protected $type;
+
 
 }
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -42,6 +42,9 @@ class Setting {
 	/** @var string setting type */
 	protected $type;
 
+	/** @var string setting name */
+	protected $name;
+
 
 }
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -45,6 +45,9 @@ class Setting {
 	/** @var string setting name */
 	protected $name;
 
+	/** @var string setting description */
+	protected $description;
+
 
 }
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -51,6 +51,9 @@ class Setting {
 	/** @var bool whether the setting holds an array of multiple values */
 	protected $is_multi = false;
 
+	/** @var array valid setting options */
+	protected $options = [];
+
 
 }
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -48,6 +48,9 @@ class Setting {
 	/** @var string setting description */
 	protected $description;
 
+	/** @var bool whether the setting holds an array of multiple values */
+	protected $is_multi = false;
+
 
 }
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -83,117 +83,6 @@ class Setting {
 	protected $control;
 
 
-	/** Setter Methods ************************************************************************************************/
-
-
-	/**
-	 * Sets the setting ID.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param string $id
-	 */
-	public function set_id( $id ) {
-		$this->id = $id;
-	}
-
-
-	/**
-	 * Sets the setting type.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param string $type
-	 */
-	public function set_type( $type ) {
-		$this->type = $type;
-	}
-
-
-	/**
-	 * Sets the setting name.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param string $name
-	 */
-	public function set_name( $name ) {
-		$this->name = $name;
-	}
-
-
-	/**
-	 * Sets the setting description.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param string $description
-	 */
-	public function set_description( $description ) {
-		$this->description = $description;
-	}
-
-
-	/**
-	 * Sets whether the setting holds an array of multiple values.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param bool $is_multi
-	 */
-	public function set_is_multi( $is_multi ) {
-		$this->is_multi = $is_multi;
-	}
-
-
-	/**
-	 * Sets the setting options.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param array $options
-	 */
-	public function set_options( $options ) {
-		$this->options = $options;
-	}
-
-
-	/**
-	 * Sets the setting default value.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param array|bool|float|int|string $default
-	 */
-	public function set_default( $default ) {
-		$this->default = $default;
-	}
-
-
-	/**
-	 * Sets the setting current value.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param array|bool|float|int|string $value
-	 */
-	public function set_value( $value ) {
-		$this->value = $value;
-	}
-
-
-	/**
-	 * Sets the setting control.
-	 *
-	 * @since x.y.z
-	 *
-	 * @param Control $control
-	 */
-	public function set_control( $control ) {
-		$this->control = $control;
-	}
-
-
 	/** Getter Methods ************************************************************************************************/
 
 
@@ -302,6 +191,117 @@ class Setting {
 	 */
 	public function get_control() {
 		return $this->control;
+	}
+
+
+	/** Setter Methods ************************************************************************************************/
+
+
+	/**
+	 * Sets the setting ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $id
+	 */
+	public function set_id( $id ) {
+		$this->id = $id;
+	}
+
+
+	/**
+	 * Sets the setting type.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $type
+	 */
+	public function set_type( $type ) {
+		$this->type = $type;
+	}
+
+
+	/**
+	 * Sets the setting name.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $name
+	 */
+	public function set_name( $name ) {
+		$this->name = $name;
+	}
+
+
+	/**
+	 * Sets the setting description.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $description
+	 */
+	public function set_description( $description ) {
+		$this->description = $description;
+	}
+
+
+	/**
+	 * Sets whether the setting holds an array of multiple values.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param bool $is_multi
+	 */
+	public function set_is_multi( $is_multi ) {
+		$this->is_multi = $is_multi;
+	}
+
+
+	/**
+	 * Sets the setting options.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $options
+	 */
+	public function set_options( $options ) {
+		$this->options = $options;
+	}
+
+
+	/**
+	 * Sets the setting default value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array|bool|float|int|string $default
+	 */
+	public function set_default( $default ) {
+		$this->default = $default;
+	}
+
+
+	/**
+	 * Sets the setting current value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array|bool|float|int|string $value
+	 */
+	public function set_value( $value ) {
+		$this->value = $value;
+	}
+
+
+	/**
+	 * Sets the setting control.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param Control $control
+	 */
+	public function set_control( $control ) {
+		$this->control = $control;
 	}
 
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -64,6 +64,117 @@ class Setting {
 	protected $control;
 
 
+	/** Setter Methods ************************************************************************************************/
+
+
+	/**
+	 * Sets the setting ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $id
+	 */
+	public function set_id( $id ) {
+		$this->id = $id;
+	}
+
+
+	/**
+	 * Sets the setting type.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $type
+	 */
+	public function set_type( $type ) {
+		$this->type = $type;
+	}
+
+
+	/**
+	 * Sets the setting name.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $name
+	 */
+	public function set_name( $name ) {
+		$this->name = $name;
+	}
+
+
+	/**
+	 * Sets the setting description.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $description
+	 */
+	public function set_description( $description ) {
+		$this->description = $description;
+	}
+
+
+	/**
+	 * Sets whether the setting holds an array of multiple values.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param bool $is_multi
+	 */
+	public function set_is_multi( $is_multi ) {
+		$this->is_multi = $is_multi;
+	}
+
+
+	/**
+	 * Sets the setting options.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $options
+	 */
+	public function set_options( $options ) {
+		$this->options = $options;
+	}
+
+
+	/**
+	 * Sets the setting default value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array|bool|float|int|string $default
+	 */
+	public function set_default( $default ) {
+		$this->default = $default;
+	}
+
+
+	/**
+	 * Sets the setting current value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array|bool|float|int|string $value
+	 */
+	public function set_value( $value ) {
+		$this->value = $value;
+	}
+
+
+	/**
+	 * Sets the setting control.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param Control $control
+	 */
+	public function set_control( $control ) {
+		$this->control = $control;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -60,6 +60,9 @@ class Setting {
 	/** @var int|float|string|bool|array setting current value */
 	protected $value;
 
+	/** @var Control control object */
+	protected $control;
+
 
 }
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -35,6 +35,11 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Settings
  */
 class Setting {
 
+
+	/** @var string unique setting ID */
+	protected $id;
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -94,6 +94,7 @@ class Setting {
 	 * @return string
 	 */
 	public function get_id() {
+
 		return $this->id;
 	}
 
@@ -106,6 +107,7 @@ class Setting {
 	 * @return string
 	 */
 	public function get_type() {
+
 		return $this->type;
 	}
 
@@ -118,6 +120,7 @@ class Setting {
 	 * @return string
 	 */
 	public function get_name() {
+
 		return $this->name;
 	}
 
@@ -130,6 +133,7 @@ class Setting {
 	 * @return string
 	 */
 	public function get_description() {
+
 		return $this->description;
 	}
 
@@ -142,6 +146,7 @@ class Setting {
 	 * @return bool
 	 */
 	public function is_is_multi() {
+
 		return $this->is_multi;
 	}
 
@@ -154,6 +159,7 @@ class Setting {
 	 * @return array
 	 */
 	public function get_options() {
+
 		return $this->options;
 	}
 
@@ -166,6 +172,7 @@ class Setting {
 	 * @return array|bool|float|int|string
 	 */
 	public function get_default() {
+
 		return $this->default;
 	}
 
@@ -178,6 +185,7 @@ class Setting {
 	 * @return array|bool|float|int|string
 	 */
 	public function get_value() {
+
 		return $this->value;
 	}
 
@@ -190,6 +198,7 @@ class Setting {
 	 * @return Control
 	 */
 	public function get_control() {
+
 		return $this->control;
 	}
 
@@ -205,6 +214,7 @@ class Setting {
 	 * @param string $id
 	 */
 	public function set_id( $id ) {
+
 		$this->id = $id;
 	}
 
@@ -217,6 +227,7 @@ class Setting {
 	 * @param string $type
 	 */
 	public function set_type( $type ) {
+
 		$this->type = $type;
 	}
 
@@ -229,6 +240,7 @@ class Setting {
 	 * @param string $name
 	 */
 	public function set_name( $name ) {
+
 		$this->name = $name;
 	}
 
@@ -241,6 +253,7 @@ class Setting {
 	 * @param string $description
 	 */
 	public function set_description( $description ) {
+
 		$this->description = $description;
 	}
 
@@ -253,6 +266,7 @@ class Setting {
 	 * @param bool $is_multi
 	 */
 	public function set_is_multi( $is_multi ) {
+
 		$this->is_multi = $is_multi;
 	}
 
@@ -265,6 +279,7 @@ class Setting {
 	 * @param array $options
 	 */
 	public function set_options( $options ) {
+
 		$this->options = $options;
 	}
 
@@ -277,6 +292,7 @@ class Setting {
 	 * @param array|bool|float|int|string $default
 	 */
 	public function set_default( $default ) {
+
 		$this->default = $default;
 	}
 
@@ -289,6 +305,7 @@ class Setting {
 	 * @param array|bool|float|int|string $value
 	 */
 	public function set_value( $value ) {
+
 		$this->value = $value;
 	}
 
@@ -301,6 +318,7 @@ class Setting {
 	 * @param Control $control
 	 */
 	public function set_control( $control ) {
+
 		$this->control = $control;
 	}
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -175,6 +175,117 @@ class Setting {
 	}
 
 
+	/** Getter Methods ************************************************************************************************/
+
+
+	/**
+	 * Gets the setting ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+
+	/**
+	 * Gets the setting type.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+		return $this->type;
+	}
+
+
+	/**
+	 * Gets the setting name.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+
+	/**
+	 * Gets the setting description.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return $this->description;
+	}
+
+
+	/**
+	 * Returns whether the setting holds an array of multiple values.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	public function is_is_multi() {
+		return $this->is_multi;
+	}
+
+
+	/**
+	 * Gets the setting options.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	public function get_options() {
+		return $this->options;
+	}
+
+
+	/**
+	 * Gets the setting default value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array|bool|float|int|string
+	 */
+	public function get_default() {
+		return $this->default;
+	}
+
+
+	/**
+	 * Gets the setting current value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array|bool|float|int|string
+	 */
+	public function get_value() {
+		return $this->value;
+	}
+
+
+	/**
+	 * Gets the setting control.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return Control
+	 */
+	public function get_control() {
+		return $this->control;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -57,6 +57,9 @@ class Setting {
 	/** @var int|float|string|bool|array setting default value */
 	protected $default;
 
+	/** @var int|float|string|bool|array setting current value */
+	protected $value;
+
 
 }
 


### PR DESCRIPTION
# Summary

This PR adds properties and simple getters and setters to the `Setting` class.

### Story: [CH 32585](https://app.clubhouse.io/skyverge/story/32585/add-properties-getters-and-setters-to-settings-api-setting-class)
### Release: #436

## QA

Unit tests pass.