### PR TITLE
Add Setting::validate_value()

### DIFF
--- a/tests/integration/Settings_API/SettingTest.php
+++ b/tests/integration/Settings_API/SettingTest.php
@@ -22,4 +22,60 @@ class SettingTest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
+	/**
+	 * @see Setting::validate_value()
+	 *
+	 * @param mixed $value value to pass to method
+	 * @param string $type setting type
+	 * @param bool $type whether the value should be considered valid or not
+	 *
+	 * @dataProvider provider_validate_value
+	 * */
+	public function test_validate_value( $value, $type, $expected ) {
+
+		$setting = new Setting();
+		$setting->set_type( $type );
+
+		$this->assertSame( $expected, $setting->validate_value( $value ) );
+	}
+
+
+	/**
+	 * Provider for test_validate_value()
+	 *
+	 * @return array
+	 */
+	public function provider_validate_value() {
+
+		require_once( 'woocommerce/Settings_API/Setting.php' );
+
+		return [
+			[ 'example', Setting::TYPE_STRING, true ],
+			[ 3.1415926, Setting::TYPE_STRING, false ],
+
+			[ 'https://skyverge.com/', Setting::TYPE_URL, true ],
+			[ 'file:///tmp/', Setting::TYPE_URL, false ],
+			[ 'example', Setting::TYPE_URL, false ],
+
+			[ 'test@example.com', Setting::TYPE_EMAIL, true ],
+			[ 'not-an-email.com', Setting::TYPE_EMAIL, false ],
+			[ '', Setting::TYPE_EMAIL, false ],
+
+			[ 1729, Setting::TYPE_INTEGER, true ],
+			[ 'hi', Setting::TYPE_INTEGER, false ],
+
+			[ 3.14, Setting::TYPE_FLOAT, true ],
+			[ 3000, Setting::TYPE_FLOAT, false ],
+			[ 'hi', Setting::TYPE_FLOAT, false ],
+
+			[ true, Setting::TYPE_BOOLEAN, true ],
+			[ false, Setting::TYPE_BOOLEAN, true ],
+			[ 'yes', Setting::TYPE_BOOLEAN, false ],
+			[ 'no', Setting::TYPE_BOOLEAN, false ],
+			[ 1, Setting::TYPE_BOOLEAN, false ],
+			[ 0, Setting::TYPE_BOOLEAN, false ],
+		];
+	}
+
+
 }

--- a/tests/integration/Settings_API/SettingTest.php
+++ b/tests/integration/Settings_API/SettingTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
+
+class SettingTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	protected function _before() {
+
+	}
+
+
+	protected function _after() {
+
+	}
+
+
+	/** Tests *********************************************************************************************************/
+
+
+}

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -412,6 +412,20 @@ class Setting {
 	}
 
 
+	/**
+	 * Validates a boolean value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param mixed $value value to validate
+	 * @return bool
+	 */
+	public function validate_boolean_value( $value ) {
+
+		return is_bool( $value );
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -333,7 +333,9 @@ class Setting {
 	 */
 	public function validate_value( $value ) {
 
-		return true;
+		$validate_method = "validate_{$this->get_type()}_value";
+
+		return is_callable( [ $this, $validate_method ] ) ? $this->$validate_method( $value ) : true;
 	}
 
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -323,6 +323,20 @@ class Setting {
 	}
 
 
+	/**
+	 * Validates the setting value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array|bool|float|int|string $value
+	 * @return bool
+	 */
+	public function validate_value( $value ) {
+
+		return true;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -326,9 +326,6 @@ class Setting {
 	/**
 	 * Validates the setting value.
 	 *
-	 * TODO: add integration test to confirm URL values are properly validated {WV 2020-03-19}
-	 * TODO: add integration test to confirm email values are properly validated {WV 2020-03-19}
-	 *
 	 * @since x.y.z
 	 *
 	 * @param array|bool|float|int|string $value

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -327,6 +327,7 @@ class Setting {
 	 * Validates the setting value.
 	 *
 	 * TODO: add integration test to confirm URL values are properly validated {WV 2020-03-19}
+	 * TODO: add integration test to confirm email values are properly validated {WV 2020-03-19}
 	 *
 	 * @since x.y.z
 	 *
@@ -366,6 +367,20 @@ class Setting {
 	public function validate_url_value( $value ) {
 
 		return wc_is_valid_url( $value );
+	}
+
+
+	/**
+	 * Validates an email value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param mixed $value value to validate
+	 * @return bool
+	 */
+	public function validate_email_value( $value ) {
+
+		return is_email( $value );
 	}
 
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -384,6 +384,20 @@ class Setting {
 	}
 
 
+	/**
+	 * Validates an integer value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param mixed $value value to validate
+	 * @return bool
+	 */
+	public function validate_integer_value( $value ) {
+
+		return is_numeric( $value ) && ! is_float( $value );
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -326,6 +326,8 @@ class Setting {
 	/**
 	 * Validates the setting value.
 	 *
+	 * TODO: add integration test to confirm URL values are properly validated {WV 2020-03-19}
+	 *
 	 * @since x.y.z
 	 *
 	 * @param array|bool|float|int|string $value
@@ -350,6 +352,20 @@ class Setting {
 	protected function validate_string_value( $value ) {
 
 		return is_string( $value );
+	}
+
+
+	/**
+	 * Validates a URL value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array|bool|float|int|string $value value to validate
+	 * @return bool
+	 */
+	public function validate_url_value( $value ) {
+
+		return wc_is_valid_url( $value );
 	}
 
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -364,7 +364,7 @@ class Setting {
 	 * @param array|bool|float|int|string $value value to validate
 	 * @return bool
 	 */
-	public function validate_url_value( $value ) {
+	protected function validate_url_value( $value ) {
 
 		return wc_is_valid_url( $value );
 	}
@@ -378,7 +378,7 @@ class Setting {
 	 * @param mixed $value value to validate
 	 * @return bool
 	 */
-	public function validate_email_value( $value ) {
+	protected function validate_email_value( $value ) {
 
 		return is_email( $value );
 	}
@@ -406,7 +406,7 @@ class Setting {
 	 * @param mixed $value value to validate
 	 * @return bool
 	 */
-	public function validate_float_value( $value ) {
+	protected function validate_float_value( $value ) {
 
 		return is_float( $value );
 	}
@@ -420,7 +420,7 @@ class Setting {
 	 * @param mixed $value value to validate
 	 * @return bool
 	 */
-	public function validate_boolean_value( $value ) {
+	protected function validate_boolean_value( $value ) {
 
 		return is_bool( $value );
 	}

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -380,7 +380,7 @@ class Setting {
 	 */
 	protected function validate_email_value( $value ) {
 
-		return is_email( $value );
+		return (bool) is_email( $value );
 	}
 
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -398,6 +398,20 @@ class Setting {
 	}
 
 
+	/**
+	 * Validates a float value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param mixed $value value to validate
+	 * @return bool
+	 */
+	public function validate_float_value( $value ) {
+
+		return is_float( $value );
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -337,6 +337,20 @@ class Setting {
 	}
 
 
+	/**
+	 * Validates a string value.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array|bool|float|int|string $value value to validate
+	 * @return bool
+	 */
+	protected function validate_string_value( $value ) {
+
+		return is_string( $value );
+	}
+
+
 }
 
 endif;


### PR DESCRIPTION
# Summary

This PR updates adds the `validate_value()` method to the `Setting` class.

### Story: [CH 32633](https://app.clubhouse.io/skyverge/story/32633)
### Release: #436

## Details

The validation methods for URL and Email values use WooCommerce and WordPress functions, so instead of unit tests, I added integration tests for this method.

## QA

- [x] Unit tests pass
- [x] Integration tests pass
