### PR TITLE
Add the REST API update_item() method

### DIFF
--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -184,6 +184,42 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/**
+	 * @see Settings::update_item()
+	 *
+	 * @param string $setting_id setting ID
+	 * @param array|bool|float|int|string $value setting value
+	 *
+	 * @dataProvider provider_test_update_item_error
+	 */
+	public function test_update_item_error( $setting_id, $value ) {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+		$request    = new WP_REST_Request( 'POST', "/wc/v3/{$settings->get_id()}/settings/{$setting_id}" );
+
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_url_params( [ 'id' => $setting_id ] );
+		$request->set_body( json_encode( [ 'value' => $value ] ) );
+
+		$response = $controller->update_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wc_rest_setting_could_not_update', $response->get_error_code() );
+		$this->assertSame( [ 'status' => 400 ], $response->get_error_data() );
+	}
+
+
+	/** @see test_update_item_error() */
+	public function provider_test_update_item_error() {
+
+		return [
+			'setting not found' => [ 'not_found', null ],
+			'invalid value'     => [ 'test_one', 1234 ],
+		];
+	}
+
+
 	/** @see Settings::prepare_setting_item() */
 	public function test_prepare_setting_item() {
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -162,6 +162,28 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Settings::update_item() */
+	public function test_update_item() {
+
+		$settings   = $this->get_settings_instance();
+		$controller = new Settings( $settings );
+
+		$setting = $settings->get_setting( 'test_one' );
+		$request = new WP_REST_Request( 'POST', "/wc/v3/{$settings->get_id()}/settings/{$setting->get_id()}" );
+
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_url_params( [ 'id' => $setting->get_id() ] );
+		$request->set_body( json_encode( [ 'value' => 'a' ] ) );
+
+		$response = $controller->update_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assert_item_matches_setting( $response->get_data(), $setting );
+	}
+
+
 	/** @see Settings::prepare_setting_item() */
 	public function test_prepare_setting_item() {
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -180,7 +180,12 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( 200, $response->get_status() );
 
-		$this->assert_item_matches_setting( $response->get_data(), $setting );
+		$data = $response->get_data();
+
+		$this->assert_item_matches_setting( $data, $setting );
+
+		$this->assertEquals( 'a', $data['value'] );
+		$this->assertEquals( 'a', get_option( $settings->get_option_name_prefix() . '_' . $setting->get_id() ) );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -194,10 +194,11 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @param string $setting_id setting ID
 	 * @param array|bool|float|int|string $value setting value
+	 * @param int $status WP_Error status
 	 *
 	 * @dataProvider provider_test_update_item_error
 	 */
-	public function test_update_item_error( $setting_id, $value ) {
+	public function test_update_item_error( $setting_id, $value, $status ) {
 
 		$settings   = $this->get_settings_instance();
 		$controller = new Settings( $settings );
@@ -211,7 +212,7 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'wc_rest_setting_could_not_update', $response->get_error_code() );
-		$this->assertSame( [ 'status' => 400 ], $response->get_error_data() );
+		$this->assertSame( [ 'status' => $status ], $response->get_error_data() );
 	}
 
 
@@ -219,8 +220,9 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	public function provider_test_update_item_error() {
 
 		return [
-			'setting not found' => [ 'not_found', null ],
-			'invalid value'     => [ 'test_one', 1234 ],
+			'setting not found'    => [ 'not_found', null, 404 ],
+			'invalid value type'   => [ 'test_one', 1234, 400 ],
+			'value not in options' => [ 'test_one', 'x', 400 ],
 		];
 	}
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -312,7 +312,7 @@ abstract class Abstract_Settings {
 		$setting = $this->get_setting( $setting_id );
 
 		if ( ! $setting ) {
-			throw new Framework\SV_WC_Plugin_Exception( "Setting {$setting_id} does not exist" );
+			throw new Framework\SV_WC_Plugin_Exception( "Setting {$setting_id} does not exist", 404 );
 		}
 
 		// performs the validations and updates the value

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -356,7 +356,7 @@ class Setting {
 
 		if ( ! $this->validate_value( $value ) ) {
 
-			throw new Framework\SV_WC_Plugin_Exception( "Setting value for setting {$this->id} is not valid for the setting type {$this->type}" );
+			throw new Framework\SV_WC_Plugin_Exception( "Setting value for setting {$this->id} is not valid for the setting type {$this->type}", 400 );
 
 		} elseif ( ! empty( $this->options ) && ! in_array( $value, $this->options ) ) {
 
@@ -364,7 +364,7 @@ class Setting {
 				'Setting value for setting %s must be one of %s',
 				$this->id,
 				Framework\SV_WC_Helper::list_array_items( $this->options, 'or' )
-			) );
+			), 400 );
 
 		} else {
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -204,6 +204,19 @@ class Settings extends \WP_REST_Controller {
 	 */
 	public function update_item( $request ) {
 
+		try {
+
+		} catch ( \Exception $e ) {
+
+			return new \WP_Error(
+				'wc_rest_setting_could_not_update',
+				sprintf(
+					/* Placeholders: %s - error message */
+					__( 'Could not update setting: %s', 'woocommerce-plugin-framework' ),
+					$e->getMessage()
+				)
+			);
+		}
 	}
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -212,7 +212,7 @@ class Settings extends \WP_REST_Controller {
 			// throws an exception if the setting doesn't exist or the value is not valid
 			$this->settings->update_value( $setting_id, $value );
 
-			return $this->prepare_item_for_response( $this->settings->get_setting( $setting_id ), $request );
+			return rest_ensure_response( $this->prepare_setting_item( $this->settings->get_setting( $setting_id ), $request ) );
 
 		} catch ( \Exception $e ) {
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -222,7 +222,8 @@ class Settings extends \WP_REST_Controller {
 					/* Placeholders: %s - error message */
 					__( 'Could not update setting: %s', 'woocommerce-plugin-framework' ),
 					$e->getMessage()
-				)
+				),
+				[ 'status' => 400 ]
 			);
 		}
 	}

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -194,7 +194,17 @@ class Settings extends \WP_REST_Controller {
 	}
 
 
-	// TODO: update_item()
+	/**
+	 * Updates a single setting.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param \WP_REST_Request $request request object
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+
+	}
 
 
 	/** Utility methods ***********************************************************************************************/

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -201,6 +201,8 @@ class Settings extends \WP_REST_Controller {
 
 
 	/**
+	 * Prepares the item for the REST response.
+	 *
 	 * @since x.y.z
 	 *
 	 * @param Setting $setting a setting object

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -206,6 +206,14 @@ class Settings extends \WP_REST_Controller {
 
 		try {
 
+			$setting_id = $request->get_param( 'id' );
+			$value      = $request->get_param( 'value' );
+
+			// throws an exception if the setting doesn't exist
+			$this->settings->update_value( $setting_id, $value );
+
+			return $this->prepare_item_for_response( $this->settings->get_setting( $setting_id ), $request );
+
 		} catch ( \Exception $e ) {
 
 			return new \WP_Error(

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -209,7 +209,7 @@ class Settings extends \WP_REST_Controller {
 			$setting_id = $request->get_param( 'id' );
 			$value      = $request->get_param( 'value' );
 
-			// throws an exception if the setting doesn't exist
+			// throws an exception if the setting doesn't exist or the value is not valid
 			$this->settings->update_value( $setting_id, $value );
 
 			return $this->prepare_item_for_response( $this->settings->get_setting( $setting_id ), $request );

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -223,7 +223,7 @@ class Settings extends \WP_REST_Controller {
 					__( 'Could not update setting: %s', 'woocommerce-plugin-framework' ),
 					$e->getMessage()
 				),
-				[ 'status' => 400 ]
+				[ 'status' => $e->getCode() ?: 400 ]
 			);
 		}
 	}


### PR DESCRIPTION
# Summary

This PR adds the `update_item()` method to the Settings REST controller class.

### Story: [CH 32778](https://app.clubhouse.io/skyverge/story/32778)
### Release: #436 

## Details

The method enhances the `settings/{setting_id}` endpoint to allow users to update the value of the setting. Since we perform type validation on `Setting::update_value()`, updating the value of a setting only works if the body of the request is a JSON object with the `value` property set to the new value using the appropriate type for the setting.

## QA

- [x] Unit tests pass
- [x] Integration tests pass
