### PR TITLE
Add the REST API get_item() method

### DIFF
--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -95,6 +95,25 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Settings::get_item() */
+	public function test_get_item_not_found() {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+
+		$setting_id = 'test';
+
+		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings" );
+		$request->set_url_params( [ 'id' => $setting_id ] );
+
+		$response = $controller->get_item( $request );
+
+		$this->assertTrue( $response instanceof WP_Error );
+		$this->assertSame( 'wc_rest_setting_not_found', $response->get_error_code() );
+		$this->assertSame( [ 'status' => 404 ], $response->get_error_data() );
+	}
+
+
 	/** @see Settings::prepare_item_for_response() */
 	public function test_prepare_item_for_response() {
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -55,7 +55,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$settings->register_control( $setting_id, Control::TYPE_SELECT, [
 			'name'        => 'Select field',
-			'description' => 'A regultar select input field',
+			'description' => 'A regular select input field',
 			'options'     => [
 				'a' => 'A',
 				'b' => 'B',

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -38,6 +38,63 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
+	/** @see Settings::get_item() */
+	public function test_get_item() {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+
+		$setting_id = 'test';
+
+		$settings->register_setting( $setting_id, Setting::TYPE_STRING, [
+			'name'        => 'Test Setting',
+			'description' => 'A simple setting',
+			'options'     => [ 'a', 'b', 'c' ],
+			'default'     => 'c',
+		] );
+
+		$settings->register_control( $setting_id, Control::TYPE_SELECT, [
+			'name'        => 'Select field',
+			'description' => 'A regultar select input field',
+			'options'     => [
+				'a' => 'A',
+				'b' => 'B',
+				'c' => 'C'
+			],
+		] );
+
+		$setting = $settings->get_setting( $setting_id );
+		$control = $setting->get_control();
+
+		$setting->set_value( 'a' );
+
+		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings" );
+		$request->set_url_params( [ 'id' => $setting_id ] );
+
+		$response = $controller->get_item( $request );
+
+		$this->assertTrue( $response instanceof WP_REST_Response );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$item = $response->get_data();
+
+		$this->assertEquals( $setting->get_id(), $item['id'] );
+		$this->assertEquals( $setting->get_type(), $item['type'] );
+		$this->assertEquals( $setting->get_name(), $item['name'] );
+		$this->assertEquals( $setting->get_description(), $item['description'] );
+		$this->assertEquals( $setting->is_is_multi(), $item['is_multi'] );
+		$this->assertEquals( $setting->get_options(), $item['options'] );
+		$this->assertEquals( $setting->get_default(), $item['default'] );
+		$this->assertEquals( $setting->get_value(), $item['value'] );
+
+		$this->assertEquals( $control->get_type(), $item['control']['type'] );
+		$this->assertEquals( $control->get_name(), $item['control']['name'] );
+		$this->assertEquals( $control->get_description(), $item['control']['description'] );
+		$this->assertEquals( $control->get_options(), $item['control']['options'] );
+	}
+
+
 	/** @see Settings::prepare_item_for_response() */
 	public function test_prepare_item_for_response() {
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -68,7 +68,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$setting->set_value( 'a' );
 
-		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings" );
+		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings/{$setting_id}" );
 		$request->set_url_params( [ 'id' => $setting_id ] );
 
 		$response = $controller->get_item( $request );

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -103,7 +103,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$setting_id = 'test';
 
-		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings" );
+		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings/{$setting_id}" );
 		$request->set_url_params( [ 'id' => $setting_id ] );
 
 		$response = $controller->get_item( $request );

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -125,7 +125,17 @@ class Settings extends \WP_REST_Controller {
 	// TODO: get_items()
 
 
-	// TODO: get_item()
+	/**
+	 * Gets a single setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_item( $request ) {
+
+	}
 
 
 	/** Update methods ************************************************************************************************/

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -139,6 +139,7 @@ class Settings extends \WP_REST_Controller {
 
 		if ( $setting = $this->settings->get_setting( $setting_id ) ) {
 
+			return $this->prepare_item_for_response( $setting );
 
 		} else {
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -142,6 +142,15 @@ class Settings extends \WP_REST_Controller {
 
 		} else {
 
+			return new \WP_Error(
+				'wc_rest_setting_not_found',
+				sprintf(
+					/* translators: Placeholder: %s - setting ID */
+					__( 'Setting %s does not exist', 'woocommerce-plugin-framework' ),
+					$setting_id
+				),
+				[ 'status' => 404 ]
+			);
 		}
 	}
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -135,6 +135,14 @@ class Settings extends \WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 
+		$setting_id = $request->get_param( 'id' );
+
+		if ( $setting = $this->settings->get_setting( $setting_id ) ) {
+
+
+		} else {
+
+		}
 	}
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -139,7 +139,7 @@ class Settings extends \WP_REST_Controller {
 
 		if ( $setting = $this->settings->get_setting( $setting_id ) ) {
 
-			return $this->prepare_item_for_response( $setting );
+			return $this->prepare_item_for_response( $setting, $request );
 
 		} else {
 


### PR DESCRIPTION
# Summary

Adds `get_item` method.

### Story: [CH 32743](https://app.clubhouse.io/skyverge/story/32766/add-the-rest-api-get-item-method)
### Release: #436 

## Details

I've added a few comments/questions for things I am not sure.

## QA

- [x] Unit tests pass
- [x] Integration tests pass