### PR TITLE
Update `Abstract_Settings::get_valid_control_types` to apply a filter, passing the setting type as a param

### DIFF
--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -519,6 +519,22 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Abstract_Settings::get_setting_control_types() */
+	public function test_get_setting_control_types() {
+
+		$setting = $this->get_settings_instance()->get_setting( 'test-setting-a' );
+
+		$this->assertIsArray( $this->get_settings_instance()->get_setting_control_types( $setting ) );
+
+		add_filter( "wc_{$this->get_settings_instance()->get_id()}_settings_api_setting_control_types", function() {
+
+			return [ 'my_type' ];
+		} );
+
+		$this->assertEquals( [ 'my_type' ], $this->get_settings_instance()->get_setting_control_types( $setting ) );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -112,13 +112,22 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @param string $setting_id the setting ID
 	 * @param string $control_type the control type
-	 * @param bool $registered whether the control should be succesfully registered or not
+	 * @param string[] $setting_control_types the control types valid for the setting
+	 * @param bool $registered whether the control should be successfully registered or not
 	 *
 	 * @dataProvider provider_register_control
 	 */
-	public function test_register_control( $setting_id, $control_type, $registered ) {
+	public function test_register_control( $setting_id, $control_type, $setting_control_types, $registered ) {
 
 		$this->get_settings_instance()->register_setting( 'registered_setting', Setting::TYPE_STRING );
+
+		if ( ! empty( $setting_control_types ) ) {
+
+			add_filter( "wc_{$this->get_settings_instance()->get_id()}_settings_api_setting_control_types", function () use ( $setting_control_types ) {
+
+				return $setting_control_types;
+			} );
+		}
 
 		$this->assertSame( $registered, $this->get_settings_instance()->register_control( $setting_id, $control_type ) );
 
@@ -139,9 +148,11 @@ class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 		require_once 'woocommerce/Settings_API/Control.php';
 
 		return [
-			[ 'unknown_setting',    Control::TYPE_TEXT, false ],
-			[ 'registered_setting', 'invalid_type',     false ],
-			[ 'registered_setting', Control::TYPE_TEXT, true ],
+			[ 'unknown_setting',    Control::TYPE_TEXT, [], false ],
+			[ 'registered_setting', 'invalid_type',     [], false ],
+			[ 'registered_setting', Control::TYPE_TEXT, [], true ],
+			[ 'registered_setting', Control::TYPE_TEXT, [ Control::TYPE_TEXT, Control::TYPE_SELECT ], true ],
+			[ 'registered_setting', Control::TYPE_EMAIL, [ Control::TYPE_TEXT, Control::TYPE_SELECT ], false ],
 		];
 	}
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -180,7 +180,7 @@ abstract class Abstract_Settings {
 				throw new \InvalidArgumentException( "Setting {$setting_id} does not exist" );
 			}
 
-			$setting_control_types = $this->get_valid_control_types( $setting );
+			$setting_control_types = $this->get_setting_control_types( $setting );
 			if ( ! empty( $setting_control_types ) && ! in_array( $type, $setting_control_types, true ) ) {
 				throw new \UnexpectedValueException( "{$type} is not a valid control type for setting {$setting->get_id()} of type {$setting->get_type()}" );
 			}
@@ -504,7 +504,7 @@ abstract class Abstract_Settings {
 	 * @param Setting $setting setting object
 	 * @return string[]
 	 */
-	public function get_valid_control_types( $setting ) {
+	public function get_setting_control_types( $setting ) {
 
 		/**
 		 * Filters the list of valid control types for a setting.

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -506,9 +506,15 @@ abstract class Abstract_Settings {
 	 */
 	public function get_valid_control_types( $setting ) {
 
-		// TODO: apply filter {DM 2020-03-20}
-
-		return [];
+		/**
+		 * Filters the list of valid control types for a setting.
+		 *
+		 * @param string[] $control_types valid control types
+		 * @param string $setting_type setting type
+		 * @param Setting $setting setting object
+		 * @param Abstract_Settings $settings the settings handler instance
+		 */
+		return apply_filters( "wc_{$this->get_id()}_settings_api_control_types", [], $setting->get_type(), $setting, $this );
 	}
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -514,7 +514,7 @@ abstract class Abstract_Settings {
 		 * @param Setting $setting setting object
 		 * @param Abstract_Settings $settings the settings handler instance
 		 */
-		return apply_filters( "wc_{$this->get_id()}_settings_api_control_types", [], $setting->get_type(), $setting, $this );
+		return apply_filters( "wc_{$this->get_id()}_settings_api_setting_control_types", [], $setting->get_type(), $setting, $this );
 	}
 
 


### PR DESCRIPTION
# Summary

Adds a filter for the control types for a specific setting.

### Story: [CH 32743](https://app.clubhouse.io/skyverge/story/32743/update-abstract-settings-get-valid-control-types-to-apply-a-filter-passing-the-setting-type-as-a-param)
### Release: #436 

## QA

- [x] Unit tests pass
- [x] Integration tests pass