### PR TITLE
Add get_value() to Abstract_Settings

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -113,6 +113,54 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::get_value() */
+	public function test_get_value() {
+
+		$setting = $this->get_settings_instance()->get_setting( 'test-setting-b' );
+		$setting->set_value( 1000 );
+		$this->get_settings_instance()->save( $setting->get_id() );
+
+		$this->assertEquals( 1000, $this->get_settings_instance()->get_value( $setting->get_id() ) );
+	}
+
+
+	/**
+	 * @see Abstract_Settings::get_value()
+	 *
+	 * @param mixed $expected_value the returned value
+	 * @param bool $with_default whether to return the default value if nothing is stored
+	 * @throws Framework\SV_WC_Plugin_Exception
+	 *
+	 * @dataProvider provider_get_value_nothing_stored
+	 */
+	public function test_get_value_nothing_stored( $expected_value, $with_default ) {
+
+		$setting = $this->get_settings_instance()->get_setting( 'test-setting-b' );
+		$this->get_settings_instance()->delete_value( $setting->get_id() );
+
+		$this->assertEquals( $expected_value, $this->get_settings_instance()->get_value( $setting->get_id(), $with_default ) );
+	}
+
+
+	/** @see test_get_value_nothing_stored() */
+	public function provider_get_value_nothing_stored() {
+
+		return [
+			[ 3600, true ],
+			[ null, false ],
+		];
+	}
+
+
+	/** @see Abstract_Settings::get_value() */
+	public function test_get_value_exception() {
+
+		$this->expectException( Framework\SV_WC_Plugin_Exception::class );
+
+		$this->get_settings_instance()->get_value( 'not_a_setting' );
+	}
+
+
 	/** @see Abstract_Settings::delete_value() */
 	public function test_delete_value() {
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -201,6 +201,36 @@ abstract class Abstract_Settings {
 
 
 	/**
+	 * Gets the stored value for a setting.
+	 *
+	 * Optionally, will return the setting's default value if nothing is stored.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $setting_id setting ID
+	 * @param bool $with_default whether to return the default value if nothing is stored
+	 * @return array|bool|float|int|string
+	 * @throws Framework\SV_WC_Plugin_Exception
+	 */
+	public function get_value( $setting_id, $with_default = true ) {
+
+		$setting = $this->get_setting( $setting_id );
+
+		if ( ! $setting ) {
+			throw new Framework\SV_WC_Plugin_Exception( "Setting {$setting_id} does not exist" );
+		}
+
+		$value = $setting->get_value();
+
+		if ( $with_default && null === $value ) {
+			$value = $setting->get_default();
+		}
+
+		return $value;
+	}
+
+
+	/**
 	 * Deletes the stored value for a setting.
 	 *
 	 * @since x.y.z


### PR DESCRIPTION
# Summary

Adds the `get_value` method to the handler class.

### Story: [CH 32720](https://app.clubhouse.io/skyverge/story/32720/add-get-value-to-abstract-settings)
### Release: #436 

## QA

- [x] Unit tests pass
- [x] Integration tests pass