### PR TITLE
Add the REST API get_items() method

### DIFF
--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -221,24 +221,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		$settings   = $this->get_settings_instance();
 		$controller = new Settings( $settings );
 
-		$settings->register_setting( 'test', Setting::TYPE_STRING, [
-			'name'        => 'Test Setting',
-			'description' => 'A simple setting',
-			'options'     => [ 'a', 'b', 'c' ],
-			'default'     => 'c',
-		] );
-
-		$settings->register_control( 'test', Control::TYPE_SELECT, [
-			'name'  => 'Select field',
-			'description' => 'A regular select input field',
-			'options'     => [
-				'a' => 'A',
-				'b' => 'B',
-				'c' => 'C'
-			],
-		] );
-
-		$setting = $settings->get_setting( 'test' );
+		$setting = $settings->get_setting( 'test_one' );
 		$setting->set_value( 'a' );
 
 		$item = $controller->prepare_item_for_response( $setting, null )->get_data();

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -162,8 +162,8 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Settings::prepare_item_for_response() */
-	public function test_prepare_item_for_response() {
+	/** @see Settings::prepare_setting_item() */
+	public function test_prepare_setting_item() {
 
 		$settings   = $this->get_settings_instance();
 		$controller = new Settings( $settings );
@@ -171,22 +171,22 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		$setting = $settings->get_setting( 'test_one' );
 		$setting->set_value( 'a' );
 
-		$item = $controller->prepare_item_for_response( $setting, null )->get_data();
+		$item = $controller->prepare_setting_item( $setting, null );
 
 		$this->assert_item_matches_setting( $item, $setting );
 		$this->assert_item_matches_control( $item['control'], $setting->get_control() );
 	}
 
 
-	/** @see Settings::prepare_item_for_response() */
-	public function test_prepare_item_for_response_value_not_set() {
+	/** @see Settings::prepare_setting_item() */
+	public function test_prepare_setting_item_value_not_set() {
 
 		$settings   = $this->get_settings_instance();
 		$controller = new Settings( $settings );
 
 		$settings->register_setting( 'test', Setting::TYPE_STRING );
 
-		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null )->get_data();
+		$item = $controller->prepare_setting_item( $settings->get_setting( 'test' ), null );
 
 		// $item['value'] is null if no value has been set for the setting
 		// we want users of the API to differentiate between a setting that's been set vs. a setting that has a default value but not saved yet
@@ -194,15 +194,15 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/** @see Settings::prepare_item_for_response() */
-	public function test_prepare_item_for_response_control_not_set() {
+	/** @see Settings::prepare_setting_item() */
+	public function test_prepare_setting_item_control_not_set() {
 
 		$settings   = $this->get_settings_instance();
 		$controller = new Settings( $settings );
 
 		$settings->register_setting( 'test', Setting::TYPE_STRING );
 
-		$item = $controller->prepare_item_for_response( $settings->get_setting( 'test' ), null )->get_data();
+		$item = $controller->prepare_setting_item( $settings->get_setting( 'test' ), null );
 
 		$this->assertSame( null, $item['control'] );
 	}

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -138,7 +138,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * Asserts that entries in an array match the properties of a control
+	 * Asserts that entries in an array match the properties of a control.
 	 *
 	 * @param array $item a data array
 	 * @param Control $control a control object

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -158,30 +158,11 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		$settings   = $this->get_settings_instance();
 		$controller = new Settings( $settings );
 
-		$setting_id = 'test';
-
-		$settings->register_setting( $setting_id, Setting::TYPE_STRING, [
-			'name'        => 'Test Setting',
-			'description' => 'A simple setting',
-			'options'     => [ 'a', 'b', 'c' ],
-			'default'     => 'c',
-		] );
-
-		$settings->register_control( $setting_id, Control::TYPE_SELECT, [
-			'name'        => 'Select field',
-			'description' => 'A regular select input field',
-			'options'     => [
-				'a' => 'A',
-				'b' => 'B',
-				'c' => 'C'
-			],
-		] );
-
-		$setting = $settings->get_setting( $setting_id );
+		$setting = $settings->get_setting( 'test_one' );
 		$setting->set_value( 'a' );
 
-		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings/{$setting_id}" );
-		$request->set_url_params( [ 'id' => $setting_id ] );
+		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings/{$setting->get_id()}" );
+		$request->set_url_params( [ 'id' => $setting->get_id() ] );
 
 		$response = $controller->get_item( $request );
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -79,6 +79,40 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
+	/**
+	 * Asserts that entries in an array match the properties of a setting.
+	 *
+	 * @param array $item a data array
+	 * @param Setting $setting a setting object
+	 */
+	private function assert_item_matches_setting( array $item, $setting ) {
+
+		$this->assertEquals( $setting->get_id(), $item['id'] );
+		$this->assertEquals( $setting->get_type(), $item['type'] );
+		$this->assertEquals( $setting->get_name(), $item['name'] );
+		$this->assertEquals( $setting->get_description(), $item['description'] );
+		$this->assertEquals( $setting->is_is_multi(), $item['is_multi'] );
+		$this->assertEquals( $setting->get_options(), $item['options'] );
+		$this->assertEquals( $setting->get_default(), $item['default'] );
+		$this->assertEquals( $setting->get_value(), $item['value'] );
+	}
+
+
+	/**
+	 * Asserts that entries in an array match the properties of a control
+	 *
+	 * @param array $item a data array
+	 * @param Control $control a control object
+	 */
+	private function assert_item_matches_control( array $item, $control ) {
+
+		$this->assertEquals( $control->get_type(), $item['type'] );
+		$this->assertEquals( $control->get_name(), $item['name'] );
+		$this->assertEquals( $control->get_description(), $item['description'] );
+		$this->assertEquals( $control->get_options(), $item['options'] );
+	}
+
+
 	/** @see Settings::get_item() */
 	public function test_get_item() {
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -118,40 +118,6 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
-	/**
-	 * Asserts that entries in an array match the properties of a setting.
-	 *
-	 * @param array $item a data array
-	 * @param Setting $setting a setting object
-	 */
-	private function assert_item_matches_setting( array $item, $setting ) {
-
-		$this->assertEquals( $setting->get_id(), $item['id'] );
-		$this->assertEquals( $setting->get_type(), $item['type'] );
-		$this->assertEquals( $setting->get_name(), $item['name'] );
-		$this->assertEquals( $setting->get_description(), $item['description'] );
-		$this->assertEquals( $setting->is_is_multi(), $item['is_multi'] );
-		$this->assertEquals( $setting->get_options(), $item['options'] );
-		$this->assertEquals( $setting->get_default(), $item['default'] );
-		$this->assertEquals( $setting->get_value(), $item['value'] );
-	}
-
-
-	/**
-	 * Asserts that entries in an array match the properties of a control.
-	 *
-	 * @param array $item a data array
-	 * @param Control $control a control object
-	 */
-	private function assert_item_matches_control( array $item, $control ) {
-
-		$this->assertEquals( $control->get_type(), $item['type'] );
-		$this->assertEquals( $control->get_name(), $item['name'] );
-		$this->assertEquals( $control->get_description(), $item['description'] );
-		$this->assertEquals( $control->get_options(), $item['options'] );
-	}
-
-
 	/** @see Settings::get_item() */
 	public function test_get_item() {
 
@@ -266,6 +232,40 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		}
 
 		return $this->settings;
+	}
+
+
+	/**
+	 * Asserts that entries in an array match the properties of a setting.
+	 *
+	 * @param array $item a data array
+	 * @param Setting $setting a setting object
+	 */
+	private function assert_item_matches_setting( array $item, $setting ) {
+
+		$this->assertEquals( $setting->get_id(), $item['id'] );
+		$this->assertEquals( $setting->get_type(), $item['type'] );
+		$this->assertEquals( $setting->get_name(), $item['name'] );
+		$this->assertEquals( $setting->get_description(), $item['description'] );
+		$this->assertEquals( $setting->is_is_multi(), $item['is_multi'] );
+		$this->assertEquals( $setting->get_options(), $item['options'] );
+		$this->assertEquals( $setting->get_default(), $item['default'] );
+		$this->assertEquals( $setting->get_value(), $item['value'] );
+	}
+
+
+	/**
+	 * Asserts that entries in an array match the properties of a control.
+	 *
+	 * @param array $item a data array
+	 * @param Control $control a control object
+	 */
+	private function assert_item_matches_control( array $item, $control ) {
+
+		$this->assertEquals( $control->get_type(), $item['type'] );
+		$this->assertEquals( $control->get_name(), $item['name'] );
+		$this->assertEquals( $control->get_description(), $item['description'] );
+		$this->assertEquals( $control->get_options(), $item['options'] );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -87,13 +87,13 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		$settings   = $this->get_settings_instance();
 		$controller = new Settings( $settings );
 
-		$settings_objects = [
+		$setting_objects = [
 			'test_one'   => $settings->get_setting( 'test_one' ),
 			'test_two'   => $settings->get_setting( 'test_two' ),
 			'test_three' => $settings->get_setting( 'test_three' ),
 		];
 
-		$settings_objects['test_one']->set_value( 'a' );
+		$setting_objects['test_one']->set_value( 'a' );
 
 		$request  = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings" );
 		$response = $controller->get_items( $request );
@@ -105,7 +105,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		foreach ( $items as $item ) {
 
-			$setting = $settings_objects[ $item['id'] ];
+			$setting = $setting_objects[ $item['id'] ];
 
 			$this->assert_item_matches_setting( $item, $setting );
 
@@ -114,7 +114,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 			}
 		}
 
-		$this->assertEquals( count( $settings_objects ), count( $items ) );
+		$this->assertEquals( count( $setting_objects ), count( $items ) );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -27,6 +27,47 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		require_once 'woocommerce/Settings_API/Abstract_Settings.php';
 		require_once 'woocommerce/Settings_API/Control.php';
 		require_once 'woocommerce/Settings_API/Setting.php';
+
+		$settings->register_setting( 'test_one', Setting::TYPE_STRING, [
+			'name'        => 'Test Setting One',
+			'description' => 'A simple setting',
+			'options'     => [ 'a', 'b', 'c' ],
+			'default'     => 'c',
+		] );
+
+		$settings->register_control( 'test_one', Control::TYPE_SELECT, [
+			'name'        => 'Select field',
+			'description' => 'A regular select input field for setting one',
+			'options'     => [
+				'a' => 'A',
+				'b' => 'B',
+				'c' => 'C'
+			],
+		] );
+
+		$settings->register_setting( 'test_two', Setting::TYPE_STRING, [
+			'name'        => 'Test Setting Two',
+			'description' => 'Another simple setting',
+			'options'     => [ 'a', 'b', 'c' ],
+			'default'     => 'b',
+		] );
+
+		$settings->register_control( 'test_two', Control::TYPE_SELECT, [
+			'name'        => 'Select field',
+			'description' => 'A regular select input field for setting two',
+			'options'     => [
+				'a' => 'A',
+				'b' => 'B',
+				'c' => 'C'
+			],
+		] );
+
+		$settings->register_setting( 'test_three', Setting::TYPE_STRING, [
+			'name'        => 'Test Setting Three',
+			'description' => 'A third simple setting',
+			'options'     => [ 'a', 'b', 'c' ],
+			'default'     => 'a',
+		] );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -178,8 +178,6 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		] );
 
 		$setting = $settings->get_setting( $setting_id );
-		$control = $setting->get_control();
-
 		$setting->set_value( 'a' );
 
 		$request = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings/{$setting_id}" );
@@ -193,19 +191,8 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$item = $response->get_data();
 
-		$this->assertEquals( $setting->get_id(), $item['id'] );
-		$this->assertEquals( $setting->get_type(), $item['type'] );
-		$this->assertEquals( $setting->get_name(), $item['name'] );
-		$this->assertEquals( $setting->get_description(), $item['description'] );
-		$this->assertEquals( $setting->is_is_multi(), $item['is_multi'] );
-		$this->assertEquals( $setting->get_options(), $item['options'] );
-		$this->assertEquals( $setting->get_default(), $item['default'] );
-		$this->assertEquals( $setting->get_value(), $item['value'] );
-
-		$this->assertEquals( $control->get_type(), $item['control']['type'] );
-		$this->assertEquals( $control->get_name(), $item['control']['name'] );
-		$this->assertEquals( $control->get_description(), $item['control']['description'] );
-		$this->assertEquals( $control->get_options(), $item['control']['options'] );
+		$this->assert_item_matches_setting( $item, $setting );
+		$this->assert_item_matches_control( $item['control'], $setting->get_control() );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -252,25 +252,12 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		] );
 
 		$setting = $settings->get_setting( 'test' );
-		$control = $setting->get_control();
-
 		$setting->set_value( 'a' );
 
 		$item = $controller->prepare_item_for_response( $setting, null )->get_data();
 
-		$this->assertEquals( $setting->get_id(),          $item['id'] );
-		$this->assertEquals( $setting->get_type(),        $item['type'] );
-		$this->assertEquals( $setting->get_name(),        $item['name'] );
-		$this->assertEquals( $setting->get_description(), $item['description'] );
-		$this->assertEquals( $setting->is_is_multi(),     $item['is_multi'] );
-		$this->assertEquals( $setting->get_options(),     $item['options'] );
-		$this->assertEquals( $setting->get_default(),     $item['default'] );
-		$this->assertEquals( $setting->get_value(),       $item['value'] );
-
-		$this->assertEquals( $control->get_type(),        $item['control']['type'] );
-		$this->assertEquals( $control->get_name(),        $item['control']['name'] );
-		$this->assertEquals( $control->get_description(), $item['control']['description'] );
-		$this->assertEquals( $control->get_options(),     $item['control']['options'] );
+		$this->assert_item_matches_setting( $item, $setting );
+		$this->assert_item_matches_control( $item['control'], $setting->get_control() );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -79,6 +79,43 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	/** Tests *********************************************************************************************************/
 
 
+	/** @see Settings::get_items() */
+	public function test_get_items() {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+
+		$settings_objects = [
+			'test_one'   => $settings->get_setting( 'test_one' ),
+			'test_two'   => $settings->get_setting( 'test_two' ),
+			'test_three' => $settings->get_setting( 'test_three' ),
+		];
+
+		$settings_objects['test_one']->set_value( 'a' );
+
+		$request  = new WP_REST_Request( 'GET', "/wc/v3/{$settings->get_id()}/settings" );
+		$response = $controller->get_items( $request );
+
+		$this->assertTrue( $response instanceof WP_REST_Response );
+		$this->assertSame( 200, $response->get_status() );
+
+		$items = $response->get_data();
+
+		foreach ( $items as $item ) {
+
+			$setting = $settings_objects[ $item['id'] ];
+
+			$this->assert_item_matches_setting( $item, $setting );
+
+			if ( $control = $setting->get_control() ) {
+				$this->assert_item_matches_control( $item['control'], $control );
+			}
+		}
+
+		$this->assertEquals( count( $settings_objects ), count( $items ) );
+	}
+
+
 	/**
 	 * Asserts that entries in an array match the properties of a setting.
 	 *

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -28,6 +28,8 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		require_once 'woocommerce/Settings_API/Control.php';
 		require_once 'woocommerce/Settings_API/Setting.php';
 
+		$settings = $this->get_settings_instance();
+
 		$settings->register_setting( 'test_one', Setting::TYPE_STRING, [
 			'name'        => 'Test Setting One',
 			'description' => 'A simple setting',

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -135,13 +135,7 @@ class Settings extends \WP_REST_Controller {
 		$items = [];
 
 		foreach ( $this->settings->get_settings() as $setting ) {
-
-			$response = $this->prepare_item_for_response( $setting, $request );
-
-			// check that the response object has data
-			if ( $response instanceof \WP_REST_Response && $response->get_data() ) {
-				$items[] = $response->get_data();
-			}
+			$items[] = $this->prepare_setting_item( $setting, $request );
 		}
 
 		return rest_ensure_response( $items );
@@ -162,7 +156,7 @@ class Settings extends \WP_REST_Controller {
 
 		if ( $setting = $this->settings->get_setting( $setting_id ) ) {
 
-			return $this->prepare_item_for_response( $setting, $request );
+			return rest_ensure_response( $this->prepare_setting_item( $setting, $request ) );
 
 		} else {
 
@@ -211,9 +205,9 @@ class Settings extends \WP_REST_Controller {
 	 *
 	 * @param Setting $setting a setting object
 	 * @param \WP_REST_Request $request request object
-	 * @return WP_Error|WP_REST_Response
+	 * @return array
 	 */
-	public function prepare_item_for_response( $setting, $request ) {
+	public function prepare_setting_item( $setting, $request ) {
 
 		if ( $setting instanceof Setting ) {
 
@@ -243,7 +237,7 @@ class Settings extends \WP_REST_Controller {
 			$item = [];
 		}
 
-		return rest_ensure_response( $item );
+		return $item;
 	}
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -132,7 +132,19 @@ class Settings extends \WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
+		$items = [];
 
+		foreach ( $this->settings->get_settings() as $setting ) {
+
+			$response = $this->prepare_item_for_response( $setting, $request );
+
+			// check that the response object has data
+			if ( $response instanceof \WP_REST_Response && $response->get_data() ) {
+				$items[] = $response->get_data();
+			}
+		}
+
+		return rest_ensure_response( $items );
 	}
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -122,7 +122,18 @@ class Settings extends \WP_REST_Controller {
 	}
 
 
-	// TODO: get_items()
+	/**
+	 * Gets all registered settings.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_items( $request ) {
+
+
+	}
 
 
 	/**


### PR DESCRIPTION
# Summary

This PR adds the `get_items()` method to the Settings REST controller.

### Story: [CH 32772](https://app.clubhouse.io/skyverge/story/32772)
### Release: #436

## Details

I also added a couple of helper methods to assert that an item's data matches the properties of a given setting or control object. We are performing those verifications in several tests so it made sense to me to reuse the code.

## QA

- [x] Unit tests pass
- [x] Integration tests pass
