### PR TITLE
Add validation to Setting default setter

### DIFF
--- a/tests/integration/Settings_API/SettingTest.php
+++ b/tests/integration/Settings_API/SettingTest.php
@@ -23,6 +23,44 @@ class SettingTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * @see Setting::set_default()
+	 *
+	 * @param mixed $value default value to try and set
+	 * @param string $expected expected default value
+	 * @param bool $is_multi whether the setting should be multi
+	 *
+	 * @dataProvider provider_set_default
+	 */
+	public function test_set_default( $value, $expected, $is_multi = false ) {
+
+		$setting = new Setting();
+		$setting->set_type( Setting::TYPE_STRING );
+		$setting->set_is_multi( $is_multi );
+		$setting->set_default( $value );
+
+		$this->assertSame( $expected, $setting->get_default() );
+	}
+
+
+	/** @see test_set_default() */
+	public function provider_set_default() {
+
+		return [
+			[ 'valid', 'valid' ],
+			[ 1, null ],
+			[ [ 'string-0', 'string-1' ], [ 'string-0', 'string-1' ], true ],
+			[ [ 'string-0', 1 ], [ 'string-0' ], true ],
+			[ [ 1, 2 ], null, true ],
+			[ [], null, true ],
+			[ 'valid', [ 'valid' ], true ],
+			[ 1, null, true ],
+			[ null, null ],
+			[ null, null, true ],
+		];
+	}
+
+
+	/**
 	 * @see Setting::validate_value()
 	 *
 	 * @param mixed $value value to pass to method

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -169,7 +169,7 @@ class Setting {
 	 *
 	 * @since x.y.z
 	 *
-	 * @return array|bool|float|int|string
+	 * @return array|bool|float|int|string|null
 	 */
 	public function get_default() {
 
@@ -289,11 +289,23 @@ class Setting {
 	 *
 	 * @since x.y.z
 	 *
-	 * @param array|bool|float|int|string $default
+	 * @param array|bool|float|int|string|null $value default value to set
 	 */
-	public function set_default( $default ) {
+	public function set_default( $value ) {
 
-		$this->default = $default;
+		if ( $this->is_is_multi() ) {
+
+			$_value = array_filter( (array) $value, [ $this, 'validate_value' ] );
+
+			// clear the default if all values were invalid
+			$value = ! empty( $_value ) ? $_value : null;
+
+		} elseif ( ! $this->validate_value( $value ) ) {
+
+			$value = null;
+		}
+
+		$this->default = $value;
 	}
 
 


### PR DESCRIPTION
# Summary

Removes invalid values when setting a setting's default value.

### Story: [CH 32643](https://app.clubhouse.io/skyverge/story/32643/update-setting-set-default-to-use-validate-value)
### Release: #436 

## UI Changes

None

## QA

- [x] Unit tests pass
- [x] Integration tests pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version