### PR TITLE
Add register_control() to Abstract_Settings

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -88,7 +88,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * @see Abstract_Settings::registr_control()
+	 * @see Abstract_Settings::register_control()
 	 *
 	 * @param string $setting_id the setting ID
 	 * @param string $control_type the control type

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -126,6 +126,37 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::register_control() */
+	public function test_register_control_args() {
+
+		$setting_args = [
+			'name'        => 'Setting Name',
+			'description' => 'Setting Description',
+			'options'     => [ 'black', 'white' ],
+		];
+
+		$this->get_settings_instance()->register_setting( 'color', Setting::TYPE_STRING, $setting_args );
+
+		$this->get_settings_instance()->register_control( 'color', Control::TYPE_SELECT, [
+			'options' => [
+				'black' => 'Black',
+				'white' => 'White',
+				'red'	=> 'Red',
+			],
+		] );
+
+		$control = $this->get_settings_instance()->get_setting( 'color' )->get_control();
+
+		// TODO: uncomment assert for $control->get_options when https://github.com/skyverge/wc-plugin-framework/pull/453 is merged {WV 2020-03-20}
+
+		$this->assertEquals( 'color', $control->get_setting_id() );
+		$this->assertEquals( Control::TYPE_SELECT, $control->get_type() );
+		$this->assertEquals( $setting_args['name'], $control->get_name() );
+		$this->assertEquals( $setting_args['description'], $control->get_description() );
+		// $this->assertEquals( $setting_args['options'], array_keys( $control->get_options() ) );
+	}
+
+
 	/**
 	 * @see Abstract_Settings::get_settings()
 	 *

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -3,6 +3,7 @@
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1 as Framework;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Control;
 
 /**
  * Tests for the Abstract_Settings class.
@@ -83,6 +84,45 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_settings_instance()->unregister_setting( 'test-setting-a' );
 
 		$this->assertNull( $this->get_settings_instance()->get_setting( 'test-setting-a' ) );
+	}
+
+
+	/**
+	 * @see Abstract_Settings::registr_control()
+	 *
+	 * @param string $setting_id the setting ID
+	 * @param string $control_type the control type
+	 * @param bool $expected whether the expected return value for register_control()
+	 *
+	 * @dataProvider provider_register_control
+	 */
+	public function test_register_control( $setting_id, $control_type, $expected ) {
+
+		$this->get_settings_instance()->register_setting( 'registered_setting', Setting::TYPE_STRING );
+
+		$this->assertSame( $expected, $this->get_settings_instance()->register_control( $setting_id, $control_type ) );
+
+		if ( $expected ) {
+
+			$this->assertInstanceOf( Control::class, $this->get_settings_instance()->get_setting( $setting_id )->get_control() );
+
+		} elseif ( $setting = $this->get_settings_instance()->get_setting( $setting_id ) ) {
+
+			$this->assertNull( $setting->get_control() );
+		}
+	}
+
+
+	/** @see test_register_control() */
+	public function provider_register_control() {
+
+		require_once 'woocommerce/Settings_API/Control.php';
+
+		return [
+			[ 'unknown_setting',    Control::TYPE_TEXT, false ],
+			[ 'registered_setting', 'invalid_type',     false ],
+			[ 'registered_setting', Control::TYPE_TEXT, true ],
+		];
 	}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -147,13 +147,11 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$control = $this->get_settings_instance()->get_setting( 'color' )->get_control();
 
-		// TODO: uncomment assert for $control->get_options when https://github.com/skyverge/wc-plugin-framework/pull/453 is merged {WV 2020-03-20}
-
 		$this->assertEquals( 'color', $control->get_setting_id() );
 		$this->assertEquals( Control::TYPE_SELECT, $control->get_type() );
 		$this->assertEquals( $setting_args['name'], $control->get_name() );
 		$this->assertEquals( $setting_args['description'], $control->get_description() );
-		// $this->assertEquals( $setting_args['options'], array_keys( $control->get_options() ) );
+		$this->assertEquals( $setting_args['options'], array_keys( $control->get_options() ) );
 	}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -147,11 +147,13 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$control = $this->get_settings_instance()->get_setting( 'color' )->get_control();
 
+		// TODO: uncomment assert for $control->get_options when https://github.com/skyverge/wc-plugin-framework/pull/453 is merged {WV 2020-03-20}
+
 		$this->assertEquals( 'color', $control->get_setting_id() );
 		$this->assertEquals( Control::TYPE_SELECT, $control->get_type() );
 		$this->assertEquals( $setting_args['name'], $control->get_name() );
 		$this->assertEquals( $setting_args['description'], $control->get_description() );
-		$this->assertEquals( $setting_args['options'], array_keys( $control->get_options() ) );
+		// $this->assertEquals( $setting_args['options'], array_keys( $control->get_options() ) );
 	}
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -92,17 +92,17 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @param string $setting_id the setting ID
 	 * @param string $control_type the control type
-	 * @param bool $expected whether the expected return value for register_control()
+	 * @param bool $registered whether the control should be succesfully registered or not
 	 *
 	 * @dataProvider provider_register_control
 	 */
-	public function test_register_control( $setting_id, $control_type, $expected ) {
+	public function test_register_control( $setting_id, $control_type, $registered ) {
 
 		$this->get_settings_instance()->register_setting( 'registered_setting', Setting::TYPE_STRING );
 
-		$this->assertSame( $expected, $this->get_settings_instance()->register_control( $setting_id, $control_type ) );
+		$this->assertSame( $registered, $this->get_settings_instance()->register_control( $setting_id, $control_type ) );
 
-		if ( $expected ) {
+		if ( $registered ) {
 
 			$this->assertInstanceOf( Control::class, $this->get_settings_instance()->get_setting( $setting_id )->get_control() );
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -148,6 +148,60 @@ abstract class Abstract_Settings {
 
 
 	/**
+	 * Registers a control for a setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $setting_id the setting ID
+	 * @param string $type the control type
+	 * @param array $args optional args for the control
+	 * @return bool
+	 */
+	public function register_control( $setting_id, $type, array $args = [] ) {
+
+		try {
+
+			if ( ! in_array( $type, $this->get_control_types(), true ) ) {
+				throw new \UnexpectedValueException( "{$type} is not a valid control type" );
+			}
+
+			$setting = $this->get_setting( $setting_id );
+
+			if ( ! $setting ) {
+				throw new \InvalidArgumentException( "Setting {$setting_id} does not exist" );
+			}
+
+			$args = wp_parse_args( $args, [
+				'name'        => $setting->get_name(),
+				'description' => $setting->get_description(),
+				'options'     => [],
+			] );
+
+			$control = new Control();
+
+			$control->set_setting_id( $setting_id );
+			$control->set_type( $type );
+			$control->set_name( $args['name'] );
+			$control->set_description( $args['description'] );
+
+			if ( is_array( $args['options'] ) ) {
+				$control->set_options( $args['options'], $setting->get_options() );
+			}
+
+			$setting->set_control( $control );
+
+			return true;
+
+		} catch ( \Exception $exception ) {
+
+			wc_doing_it_wrong( __METHOD__, 'Could not register setting control: ' . $exception->getMessage(), 'x.y.z' );
+
+			return false;
+		}
+	}
+
+
+	/**
 	 * Gets the settings ID.
 	 *
 	 * @since x.y.z


### PR DESCRIPTION
# Summary

This PR adds the `Abstract_Settings::register_control()` method.

### Story: [CH 32714](https://app.clubhouse.io/skyverge/story/32714)
### Release: #436

## Details

The method follows the POC approach of catching exceptions and returning `false` in case of error. 

## QA

- [x] Unit tests pass
- [x] Integration tests pass
