### PR TITLE
Update SV_WC_Payment_Gateway::get_icon() method to wrap output in a <div> element

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1573,6 +1573,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		// credit card images
 		if ( ! $icon && $this->supports_card_types() && $this->get_card_types() ) {
 
+			$icon .= '<div>';
+
 			// display icons for the selected card types
 			foreach ( $this->get_card_types() as $card_type ) {
 
@@ -1582,6 +1584,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 					$icon .= sprintf( '<img src="%s" alt="%s" class="sv-wc-payment-gateway-icon wc-%s-payment-gateway-icon" width="40" height="25" style="width: 40px; height: 25px;" />', esc_url( $url ), esc_attr( $card_type ), esc_attr( $this->get_id_dasherized() ) );
 				}
 			}
+
+			$icon .= '</div>';
 		}
 
 		// echeck image


### PR DESCRIPTION
# Summary

This PR adds a wrapping div to the credit card icons.

### Story: [CH 50834](https://app.clubhouse.io/skyverge/story/50834/update-sv-wc-payment-gateway-get-icon-method-to-wrap-output-in-a-div-element)
### Release: 

## QA

### Setup

- Configure a credit card gateway to use this branch

### Steps

1. Add a product to cart and proceed to checkout
    - [x] The credit card icons are wrapped in a div