### PR TITLE
Add validation to options setter in Settings_API\Control

### DIFF
--- a/tests/unit/Settings_API/ControlTest.php
+++ b/tests/unit/Settings_API/ControlTest.php
@@ -4,6 +4,7 @@ namespace Settings_API;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Control;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Exception;
+use TypeError;
 
 define( 'ABSPATH', true );
 
@@ -184,6 +185,78 @@ class ControlTest extends \Codeception\Test\Unit {
 			[ 'description', 'description' ],
 			[ '', '' ],
 			[ false, '', true ],
+		];
+	}
+
+
+	/**
+	 * @see Control::set_options()
+	 *
+	 * @param mixed $options value to pass to the method
+	 * @param mixed $valid_options valid option keys to check against
+	 * @param array $expected expected value
+	 * @param bool $exception whether an exception is expected
+	 *
+	 * @dataProvider provider_set_options
+	 */
+	public function test_set_options( $options, $valid_options, $expected, $exception = false ) {
+
+		if ( $exception ) {
+			$this->expectException( TypeError::class );
+		}
+
+		$control = new Control();
+		$control->set_options( $options, $valid_options );
+
+		$this->assertSame( $expected, $control->get_options() );
+	}
+
+
+	/** @see test_set_options() */
+	public function provider_set_options() {
+
+		return [
+			[
+				[],
+				[ 'b', 'd' ],
+				[],
+				false
+			],
+
+			[
+				[ 'a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D' ],
+				[ 'b', 'd' ],
+				[ 'b' => 'B', 'd' => 'D' ],
+				false
+			],
+
+			[
+				[ 'a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D' ],
+				[ 'x', 'y' ],
+				[],
+				false
+			],
+
+			[
+				[ 'a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D' ],
+				[],
+				[],
+				false
+			],
+
+			[
+				'a,b,c,d',
+				[],
+				[],
+				true
+			],
+
+			[
+				[ 'a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D' ],
+				'a',
+				[],
+				true
+			],
 		];
 	}
 

--- a/tests/unit/Settings_API/ControlTest.php
+++ b/tests/unit/Settings_API/ControlTest.php
@@ -240,7 +240,7 @@ class ControlTest extends \Codeception\Test\Unit {
 			[
 				[ 'a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D' ],
 				[],
-				[],
+				[ 'a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D' ],
 				false
 			],
 

--- a/tests/unit/Settings_API/ControlTest.php
+++ b/tests/unit/Settings_API/ControlTest.php
@@ -81,7 +81,7 @@ class ControlTest extends \Codeception\Test\Unit {
 		];
 
 		$control = new Control();
-		$control->set_options( $options );
+		$control->set_options( $options, [ 'option-1', 'option-2' ] );
 
 		$this->assertSame( $options, $control->get_options() );
 	}

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -243,7 +243,12 @@ class Control {
 	 */
 	public function set_options( array $options, array $valid_options = array() ) {
 
-		// TODO: add validation and throw an exception
+		foreach ( array_keys( $options ) as $key ) {
+
+			if ( ! in_array( $key, $valid_options, true ) ) {
+				unset( $options[ $key ] );
+			}
+		}
 
 		$this->options = $options;
 	}

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -73,8 +73,8 @@ class Control {
 
 	/** @var string the range control type */
 	const TYPE_RANGE = 'range';
-  
-  
+
+
 	/** @var string|null the setting ID to which this control belongs */
 	protected $setting_id;
 

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -241,7 +241,7 @@ class Control {
 	 * @param array $options options to set
 	 * @param array $valid_options valid option keys to check against
 	 */
-	public function set_options( array $options, array $valid_options = array() ) {
+	public function set_options( array $options, array $valid_options = [] ) {
 
 		foreach ( array_keys( $options ) as $key ) {
 

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -239,8 +239,9 @@ class Control {
 	 * @since x.y.z
 	 *
 	 * @param array $options options to set
+	 * @param array $valid_options valid option keys to check against
 	 */
-	public function set_options( array $options ) {
+	public function set_options( array $options, array $valid_options = array() ) {
 
 		// TODO: add validation and throw an exception
 

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -243,10 +243,13 @@ class Control {
 	 */
 	public function set_options( array $options, array $valid_options = [] ) {
 
-		foreach ( array_keys( $options ) as $key ) {
+		if ( ! empty( $valid_options ) ) {
 
-			if ( ! in_array( $key, $valid_options, true ) ) {
-				unset( $options[ $key ] );
+			foreach ( array_keys( $options ) as $key ) {
+
+				if ( ! in_array( $key, $valid_options, true ) ) {
+					unset( $options[ $key ] );
+				}
 			}
 		}
 


### PR DESCRIPTION
# Summary

This PR updates `set_options()` to receive an array of valid options and remove any options that don't match.

### Story: [CH 32607](https://app.clubhouse.io/skyverge/story/32607)
### Release: #436

## Details

The method included a TODO item to add validation and throw an exception. However, since both the story and implementation document specify that the method should remove any options than don't match, I ignored the exception part of the TODO.

The `$options` and `$valid_options` parameters use type hints, so PHP will already throw an error if an argument with a different type is passed.

## QA

- [ ] Unit tests pass
