### PR TITLE
Adds an AJAX request to log script errors

### DIFF
--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -73,14 +73,27 @@ abstract class Script_Handler {
 		ob_start();
 
 		?>
+
+		var errorName    = '',
+		    errorMessage = '';
+
+		if ( undefined === err || 0 === err.length ) {
+			errorName    = '<?php echo esc_js( sprintf( 'The script %s could not be loaded.', $this->get_js_handler_class_name() ) ); ?>';
+			errorMessage = '<?php echo esc_js( 'An error has occurred.' ); ?>';
+		} else {
+			errorName    = err.name;
+			errorMessage = err.message;
+		}
+
 		jQuery.post( '<?php echo esc_js( admin_url( 'admin-ajax.php' ) ) ; ?>', {
 			action:   '<?php echo esc_js( "wc_{$plugin_id}_log_script_event" ); ?>',
 			security: '<?php echo esc_js( wp_create_nonce( "wc-{$plugin_id}-log-script-event" ); ?>',
 			script:   '<?php echo esc_js( $this->get_js_handler_class_name() ); ?>',
 			type:     'error',
-			name:     err.name,
-			message:  err.message,
+			name:     errorName,
+			message:  errorMessage,
 		} );
+
 		<?php
 
 		return ob_get_clean();

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -77,9 +77,9 @@ abstract class Script_Handler {
 		var errorName    = '',
 		    errorMessage = '';
 
-		if ( undefined === err || 0 === err.length ) {
-			errorName    = '<?php echo esc_js( sprintf( 'The script %s could not be loaded.', $this->get_js_handler_class_name() ) ); ?>';
-			errorMessage = '<?php echo esc_js( 'An error has occurred.' ); ?>';
+		if ( 'undefined' === typeof err || 0 === err.length || ! err ) {
+			errorName    = '<?php echo esc_js( 'A script error has occurred.' ); ?>';
+			errorMessage = '<?php echo esc_js( sprintf( 'The script %s could not be loaded.', $this->get_js_handler_class_name() ) ); ?>';
 		} else {
 			errorName    = err.name;
 			errorMessage = err.message;

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -87,7 +87,7 @@ abstract class Script_Handler {
 
 		jQuery.post( '<?php echo esc_js( admin_url( 'admin-ajax.php' ) ) ; ?>', {
 			action:   '<?php echo esc_js( "wc_{$plugin_id}_log_script_event" ); ?>',
-			security: '<?php echo esc_js( wp_create_nonce( "wc-{$plugin_id}-log-script-event" ); ?>',
+			security: '<?php echo esc_js( wp_create_nonce( "wc-{$plugin_id}-log-script-event" ) ); ?>',
 			script:   '<?php echo esc_js( $this->get_js_handler_class_name() ); ?>',
 			type:     'error',
 			name:     errorName,

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -24,6 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\Frontend;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_6_1\\Frontend\\Script_Handler' ) ) :
@@ -53,6 +55,35 @@ abstract class Script_Handler {
 	protected function get_js_handler_class_name() {
 
 		return sprintf( '%s_5_6_1', $this->js_handler_base_class_name );
+	}
+
+
+	/**
+	 * Gets inline JavaScript code to issue an AJAX request to add a script error event to the debug log.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	protected function get_js_handler_event_debug_log_request() {
+
+		$plugin    = is_callable( [ $this, 'get_plugin' ] ) ? $this->get_plugin() : null;
+		$plugin_id = $plugin instanceof SV_WC_Plugin ? $plugin->get_id() : '';
+
+		ob_start();
+
+		?>
+		jQuery.post( '<?php echo esc_js( admin_url( 'admin-ajax.php' ) ) ; ?>', {
+			action:   '<?php echo esc_js( "wc_{$plugin_id}_log_script_event" ); ?>',
+			security: '<?php echo esc_js( wp_create_nonce( "wc-{$plugin_id}-log-script-event" ); ?>',
+			script:   '<?php echo esc_js( $this->get_js_handler_class_name() ); ?>',
+			type:     'error',
+			name:     err.name,
+			message:  err.message,
+		} );
+		<?php
+
+		return ob_get_clean();
 	}
 
 

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -59,7 +59,7 @@ abstract class Script_Handler {
 
 
 	/**
-	 * Gets inline JavaScript code to issue an AJAX request to add a script error event to the debug log.
+	 * Gets inline JavaScript code to issue an AJAX request to log a script error event.
 	 *
 	 * @since x.y.z
 	 *

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -180,9 +180,11 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 				<?php echo esc_js( $load_function ); ?>();
 			} else {
 				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+				<?php echo $this->get_js_handler_event_debug_log_request(); ?>
 			}
 		} catch( err ) {
 			window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+			<?php echo $this->get_js_handler_event_debug_log_request(); ?>
 		}
 		<?php
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -242,7 +242,6 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 			?>
 			function <?php echo esc_js( $load_function ) ?>() {
-
 				window.<?php echo esc_js( $window_object ); ?> = new <?php echo esc_js( $handler_name ); ?>( <?php echo json_encode( $args ); ?> );
 			}
 
@@ -251,9 +250,11 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 					<?php echo esc_js( $load_function ); ?>();
 				} else {
 					window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+					<?php echo $this->get_js_handler_event_debug_log_request(); ?>
 				}
 			} catch( err ) {
 				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+				<?php echo $this->get_js_handler_event_debug_log_request(); ?>
 			}
 			<?php
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1020,9 +1020,11 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 				<?php echo esc_js( $load_function ); ?>();
 			} else {
 				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+				<?php echo $this->get_js_handler_event_debug_log_request(); ?>
 			}
 		} catch( err ) {
 			window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+			<?php echo $this->get_js_handler_event_debug_log_request(); ?>
 		}
 		<?php
 


### PR DESCRIPTION
## Summary

Adds a method to the script handler abstract to output some inline JavaScript to issue an AJAX post request to track script errors.

#### Story: [ch33851](https://app.clubhouse.io/skyverge/story/33851/add-an-ajax-request-to-add-to-debug-log-when-loading-of-a-payment-gateway-javascript-handler-fails)
#### Main PR: #470 

## Additional details

See #478 for callback implementation.

The added method presumes a `get_plugin()` method to be available in order to be able to extract the plugin ID. This can be added in #478.

## QA

- [x] You can test this by implementing this version of the framework in a child plugin. The plugin should output the corresponding JS code inline at payment form, apple form, payment methods screen.
