### PR TITLE
Add register_setting() to Abstract_Settings

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -44,6 +44,35 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * @see Abstract_Settings::register_setting()
+	 * @see Abstract_Settings::get_setting()
+	 */
+	public function test_register_setting() {
+
+		$this->assertTrue( $this->get_settings_instance()->register_setting( 'test-setting-d', Setting::TYPE_EMAIL, [
+			'name'        => 'Test Setting D',
+			'description' => 'Description of setting D',
+		] ) );
+
+		$this->assertInstanceOf( Setting::class, $this->get_settings_instance()->get_setting( 'test-setting-d' ) );
+
+		// existing setting ID
+		$this->assertFalse( $this->get_settings_instance()->register_setting( 'test-setting-d', Setting::TYPE_EMAIL, [
+			'name'        => 'Test Setting D',
+			'description' => 'Description of setting D',
+		] ) );
+
+		// invalid setting type
+		$this->assertFalse( $this->get_settings_instance()->register_setting( 'test-setting-e', 'invalid-type', [
+			'name'        => 'Test Setting E',
+			'description' => 'Description of setting E',
+		] ) );
+
+		$this->assertNull( $this->get_settings_instance()->get_setting( 'test-setting-e' ) );
+	}
+
+
+	/**
 	 * @see Abstract_Settings::unregister_setting()
 	 * @see Abstract_Settings::get_setting()
 	 */

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -170,13 +170,24 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 				protected function register_settings() {
 
-					// TODO: remove when register_setting() is available and a setting object can be set in the test {WV 2020-03-20}
-					$this->settings['test-setting-a'] = new Setting();
-					$this->settings['test-setting-b'] = new Setting();
-					$this->settings['test-setting-c'] = new Setting();
+					$this->register_setting( 'test-setting-a', Setting::TYPE_STRING, [
+						'name'        => 'Test Setting A',
+						'description' => 'Description of setting A',
+					] );
+
+					$this->register_setting( 'test-setting-b', Setting::TYPE_INTEGER, [
+						'name'        => 'Test Setting B',
+						'description' => 'Description of setting B',
+						'default'     => 3600,
+					] );
+
+					$this->register_setting( 'test-setting-c', Setting::TYPE_BOOLEAN, [
+						'name'        => 'Test Setting C',
+						'description' => 'Description of setting C',
+						'default'     => true,
+					] );
 
 					// TODO: remove when save() is available
-					$this->settings['test-setting-a']->set_id( 'test-setting-a' );
 					$this->settings['test-setting-a']->set_value( 'example' );
 
 					update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-a']->get_id()}", 'something' );

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -80,6 +80,61 @@ abstract class Abstract_Settings {
 
 
 	/**
+	 * Registers a setting.
+	 *
+	 * @param string $id unique setting ID
+	 * @param string $type setting type
+	 * @param array $args setting arguments
+	 * @return bool
+	 */
+	public function register_setting( $id, $type, array $args ) {
+
+		try {
+
+			if ( ! empty( $this->settings[ $id ] ) ) {
+				throw new Framework\SV_WC_Plugin_Exception( "Setting {$id} is already registered" );
+			}
+
+			if ( ! in_array( $type, $this->get_setting_types(), true ) ) {
+				throw new Framework\SV_WC_Plugin_Exception( "{$type} is not a valid setting type" );
+			}
+
+			$setting = new Setting();
+
+			$setting->set_id( $id );
+			$setting->set_type( $type );
+
+			$args = wp_parse_args( $args, [
+				'name'         => '',
+				'description'  => '',
+				'is_multi'     => false,
+				'options'      => [],
+				'default'      => null,
+			] );
+
+			$setting->set_name( $args['name'] );
+			$setting->set_description( $args['description'] );
+			$setting->set_default( $args['default'] );
+			$setting->set_is_multi( $args['is_multi'] );
+
+			if ( is_array( $args['options'] ) ) {
+				$setting->set_options( $args['options'] );
+			}
+
+			$this->settings[ $id ] = $setting;
+
+			return true;
+
+		} catch ( \Exception $exception ) {
+
+			wc_doing_it_wrong( __METHOD__, 'Could not register setting: ' . $exception->getMessage(), 'x.y.z' );
+
+			return false;
+		}
+	}
+
+
+	/**
 	 * Unregisters a setting.
 	 *
 	 * @since x.y.z

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -87,7 +87,7 @@ abstract class Abstract_Settings {
 	 * @param array $args setting arguments
 	 * @return bool
 	 */
-	public function register_setting( $id, $type, array $args ) {
+	public function register_setting( $id, $type, array $args = [] ) {
 
 		try {
 


### PR DESCRIPTION
# Summary

Adds the `Abstract_Settings::register_setting` method and an integration test for it.

I've kept the exception handling from the POC, because I liked it. It catches any exceptions and returns false (logging it with `wc_doing_it_wrong`). This way the plugin `register_settings` does not have to worry about catching exceptions.

### Story: [CH 32711](https://app.clubhouse.io/skyverge/story/32711/add-register-setting-to-abstract-settings)
### Release: #436 

## QA

- [x] Integration tests pass