### PR TITLE
Add the base REST API controller

### DIFF
--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -58,6 +58,49 @@ class Settings extends \WP_REST_Controller {
 	}
 
 
+	/**
+	 * Registers the API routes.
+	 *
+	 * @since x.y.z
+	 */
+	public function register_routes() {
+
+		register_rest_route(
+			$this->namespace, "/{$this->rest_base}", [
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace, "/{$this->rest_base}/(?P<id>[\w-]+)", [
+				'args' => [
+					'id' => [
+						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+						'type'        => 'string',
+					],
+				],
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+				],
+				[
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => [ $this, 'update_item' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+
 	/** Read methods **************************************************************************************************/
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -42,6 +42,22 @@ class Settings extends \WP_REST_Controller {
 	protected $settings;
 
 
+	/**
+	 * Settings constructor.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param Abstract_Settings $settings settings handler
+	 */
+	public function __construct( Abstract_Settings $settings ) {
+
+		$this->settings = $settings;
+		$this->namespace = 'wc/v3';
+
+		// TODO: set $this->rest_base when Abstract_Settings has a get_id() method
+	}
+
+
 }
 
 endif;

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -122,6 +122,12 @@ class Settings extends \WP_REST_Controller {
 	}
 
 
+	// TODO: get_items()
+
+
+	// TODO: get_item()
+
+
 	/** Update methods ************************************************************************************************/
 
 
@@ -141,6 +147,18 @@ class Settings extends \WP_REST_Controller {
 
 		return true;
 	}
+
+
+	// TODO: update_item()
+
+
+	/** Utility methods ***********************************************************************************************/
+
+
+	// TODO: prepare_item_for_response()
+
+
+	// TODO: get_item_schema()
 
 
 }

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -79,6 +79,27 @@ class Settings extends \WP_REST_Controller {
 	}
 
 
+	/** Update methods ************************************************************************************************/
+
+
+	/**
+	 * Checks whether the user has permissions to update a setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return bool|\WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new \WP_Error( 'wc_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce-plugin-framework' ), [ 'status' => rest_authorization_required_code() ] );
+		}
+
+		return true;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -58,6 +58,27 @@ class Settings extends \WP_REST_Controller {
 	}
 
 
+	/** Read methods **************************************************************************************************/
+
+
+	/**
+	 * Checks whether the user has permissions to get settings.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return bool|\WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new \WP_Error( 'wc_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-plugin-framework' ), [ 'status' => rest_authorization_required_code() ] );
+		}
+
+		return true;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\REST_API\Controllers;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\REST_API\\Controllers\\Settings' ) ) :
+
+/**
+ * The settings controller class.
+ *
+ * @since x.y.z
+ */
+class Settings extends \WP_REST_Controller {
+
+}
+
+endif;

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -24,6 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\REST_API\Controllers;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\REST_API\\Controllers\\Settings' ) ) :
@@ -34,6 +36,11 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\REST_API
  * @since x.y.z
  */
 class Settings extends \WP_REST_Controller {
+
+
+	/** @var Abstract_Settings settings handler */
+	protected $settings;
+
 
 }
 


### PR DESCRIPTION
# Summary

Adds the base REST API control for settings.

### Story: [CH 32703](https://app.clubhouse.io/skyverge/story/32703/add-rest-handler-class)
### Release: #436 

## Details

Note: the doc originally planned for this to be `REST_API\Settings_Controller` but I switched to `REST_API\Controllers\Settings` to better match core conventions.

Adds the class and basic methods for:
- Constructing
- Registering routes
- Permissions checks

Future stories will add methods for reading and updating settings.

## UI Changes

None

## QA

- Just code review for now. Tests will be added once feature complete.

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version