### PR TITLE
Add public helper methods to detect whether scripts optimization plugin may be active

### DIFF
--- a/tests/integration/DependenciesTest.php
+++ b/tests/integration/DependenciesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Tests for the SV_WC_Plugin_Dependencies class.
+ *
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Dependencies
+ */
+class DependenciesTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+	/** @var \SkyVerge\WooCommerce\TestPlugin\Plugin instance */
+	protected $plugin;
+
+
+	protected function _before() {
+
+
+	}
+
+
+	protected function _after() {
+
+
+	}
+
+
+	/** Tests *********************************************************************************************************/
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Dependencies::get_active_scripts_optimization_plugins
+	 */
+	public function test_get_active_scripts_optimization_plugins() {
+
+		$this->assertEquals( [], $this->get_plugin()->get_dependency_handler()->get_active_scripts_optimization_plugins() );
+	}
+
+
+	/** Helper methods ************************************************************************************************/
+
+
+	/**
+	 * Gets the plugin instance.
+	 *
+	 * @return \SkyVerge\WooCommerce\TestPlugin\Plugin
+	 */
+	protected function get_plugin() {
+
+		if ( null === $this->plugin ) {
+			$this->plugin = sv_wc_test_plugin();
+		}
+
+		return $this->plugin;
+	}
+
+
+}

--- a/tests/integration/DependenciesTest.php
+++ b/tests/integration/DependenciesTest.php
@@ -31,11 +31,20 @@ class DependenciesTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Dependencies::get_active_scripts_optimization_plugins
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Dependencies::get_active_scripts_optimization_plugins()
 	 */
 	public function test_get_active_scripts_optimization_plugins() {
 
 		$this->assertEquals( [], $this->get_plugin()->get_dependency_handler()->get_active_scripts_optimization_plugins() );
+	}
+
+
+	/**
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Dependencies::is_scripts_optimization_plugin_active()
+	 */
+	public function test_is_scripts_optimization_plugin_active() {
+
+		$this->assertEquals( false, $this->get_plugin()->get_dependency_handler()->is_scripts_optimization_plugin_active() );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -312,6 +312,42 @@ class SV_WC_Plugin_Dependencies {
 	}
 
 
+	/**
+	 * Returns the active scripts optimization plugins.
+	 *
+	 * Returns a key-value array where the key contains the plugin file identifier and the value is the name of the plugin.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	public function get_active_scripts_optimization_plugins() {
+
+		// optimization plugins to look for, indexed by the plugin file identifier
+		$plugins = [
+			'async-javascript.php' => 'Async JavaScript',
+			'autoptimize.php'      => 'Autoptimize',
+			'wp-hummingbird.php'   => 'Hummingbird',
+			'sg-optimizer.php'     => 'SG Optimizer',
+			'w3-total-cache.php'   => 'W3 Total Cache',
+			'wpFastestCache.php'   => 'WP Fastest Cache',
+			'wp-rocket.php'        => 'WP Rocket',
+		];
+
+		$active_plugins = [];
+
+		foreach ( $plugins as $filename => $plugin_name ) {
+
+			if ( $this->get_plugin()->is_plugin_active( $filename ) ) {
+
+				$active_plugins[ $filename ] = $plugin_name;
+			}
+		}
+
+		return $active_plugins;
+	}
+
+
 	/** Getter methods ********************************************************/
 
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -348,6 +348,19 @@ class SV_WC_Plugin_Dependencies {
 	}
 
 
+	/**
+	 * Returns true if any of the known scripts optimization plugins is active.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	public function is_scripts_optimization_plugin_active() {
+
+		return ! empty( $this->get_active_scripts_optimization_plugins() );
+	}
+
+
 	/** Getter methods ********************************************************/
 
 


### PR DESCRIPTION
# Summary

This PR adds the public methods to allow plugins to display notices if scripts optimization plugins are active.

### Story: [CH 33863](https://app.clubhouse.io/skyverge/story/33863/add-public-helper-methods-to-detect-whether-scripts-optimization-plugin-may-be-active)
### Release: #470 

## QA

- [x] Integration tests pass

### Setup

- Configure your plugin to use this branch of the Framework
- Update the FW namespace in the plugin if needed
- Install and activate one of the scripts optimization plugins listed on the story

### Payment Form

1. Add a snippet to add an admin notice with the active scripts optimization plugins, replacing the plugin loader method with yours:
```
add_action( 'init', function () {

	$plugin = wc_authorize_net_cim();
	
	if ( $plugin->get_dependency_handler()->is_scripts_optimization_plugin_active() ) {
	
		$plugin->get_admin_notice_handler()->add_admin_notice(
		
			sprintf( 'Active scripts optimization plugin(s): %s.',
				\SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Helper::list_array_items( $plugin->get_dependency_handler()->get_active_scripts_optimization_plugins() )
			), 'script-optimization-notice' );
	}
} );
```
1. Navigate to any page so that the snippet is executed
    - [x] The list of plugins is displayed according to the ones you have active