### PR TITLE
Add the REST API's prepare_item_for_response() method

### DIFF
--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -84,6 +84,20 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::get_id() */
+	public function test_prepare_item_for_response_value_not_set() {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+
+		$settings->register_setting( 'test', Setting::TYPE_STRING );
+
+		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null );
+
+		$this->assertEquals( null, $item['value'] );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -94,6 +94,8 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null )->get_data();
 
+		// $item['value'] is null if no value has been set for the setting
+		// we want users of the API to differentiate between a setting that's been set vs. a setting that has a default value but not saved yet
 		$this->assertEquals( null, $item['value'] );
 	}
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\REST_API\Controllers\Settings;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Control;
 
 /**
  * Tests for the Abstract_Settings class.
@@ -20,7 +23,10 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 	protected function _before() {
 
+		require_once 'woocommerce/rest-api/Controllers/Settings.php';
 		require_once 'woocommerce/Settings_API/Abstract_Settings.php';
+		require_once 'woocommerce/Settings_API/Control.php';
+		require_once 'woocommerce/Settings_API/Setting.php';
 	}
 
 
@@ -30,6 +36,52 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/** Tests *********************************************************************************************************/
+
+
+	/** @see Abstract_Settings::get_id() */
+	public function test_prepare_item_for_response() {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+
+		$settings->register_setting( 'test', Setting::TYPE_STRING, [
+			'name'        => 'Test Setting',
+			'description' => 'A simple setting',
+			'options'     => [ 'a', 'b', 'c' ],
+			'default'     => 'c',
+		] );
+
+		$settings->register_control( 'test', Control::TYPE_SELECT, [
+			'name'  => 'Select field',
+			'description' => 'A regultar select input field',
+			'options'     => [
+				'a' => 'A',
+				'b' => 'B',
+				'c' => 'C'
+			],
+		] );
+
+		$setting = $settings->get_setting( 'test' );
+		$control = $setting->get_control();
+
+		$setting->set_value( 'a' );
+
+		$item = $controller->prepare_item_for_response( $setting, null );
+
+		$this->assertEquals( $setting->get_id(),          $item['id'] );
+		$this->assertEquals( $setting->get_type(),        $item['type'] );
+		$this->assertEquals( $setting->get_name(),        $item['name'] );
+		$this->assertEquals( $setting->get_description(), $item['description'] );
+		$this->assertEquals( $setting->is_is_multi(),     $item['is_multi'] );
+		$this->assertEquals( $setting->get_options(),     $item['options'] );
+		$this->assertEquals( $setting->get_default(),     $item['default'] );
+		$this->assertEquals( $setting->get_value(),       $item['value'] );
+
+		$this->assertEquals( $control->get_type(),        $item['control']['type'] );
+		$this->assertEquals( $control->get_name(),        $item['control']['name'] );
+		$this->assertEquals( $control->get_description(), $item['control']['description'] );
+		$this->assertEquals( $control->get_options(),     $item['control']['options'] );
+	}
 
 
 	/** Helper methods ************************************************************************************************/

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -6,7 +6,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Control;
 
 /**
- * Tests for the Abstract_Settings class.
+ * Tests for the Settings class.
  *
  * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\REST_API\Controllers\Settings
  */
@@ -38,7 +38,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
-	/** @see Abstract_Settings::get_id() */
+	/** @see Settings::prepare_item_for_response() */
 	public function test_prepare_item_for_response() {
 
 		$settings   = $this->get_settings_instance();
@@ -84,7 +84,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Abstract_Settings::get_id() */
+	/** @see Settings::prepare_item_for_response() */
 	public function test_prepare_item_for_response_value_not_set() {
 
 		$settings   = $this->get_settings_instance();
@@ -98,7 +98,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Abstract_Settings::get_id() */
+	/** @see Settings::prepare_item_for_response() */
 	public function test_prepare_item_for_response_control_not_set() {
 
 		$settings   = $this->get_settings_instance();

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
+
+/**
+ * Tests for the Abstract_Settings class.
+ *
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\REST_API\Controllers\Settings
+ */
+class SettingsTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** @var Abstract_Settings */
+	protected $settings;
+
+
+	protected function _before() {
+
+		require_once 'woocommerce/Settings_API/Abstract_Settings.php';
+	}
+
+
+	protected function _after() {
+
+	}
+
+
+	/** Tests *********************************************************************************************************/
+
+
+	/** Helper methods ************************************************************************************************/
+
+
+	/**
+	 * Gets the settings instance.
+	 *
+	 * @return Abstract_Settings
+	 */
+	protected function get_settings_instance() {
+
+		if ( null === $this->settings ) {
+
+			$this->settings = new class( 'test-plugin' ) extends Abstract_Settings {
+
+
+				protected function register_settings() {
+
+				}
+
+
+			};
+		}
+
+		return $this->settings;
+	}
+
+
+}

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -66,7 +66,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$setting->set_value( 'a' );
 
-		$item = $controller->prepare_item_for_response( $setting, null );
+		$item = $controller->prepare_item_for_response( $setting, null )->get_data();
 
 		$this->assertEquals( $setting->get_id(),          $item['id'] );
 		$this->assertEquals( $setting->get_type(),        $item['type'] );
@@ -92,7 +92,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$settings->register_setting( 'test', Setting::TYPE_STRING );
 
-		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null );
+		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null )->get_data();
 
 		$this->assertEquals( null, $item['value'] );
 	}
@@ -106,7 +106,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$settings->register_setting( 'test', Setting::TYPE_STRING );
 
-		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null );
+		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null )->get_data();
 
 		$this->assertArrayNotHasKey( 'control', $item );
 	}

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -53,7 +53,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$settings->register_control( 'test', Control::TYPE_SELECT, [
 			'name'  => 'Select field',
-			'description' => 'A regultar select input field',
+			'description' => 'A regular select input field',
 			'options'     => [
 				'a' => 'A',
 				'b' => 'B',

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -108,7 +108,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null )->get_data();
 
-		$this->assertArrayNotHasKey( 'control', $item );
+		$this->assertSame( null, $item['control'] );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -98,6 +98,20 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::get_id() */
+	public function test_prepare_item_for_response_control_not_set() {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+
+		$settings->register_setting( 'test', Setting::TYPE_STRING );
+
+		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null );
+
+		$this->assertArrayNotHasKey( 'control', $item );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -160,7 +160,7 @@ class Settings extends \WP_REST_Controller {
 	 *
 	 * @param Setting $setting a setting object
 	 * @param \WP_REST_Request $request request object
-	 * @return WP_Error|WP_HTTP_Response
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function prepare_item_for_response( $setting, $request ) {
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -175,6 +175,7 @@ class Settings extends \WP_REST_Controller {
 				'options'     => $setting->get_options(),
 				'default'     => $setting->get_default(),
 				'value'       => $setting->get_value(),
+				'control'     => null,
 			];
 
 			if ( $control = $setting->get_control() ) {

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -25,6 +25,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\REST_API\Controllers;
 
 use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Setting;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -155,7 +156,44 @@ class Settings extends \WP_REST_Controller {
 	/** Utility methods ***********************************************************************************************/
 
 
-	// TODO: prepare_item_for_response()
+	/**
+	 * @sincex.y.z
+	 *
+	 * @param Setting $setting a setting object
+	 * @param \WP_REST_Request $request request object
+	 * @return array
+	 */
+	public function prepare_item_for_response( $setting, $request ) {
+
+		if ( $setting instanceof Setting ) {
+
+			$item = [
+				'id'          => $setting->get_id(),
+				'type'        => $setting->get_type(),
+				'name'        => $setting->get_name(),
+				'description' => $setting->get_description(),
+				'is_multi'    => $setting->is_is_multi(),
+				'options'     => $setting->get_options(),
+				'default'     => $setting->get_default(),
+				'value'       => $setting->get_value(),
+			];
+
+			if ( $control = $setting->get_control() ) {
+				$item['control'] = [
+					'type'        => $control->get_type(),
+					'name'        => $control->get_name(),
+					'description' => $control->get_description(),
+					'options'     => $control->geT_options(),
+				];
+			}
+
+		} else {
+
+			$item = [];
+		}
+
+		return $item;
+	}
 
 
 	// TODO: get_item_schema()

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -156,7 +156,7 @@ class Settings extends \WP_REST_Controller {
 
 
 	/**
-	 * @sincex.y.z
+	 * @since x.y.z
 	 *
 	 * @param Setting $setting a setting object
 	 * @param \WP_REST_Request $request request object

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -161,7 +161,7 @@ class Settings extends \WP_REST_Controller {
 	 *
 	 * @param Setting $setting a setting object
 	 * @param \WP_REST_Request $request request object
-	 * @return array
+	 * @return WP_Error|WP_HTTP_Response
 	 */
 	public function prepare_item_for_response( $setting, $request ) {
 
@@ -192,7 +192,7 @@ class Settings extends \WP_REST_Controller {
 			$item = [];
 		}
 
-		return $item;
+		return rest_ensure_response( $item );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds the `prepare_item_for_response()` method to the `Settings` REST Controller class.

### Story: [CH 32761](https://app.clubhouse.io/skyverge/story/32761/add-the-rest-api-prepare-item-for-response-method)
### Release: #436

## Details

I wasn't sure whether the implementation document expected the method to return an array, or a REST Response object containing an array. However, since `WP_REST_Controller::prepare_item_for_response()` returns `WP_Error|WP_REST_Response`, I decided to match the parent's method return type in this PR.

From what I can see, we would be converting the array into a response object anyway, so I think it makes sense to match the return type of the parent method.

## QA

- [x] Integration tests pass