### PR TITLE
Add update_value() to Abstract_Settings

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -271,7 +271,8 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 			$this->expectException( SV_WC_Plugin_Exception::class );
 		}
 
-		$setting_id = 'test-setting';
+		$setting_id  = 'test-setting';
+		$option_name = $this->get_settings_instance()->get_option_name_prefix() . '_' . $setting_id;
 
 		if ( $register ) {
 			$this->get_settings_instance()->register_setting( $setting_id, $type, [ 'options' => $options ] );
@@ -280,6 +281,15 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_settings_instance()->update_value( $setting_id, $value );
 
 		$this->assertSame( $expected, $this->get_settings_instance()->get_setting( $setting_id )->get_value() );
+
+		$setting = $this->get_settings_instance()->get_setting( $setting_id );
+		$method  = new ReflectionMethod( Abstract_Settings::class, 'get_value_from_database' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invokeArgs( $this->get_settings_instance(), [
+			get_option( $option_name ),
+			$setting
+		] ) );
 	}
 
 
@@ -316,7 +326,7 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 			[ true, 1, Setting::TYPE_INTEGER, [ 1, 2 ], 1, false ],
 			[ true, 3, Setting::TYPE_INTEGER, [ 1, 2 ], null, true ],
 
-			[ true, 12345, Setting::TYPE_FLOAT, [], 12345, false ],
+			[ true, 12345, Setting::TYPE_FLOAT, [], 12345.0, false ],
 			[ true, 1.345, Setting::TYPE_FLOAT, [], 1.345, false ],
 			[ true, '234', Setting::TYPE_FLOAT, [], null, true ],
 			[ true, 1.5, Setting::TYPE_FLOAT, [ 1.5, 2.5 ], 1.5, false ],

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -312,6 +312,8 @@ abstract class Abstract_Settings {
 
 		// performs the validations and updates the value
 		$setting->update_value( $value );
+
+		$this->save( $setting_id );
 	}
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -294,6 +294,28 @@ abstract class Abstract_Settings {
 
 
 	/**
+	 * Updates the stored value for a setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $setting_id setting ID
+	 * @param array|bool|float|int|string $value
+	 * @throws Framework\SV_WC_Plugin_Exception
+	 */
+	public function update_value( $setting_id, $value ) {
+
+		$setting = $this->get_setting( $setting_id );
+
+		if ( ! $setting ) {
+			throw new Framework\SV_WC_Plugin_Exception( "Setting {$setting_id} does not exist" );
+		}
+
+		// performs the validations and updates the value
+		$setting->update_value( $value );
+	}
+
+
+	/**
 	 * Deletes the stored value for a setting.
 	 *
 	 * @since x.y.z


### PR DESCRIPTION
# Summary

Adds the `get_value` method to the handler class.

### Story: [CH 32723](https://app.clubhouse.io/skyverge/story/32723/add-update-value-to-abstract-settings)
### Release: #436 

## QA

- [x] Unit tests pass
- [x] Integration tests pass