### PR TITLE
Update Setting::validate_value() to be more strict about floats and integers

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -146,11 +146,55 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Abstract_Settings::get_value_from_database() */
-	public function test_get_value_from_database() {
+	/**
+	 * @see Abstract_Settings::get_value_from_database()
+	 *
+	 * @param mixed $value the value stored in the database
+	 * @param mixed $expected_value the converted value
+	 * @param string $type the setting type
+	 *
+	 * @dataProvider provider_get_value_from_database
+	 */
+	public function test_get_value_from_database( $value, $expected_value, $type ) {
 
-		// TODO: implement this test when load_settings() is available {WV 2020-03-20}
-		$this->markTestSkipped();
+		$setting = new Setting();
+		$setting->set_type( $type );
+
+		$method  = new ReflectionMethod( Abstract_Settings::class, 'get_value_from_database' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_value, $method->invokeArgs( $this->get_settings_instance(), [ $value, $setting ] ) );
+	}
+
+
+	/** @see test_get_value_from_database() */
+	public function provider_get_value_from_database() {
+
+		require_once 'woocommerce/Settings_API/Setting.php';
+
+		return [
+			[ '12345', 12345, Setting::TYPE_INTEGER ],
+			[ '12.45', 12,    Setting::TYPE_INTEGER ],
+			[ '0',     0,     Setting::TYPE_INTEGER ],
+			[ 'hello', null,  Setting::TYPE_INTEGER ],
+			[ null,    null,  Setting::TYPE_INTEGER ],
+			[ '',      null,  Setting::TYPE_INTEGER ],
+
+			[ '12345', 12345.0, Setting::TYPE_FLOAT ],
+			[ '12.45', 12.45,   Setting::TYPE_FLOAT ],
+			[ '0',     0.0,     Setting::TYPE_FLOAT ],
+			[ 'hello', null,    Setting::TYPE_FLOAT ],
+			[ null,    null,    Setting::TYPE_FLOAT ],
+			[ '',      null,    Setting::TYPE_FLOAT ],
+
+			[ 'yes', true,  Setting::TYPE_BOOLEAN ],
+			[ 'no',  false, Setting::TYPE_BOOLEAN ],
+			[ '1',   true,  Setting::TYPE_BOOLEAN ],
+			[ '0',   false, Setting::TYPE_BOOLEAN ],
+			[ 'hey', false, Setting::TYPE_BOOLEAN ],
+			[ null,  null,  Setting::TYPE_BOOLEAN ],
+			[ '',    false, Setting::TYPE_BOOLEAN ],
+		];
 	}
 
 

--- a/tests/integration/Settings_API/SettingTest.php
+++ b/tests/integration/Settings_API/SettingTest.php
@@ -99,12 +99,17 @@ class SettingTest extends \Codeception\TestCase\WPTestCase {
 			[ 'not-an-email.com', Setting::TYPE_EMAIL, false ],
 			[ '', Setting::TYPE_EMAIL, false ],
 
-			[ 1729, Setting::TYPE_INTEGER, true ],
-			[ 'hi', Setting::TYPE_INTEGER, false ],
+			[ 12345, Setting::TYPE_INTEGER, true ],
+			[ 1.345, Setting::TYPE_INTEGER, false ],
+			[ '234', Setting::TYPE_INTEGER, false ],
+			[ '2.4', Setting::TYPE_INTEGER, false ],
+			[ 'hey', Setting::TYPE_INTEGER, false ],
 
-			[ 3.14, Setting::TYPE_FLOAT, true ],
-			[ 3000, Setting::TYPE_FLOAT, false ],
-			[ 'hi', Setting::TYPE_FLOAT, false ],
+			[ 12345, Setting::TYPE_FLOAT, true ],
+			[ 1.345, Setting::TYPE_FLOAT, true ],
+			[ '234', Setting::TYPE_FLOAT, false ],
+			[ '2.4', Setting::TYPE_FLOAT, false ],
+			[ 'hey', Setting::TYPE_FLOAT, false ],
 
 			[ true, Setting::TYPE_BOOLEAN, true ],
 			[ false, Setting::TYPE_BOOLEAN, true ],

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -254,8 +254,22 @@ abstract class Abstract_Settings {
 	 */
 	protected function get_value_from_database( $value, Setting $setting ) {
 
-		if ( null !== $value && Setting::TYPE_BOOLEAN === $setting->get_type() ) {
-			$value = wc_string_to_bool( $value );
+		if ( null !== $value ) {
+
+			switch ( $setting->get_type() ) {
+
+				case Setting::TYPE_BOOLEAN:
+					$value = wc_string_to_bool( $value );
+				break;
+
+				case Setting::TYPE_INTEGER:
+					$value = is_numeric( $value ) ? (int) $value : null;
+				break;
+
+				case Setting::TYPE_FLOAT:
+					$value = is_numeric( $value ) ? (float) $value : null;
+				break;
+			}
 		}
 
 		return $value;

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -424,7 +424,7 @@ class Setting {
 	 */
 	protected function validate_float_value( $value ) {
 
-		return is_float( $value );
+		return is_int( $value ) || is_float( $value );
 	}
 
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -410,7 +410,7 @@ class Setting {
 	 */
 	public function validate_integer_value( $value ) {
 
-		return is_numeric( $value ) && ! is_float( $value );
+		return is_int( $value );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR updates `validate_value()` to expect `int` values for integer settings and `int|float` values for float settings.

### Story: [CH 32797](https://app.clubhouse.io/skyverge/story/32797)
### Release: #436

## Details

I also updated `get_value_from_database()` to convert numeric strings into the proper type for float and integer settings.

## QA

- [x] Unit tests pass
- [x] Integration tests pass
