### PR TITLE
Add Control type setter validation

### DIFF
--- a/tests/unit/Settings_API/ControlTest.php
+++ b/tests/unit/Settings_API/ControlTest.php
@@ -16,6 +16,7 @@ class ControlTest extends \Codeception\Test\Unit {
 	protected function _before() {
 
 		require_once( 'woocommerce/class-sv-wc-plugin-exception.php' );
+		require_once( 'woocommerce/class-sv-wc-helper.php' );
 		require_once( 'woocommerce/Settings_API/Control.php' );
 	}
 
@@ -116,6 +117,41 @@ class ControlTest extends \Codeception\Test\Unit {
 			[ 'yes', 'yes' ],
 			[ '', '' ],
 			[ false, '', true ],
+		];
+	}
+
+
+	/**
+	 * @see Control::set_type()
+	 *
+	 * @param mixed $value value to pass to the method
+	 * @param array $allowed_types allowed control types
+	 * @param string $expected expected value
+	 * @param bool $exception whether an exception is expected
+	 * @throws SV_WC_Plugin_Exception
+	 *
+	 * @dataProvider provider_set_type
+	 */
+	public function test_set_type( $value, array $allowed_types, $expected, $exception = false ) {
+
+		if ( $exception ) {
+			$this->expectException( SV_WC_Plugin_Exception::class );
+		}
+
+		$control = new Control();
+		$control->set_type( $value, $allowed_types );
+
+		$this->assertSame( $expected, $control->get_type() );
+	}
+
+
+	/** @see test_set_type() */
+	public function provider_set_type() {
+
+		return [
+			[ 'yes', [ 'yes', 'maybe' ], 'yes' ],     // valid value
+			[ 'no', [ 'yes', 'maybe' ], null, true ], // invalid value
+			[ 'no', [], 'no' ],                       // no types to validate
 		];
 	}
 

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -188,10 +188,18 @@ class Control {
 	 * @since x.y.z
 	 *
 	 * @param string $value setting ID to set
+	 * @param string[] $valid_types allowed control types
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
-	public function set_type( $value ) {
+	public function set_type( $value, array $valid_types = [] ) {
 
-		// TODO: add validation and throw an exception
+		if ( ! empty( $valid_types ) && ! in_array( $value, $valid_types, true ) ) {
+
+			throw new Framework\SV_WC_Plugin_Exception( sprintf(
+				'Control type must be one of %s',
+				Framework\SV_WC_Helper::list_array_items( $valid_types, 'or' )
+			) );
+		}
 
 		$this->type = $value;
 	}

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -24,7 +24,7 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -170,12 +170,12 @@ class Control {
 	 * @since x.y.z
 	 *
 	 * @param string $value setting ID to set
-	 * @throws SV_WC_Plugin_Exception
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	public function set_setting_id( $value ) {
 
 		if ( ! is_string( $value ) ) {
-			throw new SV_WC_Plugin_Exception( 'Setting ID value must be a string' );
+			throw new Framework\SV_WC_Plugin_Exception( 'Setting ID value must be a string' );
 		}
 
 		$this->setting_id = $value;
@@ -203,12 +203,12 @@ class Control {
 	 * @since x.y.z
 	 *
 	 * @param string $value control name to set
-	 * @throws SV_WC_Plugin_Exception
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	public function set_name( $value ) {
 
 		if ( ! is_string( $value ) ) {
-			throw new SV_WC_Plugin_Exception( 'Control name value must be a string' );
+			throw new Framework\SV_WC_Plugin_Exception( 'Control name value must be a string' );
 		}
 
 		$this->name = $value;
@@ -221,12 +221,12 @@ class Control {
 	 * @since x.y.z
 	 *
 	 * @param string $value control description to set
-	 * @throws SV_WC_Plugin_Exception
+	 * @throws Framework\SV_WC_Plugin_Exception
 	 */
 	public function set_description( $value ) {
 
 		if ( ! is_string( $value ) ) {
-			throw new SV_WC_Plugin_Exception( 'Control description value must be a string' );
+			throw new Framework\SV_WC_Plugin_Exception( 'Control description value must be a string' );
 		}
 
 		$this->description = $value;


### PR DESCRIPTION
# Summary

Adds basic set validation to the control type setter.

### Story: [CH 32641](https://app.clubhouse.io/skyverge/story/32641/add-validation-to-the-control-type-setter)
### Release: #436 

## QA

- [x] Unit tests pass