### PR TITLE
Update base REST handler to add a settings controller & endpoints

### DIFF
--- a/tests/integration/REST_API/RESTAPITest.php
+++ b/tests/integration/REST_API/RESTAPITest.php
@@ -1,5 +1,9 @@
 <?php
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Helper;
+
 /**
  * Tests for the REST_API class.
  *
@@ -11,8 +15,15 @@ class RESTAPITest extends \Codeception\TestCase\WPTestCase {
 	/** @var \IntegrationTester */
 	protected $tester;
 
+	/** @var Abstract_Settings */
+	protected $settings;
+
+
 	protected function _before() {
 
+		require_once 'woocommerce/class-sv-wc-plugin.php';
+		require_once 'woocommerce/rest-api/Controllers/Settings.php';
+		require_once 'woocommerce/Settings_API/Abstract_Settings.php';
 	}
 
 
@@ -24,7 +35,42 @@ class RESTAPITest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
+	/** @see Abstract_Settings::get_id() */
+	public function test_register_routes() {
+
+		$settings = $this->get_settings_instance();
+		$plugin   = $this->make( SkyVerge\WooCommerce\TestPlugin\Plugin::class, [ 'get_settings_handler' =>  $settings ] );
+
+		$handler = new Framework\REST_API( $plugin );
+		$handler->register_routes();
+
+		$this->assertArrayHasKey( "/wc/v3/{$settings->get_id()}/settings", rest_get_server()->get_routes() );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 
+	/**
+	 * Gets the settings instance.
+	 *
+	 * @return Abstract_Settings
+	 */
+	protected function get_settings_instance() {
+
+		if ( null === $this->settings ) {
+
+			$this->settings = new class( 'test-plugin' ) extends Abstract_Settings {
+
+
+				protected function register_settings() {
+
+				}
+
+
+			};
+		}
+
+		return $this->settings;
+	}
 }

--- a/tests/integration/REST_API/RESTAPITest.php
+++ b/tests/integration/REST_API/RESTAPITest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Tests for the REST_API class.
+ *
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\REST_API
+ */
+class RESTAPITest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+	protected function _before() {
+
+	}
+
+
+	protected function _after() {
+
+	}
+
+
+	/** Tests *********************************************************************************************************/
+
+
+	/** Helper methods ************************************************************************************************/
+
+
+}

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -939,7 +939,7 @@ abstract class SV_WC_Plugin {
 	 *
 	 * @since x.y.z
 	 *
-	 * @return void|Abstract_Settings
+	 * @return void|Settings_API\Abstract_Settings
 	 */
 	public function get_settings_handler() {
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -51,10 +51,9 @@ class Settings extends \WP_REST_Controller {
 	 */
 	public function __construct( Abstract_Settings $settings ) {
 
-		$this->settings = $settings;
+		$this->settings  = $settings;
 		$this->namespace = 'wc/v3';
-
-		// TODO: set $this->rest_base when Abstract_Settings has a get_id() method
+		$this->rest_base = "{$settings->get_id()}/settings";
 	}
 
 

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -134,7 +134,12 @@ class REST_API {
 	 */
 	public function register_routes() {
 
-		// stub
+		if ( $settings = $this->get_plugin()->get_settings_handler() ) {
+
+			$settings_controller = new REST_API\Controllers\Settings( $settings );
+
+			$settings_controller->register_routes();
+		}
 	}
 
 


### PR DESCRIPTION
# Summary

This PR updates the `register_routes()` method to the `REST_API` REST handler.

### Story: [CH 32755](https://app.clubhouse.io/skyverge/story/32755)
### Release: #436

## Details

The test for `register_routes()` checks for the existence of one of the routes that the `REST_API\Controllers\Settings` class is supposed to register as proof that the `REST_API\Controllers\Settings::register_routes()` method was called. We should write separate tests for the controller class to verify that all the necessary routes are registered.

## QA

- [ ] Unit tests pass
- [ ] Integration tests pass