### PR TITLE
Default to allowing all currencies for Apple Pay [6]

### DIFF
--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -313,9 +313,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 		}
 
 		// Currency notice
-		if ( ! in_array( get_woocommerce_currency(), $this->handler->get_accepted_currencies(), true ) ) {
+		$accepted_currencies = $this->handler->get_accepted_currencies();
 
-			$accepted_currencies = $this->handler->get_accepted_currencies();
+		if ( ! empty( $accepted_currencies ) && ! in_array( get_woocommerce_currency(), $accepted_currencies, true ) ) {
 
 			$errors[] = sprintf(
 				/* translators: Placeholders: %1$s - plugin name, %2$s - a currency/comma-separated list of currencies, %3$s - <a> tag, %4$s - </a> tag */

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -827,7 +827,12 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 
 		$is_available = wc_site_is_https() && $this->is_configured();
 
-		$is_available = $is_available && in_array( get_woocommerce_currency(), $this->get_accepted_currencies(), true );
+		$accepted_currencies = $this->get_accepted_currencies();
+
+		if ( ! empty( $accepted_currencies ) ) {
+
+			$is_available = $is_available && in_array( get_woocommerce_currency(), $accepted_currencies, true );
+		}
 
 		/**
 		 * Filters whether Apple Pay should be made available to users.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1055,13 +1055,15 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/**
 	 * Gets the currencies supported by Apple Pay.
 	 *
+	 * This method should be overwritten by any gateway that needs to restrict the supported currencies.
+	 *
 	 * @since 4.7.0
 	 *
 	 * @return array
 	 */
 	public function get_apple_pay_currencies() {
 
-		return array( 'USD' );
+		return [];
 	}
 
 


### PR DESCRIPTION
# Summary

This PR contains changes to stop restricting Apple Pay supported currencies for plugins by default.

### Story: [CH 32735](https://app.clubhouse.io/skyverge/story/32735/default-to-allowing-all-currencies-for-apple-pay-6)
### Release: #471 

## UI Changes

None.

## QA

### Setup

- Authorize.Net is configured to use Lightbox as the Payment form type
- Apple Pay is set up (a tricky thing to do, I am using Will's credentials and domain) 
- Authorize.Net gateway is using this branch of the Framework (update the version in `composer.json` to `dev-ch32735/apple-pay-all-currencies` and run `composer update skyverge/wc-plugin-framework`)
- Apple Pay is activated for Authorize.Net using this code snippet:
```
add_filter( 'wc_payment_gateway_authorize_net_cim_activate_apple_pay', '__return_true' );
```
- No other payment gateways are active, just in case
- WC Settings:
    - Currency `USD`
    - Allow Apple Pay on: Single products, Cart and Checkout

### Plugin without restricted currencies

1. Confirm your currency is set to `USD`
1. On Safari, navigate to a product page
    - [x] Apple Pay is available 
1. Navigate to the Apple Pay settings, as admin
    - [x] A notice is not displayed 
1. Switch your currency to another currency
1. On Safari, navigate to a product page
    - [x] Apple Pay is available 
1. Navigate to the Apple Pay settings, as admin
    - [x] A notice is not displayed 

### Plugin with restricted currencies

1. Implement `WC_Gateway_Authorize_Net_CIM_Credit_Card::get_apple_pay_currencies` to accept only `USD`:
```
public function get_apple_pay_currencies() {

    return [ 'USD' ];
}
```
1. Confirm your currency is set to `USD`
1. On Safari, navigate to a product page
    - [x] Apple Pay is available 
1. Navigate to the Apple Pay settings, as admin
    - [x] A notice is not displayed 
1. Switch your currency to another currency
1. On Safari, navigate to a product page
    - [x] Apple Pay is **not** available 
1. Navigate to the Apple Pay settings, as admin
    - [x] A notice is displayed - I confirmed `add_admin_notice` is called correctly, but I wasn't able to see this notice, not on this branch and not on `master`, we may have an unrelated problem with notices we need to look into - please let me know if you can see it or not

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version