### PR TITLE
Add save() to Abstract_Settings

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -116,7 +116,11 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** @see Abstract_Settings::delete_value() */
 	public function test_delete_value() {
 
-		$setting     = $this->get_settings_instance()->get_setting( 'test-setting-a' );
+		$setting = $this->get_settings_instance()->get_setting( 'test-setting-a' );
+
+		$setting->set_value( 'something' );
+		$this->get_settings_instance()->save( 'test-setting-a' );
+
 		$option_name = $this->get_settings_instance()->get_option_name_prefix() . '_' . $setting->get_id();
 
 		$this->assertNotEmpty( $setting->get_value() );
@@ -215,11 +219,6 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 						'description' => 'Description of setting C',
 						'default'     => true,
 					] );
-
-					// TODO: remove when save() is available
-					$this->settings['test-setting-a']->set_value( 'example' );
-
-					update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-a']->get_id()}", 'something' );
 				}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -133,6 +133,66 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::save() */
+	public function test_save() {
+
+		$setting_a = $this->get_settings_instance()->get_setting( 'test-setting-a' );
+		$setting_b = $this->get_settings_instance()->get_setting( 'test-setting-b' );
+
+		$option_name_a = $this->get_settings_instance()->get_option_name_prefix() . '_' . $setting_a->get_id();
+		update_option( $option_name_a, 'old value' );
+
+		$option_name_b = $this->get_settings_instance()->get_option_name_prefix() . '_' . $setting_b->get_id();
+		update_option( $option_name_b, - 1 );
+
+		$setting_a->set_value( 'new value' );
+		$setting_b->set_value( 2 );
+
+		$this->assertEquals( 'new value', $setting_a->get_value() );
+		$this->assertEquals( 'old value', get_option( $option_name_a ) );
+
+		$this->assertEquals( 2, $setting_b->get_value() );
+		$this->assertEquals( - 1, get_option( $option_name_b ) );
+
+		$this->get_settings_instance()->save();
+
+		$this->assertEquals( 'new value', $setting_a->get_value() );
+		$this->assertEquals( 'new value', get_option( $option_name_a ) );
+		$this->assertEquals( 2, $setting_b->get_value() );
+		$this->assertEquals( 2, get_option( $option_name_b ) );
+	}
+
+
+	/** @see Abstract_Settings::save() */
+	public function test_save_single_setting() {
+
+		$setting_a = $this->get_settings_instance()->get_setting( 'test-setting-a' );
+		$setting_b = $this->get_settings_instance()->get_setting( 'test-setting-b' );
+
+		$option_name_a = $this->get_settings_instance()->get_option_name_prefix() . '_' . $setting_a->get_id();
+		update_option( $option_name_a, 'old value' );
+
+		$option_name_b = $this->get_settings_instance()->get_option_name_prefix() . '_' . $setting_b->get_id();
+		update_option( $option_name_b, - 1 );
+
+		$setting_a->set_value( 'new value' );
+		$setting_b->set_value( 2 );
+
+		$this->assertEquals( 'new value', $setting_a->get_value() );
+		$this->assertEquals( 'old value', get_option( $option_name_a ) );
+
+		$this->assertEquals( 2, $setting_b->get_value() );
+		$this->assertEquals( - 1, get_option( $option_name_b ) );
+
+		$this->get_settings_instance()->save( 'test-setting-a' );
+
+		$this->assertEquals( 'new value', $setting_a->get_value() );
+		$this->assertEquals( 'new value', get_option( $option_name_a ) );
+		$this->assertEquals( 2, $setting_b->get_value() );
+		$this->assertEquals( - 1, get_option( $option_name_b ) );
+	}
+
+
 	/** @see Abstract_Settings::delete_value() */
 	public function test_delete_value_exception() {
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -169,6 +169,42 @@ abstract class Abstract_Settings {
 
 
 	/**
+	 * Saves registered settings in their current state.
+	 *
+	 * It saves all settings by default, but you can pass a setting ID to save a specific setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $setting_id setting ID
+	 */
+	public function save( $setting_id = '' ) {
+
+		if ( ! empty( $setting_id ) ) {
+			$settings = [ $this->get_setting( $setting_id ) ];
+		} else {
+			$settings = $this->settings;
+		}
+
+		$settings = array_filter( $settings );
+
+		foreach ( $settings as $setting ) {
+
+			$option_name   = "{$this->get_option_name_prefix()}_{$setting->get_id()}";
+			$setting_value = $setting->get_value();
+
+			if ( null === $setting_value ) {
+
+				delete_option( $option_name );
+
+			} else {
+
+				update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-a']->get_id()}", $this->get_value_for_database( $setting ) );
+			}
+		}
+	}
+
+
+	/**
 	 * Converts the value of a setting to be stored in an option.
 	 *
 	 * @since x.y.z

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -253,7 +253,7 @@ abstract class Abstract_Settings {
 
 			} else {
 
-				update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-a']->get_id()}", $this->get_value_for_database( $setting ) );
+				update_option( $option_name, $this->get_value_for_database( $setting ) );
 			}
 		}
 	}


### PR DESCRIPTION
# Summary

Adds the `Abstract_Settings::save` method and integration tests for it.

### Story: [CH 32717](https://app.clubhouse.io/skyverge/story/32717/add-save-to-abstract-settings)
### Release: #436 

## QA

- [x] Integration tests pass

## Open questions

 - [ ] Do we want to return anything? I always find it tricky in these cases. A _true_ could mean _all_ settings were saved or _one_ setting was saved. 