### PR TITLE
Add new Frontend\Script_Handler abstract class

### DIFF
--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -38,6 +38,11 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Frontend
  */
 abstract class Script_Handler {
 
+
+	/** @var string JS handler base class name, without the FW version */
+	protected $js_handler_base_class_name = '';
+
+
 }
 
 endif;

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -52,6 +52,7 @@ abstract class Script_Handler {
 	 */
 	protected function get_js_handler_class_name() {
 
+		return sprintf( '%s_5_6_1', $this->js_handler_base_class_name );
 	}
 
 

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -43,6 +43,18 @@ abstract class Script_Handler {
 	protected $js_handler_base_class_name = '';
 
 
+	/**
+	 * Returns the JS handler class name.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	protected function get_js_handler_class_name() {
+
+	}
+
+
 }
 
 endif;

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\Frontend;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Frontend\\Script_Handler' ) ) :
+
+
+/**
+ * Script Handler Abstract Class
+ *
+ * Handles initializing the payment registered JavaScripts
+ *
+ * @since x.y.z
+ */
+abstract class Script_Handler {
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -46,6 +46,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	/** @var SV_WC_Payment_Gateway $gateway the gateway instance */
 	protected $gateway;
 
+	/** @var string JS handler base class name, without the FW version */
+	protected $js_handler_base_class_name = 'SV_WC_Apple_Pay_Handler';
+
 
 	/**
 	 * Constructs the class.

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -34,7 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\SV_WC_Pa
  *
  * @since 4.7.0
  */
-class SV_WC_Payment_Gateway_Apple_Pay_Frontend {
+class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 
 
 	/** @var SV_WC_Payment_Gateway_Plugin $plugin the gateway plugin instance */

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -155,7 +155,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 		}
 
 		if ( ! $handler_name ) {
-			$handler_name = $this->get_js_handler_name();
+			$handler_name = parent::get_js_handler_class_name();
 		}
 
 		$args = array_merge( $args, $this->get_js_handler_params() );
@@ -177,12 +177,15 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	 * Concrete implementations can override this with their own handler.
 	 *
 	 * @since 5.6.0
+	 * @deprecated x.y.z
 	 *
 	 * @return string
 	 */
 	protected function get_js_handler_name() {
 
-		return 'SV_WC_Apple_Pay_Handler_5_6_1';
+		wc_deprecated_function( __METHOD__, 'x.y.z', parent::get_js_handler_class_name() );
+
+		return parent::get_js_handler_class_name();
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -186,7 +186,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	 */
 	protected function get_js_handler_name() {
 
-		wc_deprecated_function( __METHOD__, 'x.y.z', parent::get_js_handler_class_name() );
+		wc_deprecated_function( __METHOD__, 'x.y.z', __CLASS__ . '::get_js_handler_class_name()' );
 
 		return parent::get_js_handler_class_name();
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -37,7 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\SV_WC_Pa
  *
  * @since 4.0.0
  */
-class SV_WC_Payment_Gateway_My_Payment_Methods {
+class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 
 	/** @var SV_WC_Payment_Gateway_Plugin */

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -55,6 +55,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	/** @var bool true if there are tokens */
 	protected $has_tokens;
 
+	/** @var string JS handler base class name, without the FW version */
+	protected $js_handler_base_class_name = 'SV_WC_Payment_Methods_Handler';
+
 
 	/**
 	 * Setup Class

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -267,7 +267,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	 */
 	protected function get_js_handler_class() {
 
-		wc_deprecated_function( __METHOD__, 'x.y.z', parent::get_js_handler_class_name() );
+		wc_deprecated_function( __METHOD__, 'x.y.z', __CLASS__ . '::get_js_handler_class_name()' );
 
 		return parent::get_js_handler_class_name();
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -245,7 +245,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 			wc_enqueue_js( sprintf(
 				'window.wc_%1$s_payment_methods_handler = new %2$s( %3$s );',
 				esc_js( $this->get_plugin()->get_id() ),
-				esc_js( $this->get_js_handler_class() ),
+				esc_js( parent::get_js_handler_class_name() ),
 				json_encode( $args )
 			) );
 		}
@@ -258,12 +258,15 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	 * Plugins can override this for their own JS implementations.
 	 *
 	 * @since 5.1.0
+	 * @deprecated x.y.z
 	 *
 	 * @return string
 	 */
 	protected function get_js_handler_class() {
 
-		return 'SV_WC_Payment_Methods_Handler_5_6_1';
+		wc_deprecated_function( __METHOD__, 'x.y.z', parent::get_js_handler_class_name() );
+
+		return parent::get_js_handler_class_name();
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1011,7 +1011,12 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 		 */
 		$args = apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_js_args', $args, $this );
 
-		wc_enqueue_js( sprintf( 'window.wc_%s_payment_form_handler = new SV_WC_Payment_Form_Handler_5_6_1( %s );', esc_js( $this->get_gateway()->get_id() ), json_encode( $args ) ) );
+		wc_enqueue_js( sprintf(
+			'window.wc_%s_payment_form_handler = new %s( %s );',
+			esc_js( $this->get_gateway()->get_id() ),
+			parent::get_js_handler_class_name(),
+			json_encode( $args )
+		) );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -48,6 +48,9 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	/** @var bool default to show new payment method form */
 	protected $default_new_payment_method = true;
 
+	/** @var string JS handler base class name, without the FW version */
+	protected $js_handler_base_class_name = 'SV_WC_Payment_Form_Handler';
+
 
 	/**
 	 * Sets up class.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -36,7 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\SV_WC_Pa
  *
  * @since 4.0.0
  */
-class SV_WC_Payment_Gateway_Payment_Form {
+class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 
 
 	/** @var \SV_WC_Payment_Gateway gateway for this payment form */

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -282,6 +282,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		// exceptions
 		require_once( $payment_gateway_framework_path . '/exceptions/class-sv-wc-payment-gateway-exception.php' );
 
+		// frontend
+		require_once( $payment_gateway_framework_path . '/Frontend/Script_Handler.php' );
+
 		// gateway
 		require_once( $payment_gateway_framework_path . '/class-sv-wc-payment-gateway.php' );
 		require_once( $payment_gateway_framework_path . '/class-sv-wc-payment-gateway-direct.php' );
@@ -314,9 +317,6 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		require_once( $payment_gateway_framework_path . '/admin/class-sv-wc-payment-gateway-admin-order.php' );
 		require_once( $payment_gateway_framework_path . '/admin/class-sv-wc-payment-gateway-admin-user-handler.php' );
 		require_once( $payment_gateway_framework_path . '/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php' );
-
-		// frontend
-		require_once( $payment_gateway_framework_path . '/Frontend/Script_Handler.php' );
 
 		// integrations
 		require_once( $payment_gateway_framework_path . '/integrations/abstract-sv-wc-payment-gateway-integration.php' );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -315,6 +315,8 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		require_once( $payment_gateway_framework_path . '/admin/class-sv-wc-payment-gateway-admin-user-handler.php' );
 		require_once( $payment_gateway_framework_path . '/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php' );
 
+		// frontend
+		require_once( $payment_gateway_framework_path . '/Frontend/Script_Handler.php' );
 
 		// integrations
 		require_once( $payment_gateway_framework_path . '/integrations/abstract-sv-wc-payment-gateway-integration.php' );


### PR DESCRIPTION
# Summary

This PR adds the `Script_Handler` abstract class.

### Story: [CH 33788](https://app.clubhouse.io/skyverge/story/33788/add-new-frontend-script-handler-abstract-class)
### Release: #470 

## QA

### Setup

- Authorize.Net gateway is using this branch of the Framework
- Update the FW namespace in Authorize.Net if needed
- Update `wc-authorize-net-cim.coffee` so that `WC_Authorize_Net_Payment_Form_Handler` extends `SV_WC_Payment_Form_Handler_5_6_1`
- Compile your scripts (`npx sake scripts`)

### Payment Form

1. Configure Authorize.Net to use `Inline` as the `Payment form type`
1. Add a product to the cart and proceed to Checkout
    - [x] There are no JS errors
    - [x] The JS handler is loaded correctly (check by typing `window.SV_WC_Payment_Form_Handler_5_6_1` in your Console)

### Payment Methods

1. Navigate to the Payment methods page
    - [x] There are no JS errors
    - [x] The JS handler is loaded correctly (check by typing `window.SV_WC_Payment_Methods_Handler_5_6_1` in your Console)

### Apple Pay

1. Set up Apple Pay (a tricky thing to do, I am using Will's credentials and domain) 
1. Activate Apple Pay for Authorize.Net using this code snippet:
```
add_filter( 'wc_payment_gateway_authorize_net_cim_activate_apple_pay', '__return_true' );
```
1. Configure Authorize.Net to use `Lightbox` as the `Payment form type`
1. Add a product to the cart and proceed to Checkout
    - [x] There are no JS errors
    - [x] The JS handler is loaded correctly (check by typing `window.SV_WC_Apple_Pay_Handler_5_6_1` in your Console)