### PR TITLE
Add load_settings() to Abstract_Settings

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -73,6 +73,27 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * @see Abstract_Settings::load_settings()
+	 *
+	 * Stored values are defined in get_settings_instance().
+	 */
+	public function test_load_settings() {
+
+		$this->get_settings_instance()->register_setting( 'test-setting-d', Setting::TYPE_EMAIL, [
+			'name'        => 'Test Setting D',
+			'description' => 'Description of setting D',
+		] );
+
+		// TODO: uncomment assert for test-setting-b when https://github.com/skyverge/wc-plugin-framework/pull/453 is merged {WV 2020-03-20}
+
+		$this->assertSame( 'something', $this->get_settings_instance()->get_setting( 'test-setting-a' )->get_value() );
+		// $this->assertSame( 1729, $this->get_settings_instance()->get_setting( 'test-setting-b' )->get_value() );
+		$this->assertSame( true, $this->get_settings_instance()->get_setting( 'test-setting-c' )->get_value() );
+		$this->assertSame( null, $this->get_settings_instance()->get_setting( 'test-setting-d' )->get_value() );
+	}
+
+
+	/**
 	 * @see Abstract_Settings::unregister_setting()
 	 * @see Abstract_Settings::get_setting()
 	 */
@@ -220,14 +241,8 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 					$this->settings['test-setting-a']->set_value( 'example' );
 
 					update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-a']->get_id()}", 'something' );
-				}
-
-
-				/**
-				 * TODO: remove when load_settings() is implemented in Framework\Settings_API\Abstract_Settings {WV 2020-03-20}
-				 */
-				protected function load_settings() {
-
+					update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-b']->get_id()}", '1729' );
+					update_option( "{$this->get_option_name_prefix()}_{$this->settings['test-setting-c']->get_id()}", 'yes' );
 				}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -84,10 +84,9 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 			'description' => 'Description of setting D',
 		] );
 
-		// TODO: uncomment assert for test-setting-b when https://github.com/skyverge/wc-plugin-framework/pull/453 is merged {WV 2020-03-20}
 
 		$this->assertSame( 'something', $this->get_settings_instance()->get_setting( 'test-setting-a' )->get_value() );
-		// $this->assertSame( 1729, $this->get_settings_instance()->get_setting( 'test-setting-b' )->get_value() );
+		$this->assertSame( 1729, $this->get_settings_instance()->get_setting( 'test-setting-b' )->get_value() );
 		$this->assertSame( true, $this->get_settings_instance()->get_setting( 'test-setting-c' )->get_value() );
 		$this->assertSame( null, $this->get_settings_instance()->get_setting( 'test-setting-d' )->get_value() );
 	}

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -76,7 +76,16 @@ abstract class Abstract_Settings {
 	 *
 	 * @since x.y.z
 	 */
-	abstract protected function load_settings();
+	protected function load_settings() {
+
+		foreach ( $this->settings as $setting_id => $setting ) {
+
+			$value = get_option( $this->get_option_name_prefix() . '_' . $setting_id, null );
+			$value = $this->get_value_from_database( $value, $setting );
+
+			$this->settings[ $setting_id ]->set_value( $value );
+		}
+	}
 
 
 	/**


### PR DESCRIPTION
# Summary

This PR adds the implementation for the `Abstract_Settings::load_settings()` method.

### Story: [CH 32699](https://app.clubhouse.io/skyverge/story/32699/add-load-settings-to-abstract-settings)
### Release: #436

## Details

Each setting is loaded from a separate option in the database. The `get_value_from_database()` method is used to convert stored values into the appropriate type for the setting.

## QA

- [x] Unit tests pass
- [x] Integration tests pass
