### PR TITLE
Add try/catch when initializing payment gateway JS handlers

### DIFF
--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -166,7 +166,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 		ob_start();
 
 		$load_function = 'load_' . esc_js( $this->get_gateway()->get_id() ) . '_apple_pay_handler';
-		$loaded_event  = esc_js( $this->get_gateway()->get_id() ) . '_apple_pay_handler_loaded';
+		$loaded_event  = strtolower( $handler_name ) . '_loaded';
 
 		?>
 		function <?php echo esc_js( $load_function ) ?>() {

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -165,7 +165,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 
 		ob_start();
 
-		$load_function = 'load_' . esc_js( $this->get_gateway()->get_id() ) . '_apple_pay_handler';
+		$load_function = 'load_' . $this->get_gateway()->get_id() . '_apple_pay_handler';
 		$loaded_event  = strtolower( $handler_name ) . '_loaded';
 
 		?>

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -163,14 +163,30 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 
 		$args = array_merge( $args, $this->get_js_handler_params() );
 
-		wc_enqueue_js(
-			sprintf(
-				'window.%1$s = new %2$s(%3$s); window.%1$s.init()',
-				esc_attr( $object_name ),
-				esc_attr( $handler_name ),
-				json_encode( $args )
-			)
-		);
+		ob_start();
+
+		$load_function = 'load_' . esc_js( $this->get_gateway()->get_id() ) . '_apple_pay_handler';
+		$loaded_event  = esc_js( $this->get_gateway()->get_id() ) . '_apple_pay_handler_loaded';
+
+		?>
+		function <?php echo esc_js( $load_function ) ?>() {
+
+			window.<?php echo esc_js( $object_name ); ?> = new <?php echo esc_js( $handler_name ); ?>( <?php echo json_encode( $args ); ?> );
+			window.<?php echo esc_js( $object_name ); ?>.init();
+		}
+
+		try {
+			if ( 'undefined' !== typeof <?php echo esc_js( $handler_name ); ?> ) {
+				<?php echo esc_js( $load_function ); ?>();
+			} else {
+				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+			}
+		} catch( err ) {
+			window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+		}
+		<?php
+
+		wc_enqueue_js( ob_get_clean() );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -221,7 +221,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 		if ( $this->has_tokens ) {
 
-			$args = $this->get_js_args();
+			$args = $this->get_js_handler_params();
 
 			/**
 			 * Filters the payment gateway payment methods JavaScript args.
@@ -271,7 +271,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	 *
 	 * @return array
 	 */
-	protected function get_js_args() {
+	protected function get_js_handler_params() {
 
 		$args = [
 			'id'              => $this->get_plugin()->get_id(),

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -235,18 +235,19 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 			ob_start();
 
+			$handler_name  = $this->get_js_handler_class_name();
 			$window_object = 'wc_' . esc_js( $this->get_plugin()->get_id() ) . '_payment_methods_handler';
 			$load_function = 'load_' . esc_js( $this->get_plugin()->get_id() ) . '_payment_methods_handler';
-			$loaded_event  = strtolower( $this->get_js_handler_class_name() ) . '_loaded';
+			$loaded_event  = strtolower( $handler_name ) . '_loaded';
 
 			?>
 			function <?php echo esc_js( $load_function ) ?>() {
 
-				window.<?php echo esc_js( $window_object ); ?> = new <?php echo esc_js( $this->get_js_handler_class_name() ); ?>( <?php echo json_encode( $args ); ?> );
+				window.<?php echo esc_js( $window_object ); ?> = new <?php echo esc_js( $handler_name ); ?>( <?php echo json_encode( $args ); ?> );
 			}
 
 			try {
-				if ( 'undefined' !== typeof <?php echo esc_js( $this->get_js_handler_class_name() ); ?> ) {
+				if ( 'undefined' !== typeof <?php echo esc_js( $handler_name ); ?> ) {
 					<?php echo esc_js( $load_function ); ?>();
 				} else {
 					window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -221,19 +221,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 		if ( $this->has_tokens ) {
 
-			$args = array(
-				'id'              => $this->get_plugin()->get_id(),
-				'slug'            => $this->get_plugin()->get_id_dasherized(),
-				'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
-				'ajax_url'        => admin_url( 'admin-ajax.php' ),
-				'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
-				'i18n'            => array(
-					'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
-					'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
-					'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
-					'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
-				),
-			);
+			$args = $this->get_js_args();
 
 			/**
 			 * Filters the payment gateway payment methods JavaScript args.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -237,7 +237,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 			$window_object = 'wc_' . esc_js( $this->get_plugin()->get_id() ) . '_payment_methods_handler';
 			$load_function = 'load_' . esc_js( $this->get_plugin()->get_id() ) . '_payment_methods_handler';
-			$loaded_event  = esc_js( $this->get_plugin()->get_id() ) . '_payment_methods_handler_loaded';
+			$loaded_event  = strtolower( $this->get_js_handler_class_name() ) . '_loaded';
 
 			?>
 			function <?php echo esc_js( $load_function ) ?>() {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -256,6 +256,36 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 
 	/**
+	 * Gets the JS args for the payment methods handler.
+	 *
+	 * Payment gateways can overwrite this method to define specific args.
+	 * render_js() will apply filters to the returned array of args.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	protected function get_js_args() {
+
+		$args = [
+			'id'              => $this->get_plugin()->get_id(),
+			'slug'            => $this->get_plugin()->get_id_dasherized(),
+			'has_core_tokens' => (bool) wc_get_customer_saved_methods_list( get_current_user_id() ),
+			'ajax_url'        => admin_url( 'admin-ajax.php' ),
+			'ajax_nonce'      => wp_create_nonce( 'wc_' . $this->get_plugin()->get_id() . '_save_payment_method' ),
+			'i18n'            => [
+				'edit_button'   => esc_html__( 'Edit', 'woocommerce-plugin-framework' ),
+				'cancel_button' => esc_html__( 'Cancel', 'woocommerce-plugin-framework' ),
+				'save_error'    => esc_html__( 'Oops, there was an error updating your payment method. Please try again.', 'woocommerce-plugin-framework' ),
+				'delete_ays'    => esc_html__( 'Are you sure you want to delete this payment method?', 'woocommerce-plugin-framework' ),
+			],
+		];
+
+		return $args;
+	}
+
+
+	/**
 	 * Gets the JS handler class name.
 	 *
 	 * Plugins can override this for their own JS implementations.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -236,8 +236,8 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 			ob_start();
 
 			$handler_name  = $this->get_js_handler_class_name();
-			$window_object = 'wc_' . esc_js( $this->get_plugin()->get_id() ) . '_payment_methods_handler';
-			$load_function = 'load_' . esc_js( $this->get_plugin()->get_id() ) . '_payment_methods_handler';
+			$window_object = 'wc_' . $this->get_plugin()->get_id() . '_payment_methods_handler';
+			$load_function = 'load_' . $this->get_plugin()->get_id() . '_payment_methods_handler';
 			$loaded_event  = strtolower( $handler_name ) . '_loaded';
 
 			?>

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1002,20 +1002,21 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 
 		ob_start();
 
+		$handler_name  = $this->get_js_handler_class_name();
 		$window_object = 'wc_' . esc_js( $this->get_gateway()->get_id() ) . '_payment_form_handler';
 		$load_function = 'load_' . esc_js( $this->get_gateway()->get_id() ) . '_payment_form_handler';
-		$loaded_event  = strtolower( $this->get_js_handler_class_name() ) . '_loaded';
+		$loaded_event  = strtolower( $handler_name ) . '_loaded';
 
 		?>
 		function <?php echo esc_js( $load_function ) ?>() {
 
-			window.<?php echo esc_js( $window_object ); ?> = new <?php echo esc_js( $this->get_js_handler_class_name() ); ?>( <?php echo json_encode( $args ); ?> );
+			window.<?php echo esc_js( $window_object ); ?> = new <?php echo esc_js( $handler_name ); ?>( <?php echo json_encode( $args ); ?> );
 
 			window.jQuery( document.body ).trigger( 'update_checkout' );
 		}
 
 		try {
-			if ( 'undefined' !== typeof <?php echo esc_js( $this->get_js_handler_class_name() ); ?> ) {
+			if ( 'undefined' !== typeof <?php echo esc_js( $handler_name ); ?> ) {
 				<?php echo esc_js( $load_function ); ?>();
 			} else {
 				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1004,7 +1004,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 
 		$window_object = 'wc_' . esc_js( $this->get_gateway()->get_id() ) . '_payment_form_handler';
 		$load_function = 'load_' . esc_js( $this->get_gateway()->get_id() ) . '_payment_form_handler';
-		$loaded_event  = esc_js( $this->get_gateway()->get_id() ) . '_payment_form_handler_loaded';
+		$loaded_event  = strtolower( $this->get_js_handler_class_name() ) . '_loaded';
 
 		?>
 		function <?php echo esc_js( $load_function ) ?>() {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1003,8 +1003,8 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 		ob_start();
 
 		$handler_name  = $this->get_js_handler_class_name();
-		$window_object = 'wc_' . esc_js( $this->get_gateway()->get_id() ) . '_payment_form_handler';
-		$load_function = 'load_' . esc_js( $this->get_gateway()->get_id() ) . '_payment_form_handler';
+		$window_object = 'wc_' . $this->get_gateway()->get_id() . '_payment_form_handler';
+		$load_function = 'load_' . $this->get_gateway()->get_id() . '_payment_form_handler';
 		$loaded_event  = strtolower( $handler_name ) . '_loaded';
 
 		?>

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -981,18 +981,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 */
 	public function render_js() {
 
-		$args = array(
-			'plugin_id'               => $this->get_gateway()->get_plugin()->get_id(),
-			'id'                      => $this->get_gateway()->get_id(),
-			'id_dasherized'           => $this->get_gateway()->get_id_dasherized(),
-			'type'                    => $this->get_gateway()->get_payment_type(),
-			'csc_required'            => $this->get_gateway()->csc_enabled(),
-			'csc_required_for_tokens' => $this->get_gateway()->csc_enabled_for_tokens(),
-		);
-
-		if ( $this->get_gateway()->supports_card_types() ) {
-			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
-		}
+		$args = $this->get_js_args();
 
 		/**
 		 * Payment Gateway Payment Form JS Arguments Filter.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -981,7 +981,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 */
 	public function render_js() {
 
-		$args = $this->get_js_args();
+		$args = $this->get_js_handler_params();
 
 		/**
 		 * Payment Gateway Payment Form JS Arguments Filter.
@@ -1039,7 +1039,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 *
 	 * @return array
 	 */
-	protected function get_js_args() {
+	protected function get_js_handler_params() {
 
 		$args = [
 			'plugin_id'               => $this->get_gateway()->get_plugin()->get_id(),

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1020,6 +1020,35 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	}
 
 
+	/**
+	 * Gets the JS args for the payment form handler.
+	 *
+	 * Payment gateways can overwrite this method to define specific args.
+	 * render_js() will apply filters to the returned array of args.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	protected function get_js_args() {
+
+		$args = [
+			'plugin_id'               => $this->get_gateway()->get_plugin()->get_id(),
+			'id'                      => $this->get_gateway()->get_id(),
+			'id_dasherized'           => $this->get_gateway()->get_id_dasherized(),
+			'type'                    => $this->get_gateway()->get_payment_type(),
+			'csc_required'            => $this->get_gateway()->csc_enabled(),
+			'csc_required_for_tokens' => $this->get_gateway()->csc_enabled_for_tokens(),
+		];
+
+		if ( $this->get_gateway()->supports_card_types() ) {
+			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
+		}
+
+		return $args;
+	}
+
+
 }
 
 


### PR DESCRIPTION
# Summary

This PR adds `try/catch` blocks around the code that initilizes the Payment Form, Payment Methods, and Apple Pay handlers.

### Story: [CH 33794](https://app.clubhouse.io/skyverge/story/33794)
### Release: #470

## Details

* At first I used the wrong name for the loaded event, but caught the error and fixed in a814385f.
* The the function used to initialize the handlers uses a name based on the ID of the gateway or the plugin to generate.

    Multiple plugins may try to initialize the same class, for example `SV_WC_Payment_Methods_Handler_5_6_1`. Similarly, the Credit Card and ECheck gateways in Authorize.Net would both try to initialize `WC_Authorize_Net_Payment_Form_Handler` if the two are active at the same time. As a result, using the class name to build the name of the function would result on duplicate function names.
* For similar reasons, the name of the window object uses the ID of the gateway if available and the ID of the plugin otherwise.
* I added a `get_js_handler_params()` method to `SV_WC_Payment_Gateway_My_Payment_Methods` and `SV_WC_Payment_Gateway_Payment_Form` to allow sub classes to overwrite or expand the params for the handler without having to rewrite the `render_js()` methods that just grew bigger on this PR.

    A [TODO](https://github.com/skyverge/wc-plugins/blob/d3abef59de5d26167f1e06814df8668b80703658/woocommerce-gateway-authorize-net-cim/includes/Payment_Form.php#L126) was already added for something like this on Authorize.Net.

    I decided to leave the call to `apply_filters()` inside `render_js()` so that sub classes don't have to repeat it when they overwrrite `get_js_handler_params()`.

## QA

### Setup

- Update `composer.json` in Authorize.Net to use this branch (`dev-ch33794/add-try-catch`)
- Configure Authorize.Net in test mode (both Credit Card and ECheck)
- Update `woocommerce-gateway-authorize-net-cim/includes/Payment_Form.php` as follows:
    - Replace the entire `render_js()` method with these two methods:

    ```php
	/**
	 * Gets the JS args for the payment form handler.
	 *
	 * @since x.y.z
	 *
	 * @return array
	 */
	protected function get_js_handler_params() {

		$args = array_merge( parent::get_js_handler_params(), [
			'logging_enabled'  => $this->get_gateway()->debug_log(),
			'lightbox_enabled' => $this->get_gateway()->is_lightbox_payment_form_enabled(),
			'login_id'         => $this->get_gateway()->get_api_login_id(),
			'client_key'       => $this->get_gateway()->get_client_key(),
			'general_error'    => __( 'An error occurred, please try again or try an alternate form of payment.', 'woocommerce-gateway-authorize-net-cim' ),
			'ajax_url'         => admin_url( 'admin-ajax.php' ),
			'ajax_log_nonce'   => wp_create_nonce( 'wc_' . $this->get_gateway()->get_id() . '_log_js_data' ),
		] );

		return $args;
	}


	/**
	 * Returns the JS handler class name.
	 *
	 * @since x.y.z
	 *
	 * @return string
	 */
	protected function get_js_handler_class_name() {

		return 'WC_Authorize_Net_Payment_Form_Handler';
	}
    ```
- Activate Apple Pay for Authorize.Net using this code snippet:

    ```php
    add_filter( 'wc_payment_gateway_authorize_net_cim_activate_apple_pay', '__return_true' );
    ````
- Make sure Apple Pay is allowed on Single Product pages
- Set **Apple Merchant ID** to `merchant.com.skyverge.test`

    That's a fake ID, but I think we don't need Apple Pay to really work to confirm the handler is correctly initialized.
- Point **Certificate Path** to any file on your website's root directory

### Steps

#### Payment Form

- Add a product to the cart and go to the Checkout page
    - [x] Credit Card form fields are shown
    - [x] ECheck form fields are shown
- Open the browser's console
    - [x] `wc_authorize_net_cim_credit_card_payment_form_handler` is defined
    - [x] `wc_authorize_net_cim_credit_card_payment_form_handler.__proto__` is `SV_WC_Payment_Form_Handler_5_6_1`
    - [x] `wc_authorize_net_cim_echeck_payment_form_handler` is defined
    - [x] `wc_authorize_net_cim_echeck_payment_form_handler.__proto__` is `SV_WC_Payment_Form_Handler_5_6_1`
- Place an order using Credit Card (save the payment method)
    - [x] The order is placed successfully

#### Payment Methods

- Go to My Account > Payment Methods
    - [x] The saved payment method is shown
- Open the browser's console
    - [x] `wc_authorize_net_cim_payment_methods_handler` is an instance of `SV_WC_Payment_Methods_Handler_5_6_1`
- Edit the saved payment method and define a nickname
- Save
    - [x] The nickname is saved

#### Apple Pay

- Go to a product's page
- Open the browser's console
    - [x] `wc_authorize_net_cim_credit_card_apple_pay_handler` is an instance of `SV_WC_Apple_Pay_Handler_5_6_1`
- Execute `wc_authorize_net_cim_credit_card_apple_pay_handler.get_payment_request( {} )` ( `{}` is required )
    - [x] The server responds successfully including data for a payment request
