### PR TITLE
Add filter to active optimization plugins list

### DIFF
--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -323,8 +323,14 @@ class SV_WC_Plugin_Dependencies {
 	 */
 	public function get_active_scripts_optimization_plugins() {
 
-		// optimization plugins to look for, indexed by the plugin file identifier
-		$plugins = [
+		/**
+		 * Filters script optimization plugins to look for.
+		 *
+		 * @since x.y.z
+		 *
+		 * @param array $plugins an array of file identifiers (keys) and plugin names (values)
+		 */
+		$plugins = (array) apply_filters( 'wc_' . $this->get_plugin()->get_id() . '_scripts_optimization_plugins', [
 			'async-javascript.php' => 'Async JavaScript',
 			'autoptimize.php'      => 'Autoptimize',
 			'wp-hummingbird.php'   => 'Hummingbird',
@@ -332,7 +338,7 @@ class SV_WC_Plugin_Dependencies {
 			'w3-total-cache.php'   => 'W3 Total Cache',
 			'wpFastestCache.php'   => 'WP Fastest Cache',
 			'wp-rocket.php'        => 'WP Rocket',
-		];
+		] );
 
 		$active_plugins = [];
 


### PR DESCRIPTION
## Summary

Adds a filter in `SV_WC_Plugin_Dependencies::get_active_scripts_optimization_plugins()` to filter optimization plugins to look for. 

## QA

### Setup

- Attach the dev FW version to a plugin of your choice (doesn't have  to be a gateway)
- When `'wc_' . $this->get_plugin()->get_id() . '_scripts_optimization_plugins'` is filtered, results of `SV_WC_Plugin_Dependencies::get_active_scripts_optimization_plugins()` change accordingly.

### Steps

- [x] Filter out all results (return empty array) and activate one of the optimization plugins: calling the method in question should return no results
- [x] Add a third party plugin to the list and activate it: calling the method in question should return that plugin in the results
- [x] Integration tests pass