### PR TITLE
Add Abstract_Settings properties & methods

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -35,10 +35,10 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
-	/** @see Abstract_Settings::__construct() */
-	public function test_constructor() {
+	/** @see Abstract_Settings::get_id() */
+	public function test_get_id() {
 
-		$this->assertEquals( 'test-plugin', $this->get_settings_instance()->id );
+		$this->assertEquals( 'test-plugin', $this->get_settings_instance()->get_id() );
 	}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -88,7 +88,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	public function test_delete_value() {
 
 		$setting     = $this->get_settings_instance()->get_setting( 'test-setting-a' );
-		$option_name = $this->get_settings_instance()->id . '_' . $setting->get_id();
+		$option_name = $this->get_settings_instance()->get_option_name_prefix() . '_' . $setting->get_id();
 
 		$this->assertNotEmpty( $setting->get_value() );
 		$this->assertNotEmpty( get_option( $option_name ) );
@@ -179,7 +179,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 					$this->settings['test-setting-a']->set_id( 'test-setting-a' );
 					$this->settings['test-setting-a']->set_value( 'example' );
 
-					update_option( "{$this->id}_{$this->settings['test-setting-a']->get_id()}", 'something' );
+					update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-a']->get_id()}", 'something' );
 				}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -108,6 +108,20 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::get_setting_types() */
+	public function test_get_setting_types() {
+
+		$this->assertIsArray( $this->get_settings_instance()->get_setting_types() );
+
+		add_filter( "{$this->get_settings_instance()->get_id()}_setting_types", function() {
+
+			return [ 'my_type' ];
+		} );
+
+		$this->assertEquals( [ 'my_type' ], $this->get_settings_instance()->get_setting_types() );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -23,6 +23,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	protected function _before() {
 
 		require_once 'woocommerce/Settings_API/Abstract_Settings.php';
+		require_once 'woocommerce/Settings_API/Control.php';
 		require_once 'woocommerce/Settings_API/Setting.php';
 	}
 
@@ -119,6 +120,20 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 		} );
 
 		$this->assertEquals( [ 'my_type' ], $this->get_settings_instance()->get_setting_types() );
+	}
+
+
+	/** @see Abstract_Settings::get_control_types() */
+	public function test_get_control_types() {
+
+		$this->assertIsArray( $this->get_settings_instance()->get_control_types() );
+
+		add_filter( "{$this->get_settings_instance()->get_id()}_control_types", function() {
+
+			return [ 'my_type' ];
+		} );
+
+		$this->assertEquals( [ 'my_type' ], $this->get_settings_instance()->get_control_types() );
 	}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -55,6 +55,33 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see Abstract_Settings::get_settings()
+	 *
+	 * @param array $ids settings IDs to get
+	 * @param array $expected_ids expected settings IDs to retrieve
+	 *
+	 * @dataProvider provider_get_settings
+	 */
+	public function test_get_settings( $ids, $expected_ids ) {
+
+		$settings = $this->get_settings_instance()->get_settings( $ids );
+
+		$this->assertEquals( array_keys( $settings ), $expected_ids );
+	}
+
+
+	/** @see test_get_settings() */
+	public function provider_get_settings() {
+
+		return [
+			[ [ 'test-setting-a', 'test-setting-b' ], [ 'test-setting-a', 'test-setting-b' ] ],
+			[ [], [ 'test-setting-a', 'test-setting-b', 'test-setting-c' ] ],
+			[ [ 'test-setting-x' ], [] ],
+		];
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 
@@ -73,7 +100,9 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 				protected function register_settings() {
 
 					// TODO: remove when register_setting() is available and a setting object can be set in the test {WV 2020-03-20}
-					$this->settings['test-setting'] = new Setting();
+					$this->settings['test-setting-a'] = new Setting();
+					$this->settings['test-setting-b'] = new Setting();
+					$this->settings['test-setting-c'] = new Setting();
 				}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -29,4 +29,39 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** Helper methods ************************************************************************************************/
+
+
+	/**
+	 * Gets the settings instance.
+	 *
+	 * @return Framework\Settings_API\Abstract_Settings
+	 */
+	protected function get_settings() {
+
+		if ( null === $this->settings ) {
+
+			$this->settings = new class( 'test-plugin' ) extends Framework\Settings_API\Abstract_Settings {
+
+
+				protected function register_settings() {
+
+				}
+
+
+				/**
+				 * TODO: remove when load_settings() is implemented in Framework\Settings_API\Abstract_Settings {WV 2020-03-20}
+				 */
+				protected function load_settings() {
+
+				}
+
+
+			};
+		}
+
+		return $this->settings;
+	}
+
+
 }

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -29,6 +29,18 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** Tests *********************************************************************************************************/
+
+
+	/**
+	 * Tests constructor sets $id property.
+	 */
+	public function test_constructor() {
+
+		$this->assertEquals( 'test-plugin', $this->get_settings()->id );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1 as Framework;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
 
@@ -82,6 +83,31 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::delete_value() */
+	public function test_delete_value() {
+
+		$setting     = $this->get_settings_instance()->get_setting( 'test-setting-a' );
+		$option_name = $this->get_settings_instance()->id . '_' . $setting->get_id();
+
+		$this->assertNotEmpty( $setting->get_value() );
+		$this->assertNotEmpty( get_option( $option_name ) );
+
+		$this->get_settings_instance()->delete_value( $setting->get_id() );
+
+		$this->assertNull( $setting->get_value() );
+		$this->assertFalse( get_option( $option_name ) );
+	}
+
+
+	/** @see Abstract_Settings::delete_value() */
+	public function test_delete_value_exception() {
+
+		$this->expectException( Framework\SV_WC_Plugin_Exception::class );
+
+		$this->get_settings_instance()->delete_value( 'not_a_setting' );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 
@@ -103,6 +129,12 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 					$this->settings['test-setting-a'] = new Setting();
 					$this->settings['test-setting-b'] = new Setting();
 					$this->settings['test-setting-c'] = new Setting();
+
+					// TODO: remove when save() is available
+					$this->settings['test-setting-a']->set_id( 'test-setting-a' );
+					$this->settings['test-setting-a']->set_value( 'example' );
+
+					update_option( "{$this->id}_{$this->settings['test-setting-a']->get_id()}", 'something' );
 				}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -130,7 +130,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertIsArray( $this->get_settings_instance()->get_setting_types() );
 
-		add_filter( "{$this->get_settings_instance()->get_id()}_setting_types", function() {
+		add_filter( "wc_{$this->get_settings_instance()->get_id()}_settings_api_setting_types", function() {
 
 			return [ 'my_type' ];
 		} );
@@ -144,7 +144,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertIsArray( $this->get_settings_instance()->get_control_types() );
 
-		add_filter( "{$this->get_settings_instance()->get_id()}_control_types", function() {
+		add_filter( "wc_{$this->get_settings_instance()->get_id()}_settings_api_control_types", function() {
 
 			return [ 'my_type' ];
 		} );

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1 as Framework;
+
+/**
+ * Tests for the Abstract_Settings class.
+ *
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings
+ */
+class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** @var Framework\Settings_API\Abstract_Settings */
+	protected $settings;
+
+
+	protected function _before() {
+
+		require_once 'woocommerce/Settings_API/Abstract_Settings.php';
+	}
+
+
+	protected function _after() {
+
+	}
+
+
+}

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_6_1 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
 
 /**
  * Tests for the Abstract_Settings class.
@@ -14,7 +14,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	protected $tester;
 
 
-	/** @var Framework\Settings_API\Abstract_Settings */
+	/** @var Abstract_Settings */
 	protected $settings;
 
 
@@ -32,9 +32,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
-	/**
-	 * Tests constructor sets $id property.
-	 */
+	/** @see Abstract_Settings::__construct() */
 	public function test_constructor() {
 
 		$this->assertEquals( 'test-plugin', $this->get_settings()->id );
@@ -47,13 +45,13 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Gets the settings instance.
 	 *
-	 * @return Framework\Settings_API\Abstract_Settings
+	 * @return Abstract_Settings
 	 */
 	protected function get_settings() {
 
 		if ( null === $this->settings ) {
 
-			$this->settings = new class( 'test-plugin' ) extends Framework\Settings_API\Abstract_Settings {
+			$this->settings = new class( 'test-plugin' ) extends Abstract_Settings {
 
 
 				protected function register_settings() {

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -37,7 +37,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Abstract_Settings::__construct() */
 	public function test_constructor() {
 
-		$this->assertEquals( 'test-plugin', $this->get_settings()->id );
+		$this->assertEquals( 'test-plugin', $this->get_settings_instance()->id );
 	}
 
 
@@ -47,11 +47,11 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_unregister_setting() {
 
-		$this->assertInstanceOf( Setting::class, $this->get_settings()->get_setting( 'test-setting' ) );
+		$this->assertInstanceOf( Setting::class, $this->get_settings_instance()->get_setting( 'test-setting' ) );
 
-		$this->get_settings()->unregister_setting( 'test-setting' );
+		$this->get_settings_instance()->unregister_setting( 'test-setting' );
 
-		$this->assertNull( $this->get_settings()->get_setting( 'test-setting' ) );
+		$this->assertNull( $this->get_settings_instance()->get_setting( 'test-setting' ) );
 	}
 
 
@@ -63,7 +63,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return Abstract_Settings
 	 */
-	protected function get_settings() {
+	protected function get_settings_instance() {
 
 		if ( null === $this->settings ) {
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -109,6 +109,22 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::get_value_for_database() */
+	public function test_get_value_for_database() {
+
+		// TODO: implement this test when save() is available {WV 2020-03-20}
+		$this->markTestSkipped();
+	}
+
+
+	/** @see Abstract_Settings::get_value_from_database() */
+	public function test_get_value_from_database() {
+
+		// TODO: implement this test when load_settings() is available {WV 2020-03-20}
+		$this->markTestSkipped();
+	}
+
+
 	/** @see Abstract_Settings::get_setting_types() */
 	public function test_get_setting_types() {
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
 
 /**
  * Tests for the Abstract_Settings class.
@@ -21,6 +22,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	protected function _before() {
 
 		require_once 'woocommerce/Settings_API/Abstract_Settings.php';
+		require_once 'woocommerce/Settings_API/Setting.php';
 	}
 
 
@@ -36,6 +38,20 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	public function test_constructor() {
 
 		$this->assertEquals( 'test-plugin', $this->get_settings()->id );
+	}
+
+
+	/**
+	 * @see Abstract_Settings::unregister_setting()
+	 * @see Abstract_Settings::get_setting()
+	 */
+	public function test_unregister_setting() {
+
+		$this->assertInstanceOf( Setting::class, $this->get_settings()->get_setting( 'test-setting' ) );
+
+		$this->get_settings()->unregister_setting( 'test-setting' );
+
+		$this->assertNull( $this->get_settings()->get_setting( 'test-setting' ) );
 	}
 
 
@@ -56,6 +72,8 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 				protected function register_settings() {
 
+					// TODO: remove when register_setting() is available and a setting object can be set in the test {WV 2020-03-20}
+					$this->settings['test-setting'] = new Setting();
 				}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -47,11 +47,11 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_unregister_setting() {
 
-		$this->assertInstanceOf( Setting::class, $this->get_settings_instance()->get_setting( 'test-setting' ) );
+		$this->assertInstanceOf( Setting::class, $this->get_settings_instance()->get_setting( 'test-setting-a' ) );
 
-		$this->get_settings_instance()->unregister_setting( 'test-setting' );
+		$this->get_settings_instance()->unregister_setting( 'test-setting-a' );
 
-		$this->assertNull( $this->get_settings_instance()->get_setting( 'test-setting' ) );
+		$this->assertNull( $this->get_settings_instance()->get_setting( 'test-setting-a' ) );
 	}
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -260,7 +260,7 @@ abstract class Abstract_Settings {
 		/**
 		 * Filters the list of valid control types.
 		 *
-		 * @param array $setting_types valid control types
+		 * @param string[] $control_types valid control types
 		 * @param Abstract_Settings $settings the settings handler instance
 		 */
 		return apply_filters( "wc_{$this->get_id()}_settings_api_control_types", $control_types, $this );

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -24,6 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1 as Framework;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Settings_API\\Abstract_Settings' ) ) :
@@ -125,6 +127,29 @@ abstract class Abstract_Settings {
 	public function get_setting( $id ) {
 
 		return ! empty( $this->settings[ $id ] ) ? $this->settings[ $id ] : null;
+	}
+
+
+	/**
+	 * Deletes the stored value for a setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $setting_id setting ID
+	 * @return bool
+	 * @throws Framework\SV_WC_Plugin_Exception
+	 */
+	public function delete_value( $setting_id ) {
+
+		$setting = $this->get_setting( $setting_id );
+
+		if ( ! $setting ) {
+			throw new Framework\SV_WC_Plugin_Exception( "Setting {$setting_id} does not exist" );
+		}
+
+		$setting->set_value( null );
+
+		return delete_option( "{$this->id}_{$setting->get_id()}" );
 	}
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -208,6 +208,8 @@ abstract class Abstract_Settings {
 	/**
 	 * Gets the list of valid setting types.
 	 *
+	 * @since x.y.z
+	 *
 	 * @return array
 	 */
 	public function get_setting_types() {
@@ -228,6 +230,40 @@ abstract class Abstract_Settings {
 		 * @param Abstract_Settings $settings the settings handler instance
 		 */
 		return apply_filters( "{$this->get_id()}_setting_types", $setting_types, $this );
+	}
+
+
+	/**
+	 * Gets the list of valid control types.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	public function get_control_types() {
+
+		$control_types = [
+			Control::TYPE_TEXT,
+			Control::TYPE_TEXTAREA,
+			Control::TYPE_NUMBER,
+			Control::TYPE_EMAIL,
+			Control::TYPE_PASSWORD,
+			Control::TYPE_DATE,
+			Control::TYPE_CHECKBOX,
+			Control::TYPE_RADIO,
+			Control::TYPE_SELECT,
+			Control::TYPE_FILE,
+			Control::TYPE_COLOR,
+			Control::TYPE_RANGE,
+		];
+
+		/**
+		 * Filters the list of valid contorl types.
+		 *
+		 * @param array $setting_types valid control types
+		 * @param Abstract_Settings $settings the settings handler instance
+		 */
+		return apply_filters( "{$this->get_id()}_control_types", $control_types, $this );
 	}
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -39,7 +39,7 @@ abstract class Abstract_Settings {
 
 
 	/** @var string settings ID */
-	public $id = '';
+	public $id;
 
 	/** @var Setting[] registered settings */
 	protected $settings = [];

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -162,7 +162,7 @@ abstract class Abstract_Settings {
 
 		$setting->set_value( null );
 
-		return delete_option( "{$this->id}_{$setting->get_id()}" );
+		return delete_option( "{$this->get_option_name_prefix()}_{$setting->get_id()}" );
 	}
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -156,6 +156,8 @@ abstract class Abstract_Settings {
 	/**
 	 * Converts the value of a setting to be stored in an option.
 	 *
+	 * @since x.y.z
+	 *
 	 * @param Setting $setting
 	 * @return mixed
 	 */
@@ -173,6 +175,8 @@ abstract class Abstract_Settings {
 
 	/**
 	 * Converts the stored value of a setting to the proper setting type.
+	 *
+	 * @since x.y.z
 	 *
 	 * @param mixed $value the value stored in an option
 	 * @param Setting $setting

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -35,6 +35,14 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Settings
  */
 abstract class Abstract_Settings {
 
+
+	/** @var string settings ID */
+	public $id = '';
+
+	/** @var Setting[] registered settings */
+	protected $settings = [];
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -258,7 +258,7 @@ abstract class Abstract_Settings {
 		];
 
 		/**
-		 * Filters the list of valid contorl types.
+		 * Filters the list of valid control types.
 		 *
 		 * @param array $setting_types valid control types
 		 * @param Abstract_Settings $settings the settings handler instance

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -43,6 +43,40 @@ abstract class Abstract_Settings {
 	protected $settings = [];
 
 
+	/**
+	 * Constructs the class.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $id the ID of plugin or payment gateway that owns these settings
+	 */
+	public function __construct( $id ) {
+
+		$this->id = $id;
+
+		$this->register_settings();
+		$this->load_settings();
+	}
+
+
+	/**
+	 * Registers the settings.
+	 *
+	 * Plugins or payment gateways should overwrite this method to register their settings.
+	 *
+	 * @since x.y.z
+	 */
+	abstract protected function register_settings();
+
+
+	/**
+	 * Loads the values for all registered settings.
+	 *
+	 * @since x.y.z
+	 */
+	abstract protected function load_settings();
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -77,6 +77,19 @@ abstract class Abstract_Settings {
 	abstract protected function load_settings();
 
 
+	/**
+	 * Unregisters a setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $id setting ID to unregister
+	 */
+	public function unregister_setting( $id ) {
+
+		unset( $this->settings[ $id ] );
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -229,7 +229,7 @@ abstract class Abstract_Settings {
 		 * @param array $setting_types valid setting types
 		 * @param Abstract_Settings $settings the settings handler instance
 		 */
-		return apply_filters( "{$this->get_id()}_setting_types", $setting_types, $this );
+		return apply_filters( "wc_{$this->get_id()}_settings_api_setting_types", $setting_types, $this );
 	}
 
 
@@ -263,7 +263,7 @@ abstract class Abstract_Settings {
 		 * @param array $setting_types valid control types
 		 * @param Abstract_Settings $settings the settings handler instance
 		 */
-		return apply_filters( "{$this->get_id()}_control_types", $control_types, $this );
+		return apply_filters( "wc_{$this->get_id()}_settings_api_control_types", $control_types, $this );
 	}
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -108,7 +108,7 @@ abstract class Abstract_Settings {
 	/**
 	 * Gets all registered settings.
 	 *
-	 * @param array $ids setting IDs to get
+	 * @param string[] $ids setting IDs to get
 	 * @return Setting[]
 	 */
 	public function get_settings( array $ids = [] ) {
@@ -210,7 +210,7 @@ abstract class Abstract_Settings {
 	 *
 	 * @since x.y.z
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_setting_types() {
 
@@ -226,7 +226,7 @@ abstract class Abstract_Settings {
 		/**
 		 * Filters the list of valid setting types.
 		 *
-		 * @param array $setting_types valid setting types
+		 * @param string[] $setting_types valid setting types
 		 * @param Abstract_Settings $settings the settings handler instance
 		 */
 		return apply_filters( "wc_{$this->get_id()}_settings_api_setting_types", $setting_types, $this );
@@ -238,7 +238,7 @@ abstract class Abstract_Settings {
 	 *
 	 * @since x.y.z
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_control_types() {
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -153,6 +153,24 @@ abstract class Abstract_Settings {
 	}
 
 
+	/**
+	 * Converts the value of a setting to be stored in an option.
+	 *
+	 * @param Setting $setting
+	 * @return mixed
+	 */
+	protected function get_value_for_database( Setting $setting ) {
+
+		$value = $setting->get_value();
+
+		if ( null !== $value && Setting::TYPE_BOOLEAN === $setting->get_type() ) {
+			$value = wc_bool_to_string( $value );
+		}
+
+		return $value;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -205,6 +205,32 @@ abstract class Abstract_Settings {
 	}
 
 
+	/**
+	 * Gets the list of valid setting types.
+	 *
+	 * @return array
+	 */
+	public function get_setting_types() {
+
+		$setting_types = [
+			Setting::TYPE_STRING,
+			Setting::TYPE_URL,
+			Setting::TYPE_EMAIL,
+			Setting::TYPE_INTEGER,
+			Setting::TYPE_FLOAT,
+			Setting::TYPE_BOOLEAN,
+		];
+
+		/**
+		 * Filters the list of valid setting types.
+		 *
+		 * @param array $setting_types valid setting types
+		 * @param Abstract_Settings $settings the settings handler instance
+		 */
+		return apply_filters( "{$this->get_id()}_setting_types", $setting_types, $this );
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -91,6 +91,30 @@ abstract class Abstract_Settings {
 
 
 	/**
+	 * Gets all registered settings.
+	 *
+	 * @param array $ids setting IDs to get
+	 * @return Setting[]
+	 */
+	public function get_settings( array $ids = [] ) {
+
+		$settings = $this->settings;
+
+		if ( ! empty( $ids ) ) {
+
+			foreach ( array_keys( $this->settings ) as $id ) {
+
+				if ( ! in_array( $id, $ids, true ) ) {
+					unset( $settings[ $id ] );
+				}
+			}
+		}
+
+		return $settings;
+	}
+
+
+	/**
 	 * Gets a setting object.
 	 *
 	 * @since x.y.z

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -267,6 +267,19 @@ abstract class Abstract_Settings {
 	}
 
 
+	/**
+	 * Gets the prefix for db option names.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_option_name_prefix() {
+
+		return "wc_{$this->id}";
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -90,6 +90,20 @@ abstract class Abstract_Settings {
 	}
 
 
+	/**
+	 * Gets a setting object.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $id setting ID to get
+	 * @return Setting|null
+	 */
+	public function get_setting( $id ) {
+
+		return ! empty( $this->settings[ $id ] ) ? $this->settings[ $id ] : null;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -93,6 +93,19 @@ abstract class Abstract_Settings {
 
 
 	/**
+	 * Gets the settings ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+
+		return $this->id;
+	}
+
+
+	/**
 	 * Gets all registered settings.
 	 *
 	 * @param array $ids setting IDs to get

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -171,6 +171,23 @@ abstract class Abstract_Settings {
 	}
 
 
+	/**
+	 * Converts the stored value of a setting to the proper setting type.
+	 *
+	 * @param mixed $value the value stored in an option
+	 * @param Setting $setting
+	 * @return mixed
+	 */
+	protected function get_value_from_database( $value, Setting $setting ) {
+
+		if ( null !== $value && Setting::TYPE_BOOLEAN === $setting->get_type() ) {
+			$value = wc_string_to_bool( $value );
+		}
+
+		return $value;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -106,7 +106,9 @@ abstract class Abstract_Settings {
 
 
 	/**
-	 * Gets all registered settings.
+	 * Gets registered settings.
+	 *
+	 * It returns all settings by default, but you can pass an array of IDs to filter the results.
 	 *
 	 * @param string[] $ids setting IDs to get
 	 * @return Setting[]


### PR DESCRIPTION
# Summary

This PR adds the properties and basic methods for the Abstract_Settings clasas.

### Story: [CH 32617](https://app.clubhouse.io/skyverge/story/32617)
### Release: #436

## Details

Since `Absrtact_Settings` is... abstract, the integration tests use an an anonymous class that extends `Abstrat_Settings` as the test subject.

## QA

- [x] Unit tests pass
- [x] Integration tests pass
