### PR TITLE
Add Settings::get_item_schema()

### DIFF
--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -319,6 +319,23 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Settings::get_item_schema() */
+	public function test_get_item_schema_additional_fields() {
+
+		register_rest_field( "{$this->get_settings_instance()->get_id()}_setting", 'test', [
+			'schema' => [
+				'description' => 'A test field.',
+				'type'        => 'string',
+			],
+		] );
+
+		$controller = new Settings( $this->get_settings_instance() );
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'test', $schema['properties'] );
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -273,6 +273,52 @@ class SettingsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 
+	/** @see Settings::get_item_schema() */
+	public function test_get_item_schema() {
+
+		$controller = new Settings( $this->get_settings_instance() );
+
+		$setting_schema     = $controller->get_item_schema();
+		$setting_properties = [
+			'id',
+			'type',
+			'name',
+			'description',
+			'is_multi',
+			'options',
+			'default',
+			'value',
+			'control',
+		];
+
+		foreach ( $setting_properties as $property ) {
+
+			$this->assertArrayHasKey( $property, $setting_schema['properties'] );
+
+			// all Setting properties but 'value' should be marked as readonly
+			if ( 'value' === $property ) {
+				$this->assertArrayNotHasKey( 'readonly', $setting_schema['properties'][ $property ] );
+			} else {
+				$this->assertTrue( $setting_schema['properties'][ $property ]['readonly'] );
+			}
+		}
+
+		$control_schema     = $setting_schema['properties']['control'];
+		$control_properties = [
+			'type',
+			'name',
+			'description',
+			'options',
+		];
+
+		foreach ( $control_properties as $property ) {
+
+			$this->assertArrayHasKey( $property, $control_schema['properties'] );
+			$this->assertTrue( $control_schema['properties'][ $property ]['readonly'] );
+		}
+	}
+
+
 	/** Helper methods ************************************************************************************************/
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -360,7 +360,7 @@ class Settings extends \WP_REST_Controller {
 							'readonly'    => true,
 						],
 						'options'     => [
-							'description' => __( 'A list of key/value pairs defining the display value of each setting option.  The keys should match the options defined in the base setting for validation.', 'woocommerce-plugin-framework' ),
+							'description' => __( 'A list of key/value pairs defining the display value of each setting option. The keys should match the options defined in the base setting for validation.', 'woocommerce-plugin-framework' ),
 							'type'        => 'array',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -339,6 +339,33 @@ class Settings extends \WP_REST_Controller {
 				'control'     => [
 					'description' => __( 'Optional object that defines how the user will interact with and update the setting.', 'woocommerce-memberships' ),
 					'type'        => 'object',
+					'properties'  => [
+						'type'        => [
+							'description' => __( 'The type of the control.', 'woocommerce-plugin-framework' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'enum'        => $this->settings->get_control_types(),
+							'readonly'    => true,
+						],
+						'name'        => [
+							'description' => __( "The name of the control. Inherits the setting's name.", 'woocommerce-plugin-framework' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'description' => [
+							'description' => __( "The description of the control. Inherits the setting's description.", 'woocommerce-plugin-framework' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'options'     => [
+							'description' => __( 'A list of key/value pairs defining the display value of each setting option.  The keys should match the options defined in the base setting for validation.', 'woocommerce-plugin-framework' ),
+							'type'        => 'array',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
 					'context'     => [ 'view', 'edit' ],
 					'readonly'    => true,
 				],

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -274,6 +274,7 @@ class Settings extends \WP_REST_Controller {
 		return $item;
 	}
 
+	
 	/**
 	 * Retrieves the item's schema, conforming to JSON Schema.
 	 *

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -274,8 +274,19 @@ class Settings extends \WP_REST_Controller {
 		return $item;
 	}
 
+	/**
+	 * Retrieves the item's schema, conforming to JSON Schema.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
 
-	// TODO: get_item_schema()
+		$schema = [];
+
+		return $this->add_additional_fields_schema( $schema );
+	}
 
 
 }

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -283,7 +283,67 @@ class Settings extends \WP_REST_Controller {
 	 */
 	public function get_item_schema() {
 
-		$schema = [];
+		$schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => "{$this->settings->get_id()}_setting",
+			'type'       => 'object',
+			'properties' => [
+				'id'          => [
+					'description' => __( 'Unique identifier of the setting.', 'woocommerce-plugin-framework' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'type'        => [
+					'description' => __( 'The type of the setting.', 'woocommerce-plugin-framework' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'enum'        => $this->settings->get_setting_types(),
+					'readonly'    => true,
+				],
+				'name'        => [
+					'description' => __( 'The name of the setting.', 'woocommerce-plugin-framework' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'description' => [
+					'description' => __( 'The description of the setting. It may or may not be used for display.', 'woocommerce-plugin-framework' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'is_multi'    => [
+					'description' => __( 'Whether the setting stores an array of values or a single value.', 'woocommerce-plugin-framework' ),
+					'type'        => 'boolean',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'options'     => [
+					'description' => __( 'A list of valid options, used for validation before storing the value.', 'woocommerce-plugin-framework' ),
+					'type'        => 'array',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'default'     => [
+					'description' => __( 'Optional default value for the setting.', 'woocommerce-plugin-framework' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'value'       => [
+					'description' => __( 'The value of the setting.', 'woocommerce-plugin-framework' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+				],
+				'control'     => [
+					'description' => __( 'Optional object that defines how the user will interact with and update the setting.', 'woocommerce-memberships' ),
+					'type'        => 'object',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+			],
+		];
 
 		return $this->add_additional_fields_schema( $schema );
 	}


### PR DESCRIPTION
# Summary

This PR adds the `get_item_schema()` method to the Settings REST controller class.

### Story: [CH 33831](https://app.clubhouse.io/skyverge/story/33831)
### Release: #436

## QA

- [x] Unite tests pass
- [x] Integration tests pass

**Optional:** try issuing `OPTIONS` requests to the `/settings/` and `/settings/{setting_id}` endpoints to see the schema being used.