### PR TITLE
Improve payment form credit card input fields

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -340,6 +340,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 					'autocorrect'    => 'no',
 					'autocapitalize' => 'no',
 					'spellcheck'     => 'no',
+					'maxlength'      => 7, // the spaces before and after the slash are counted
 				],
 				'value' => $defaults['expiry'],
 			],

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -307,64 +307,64 @@ class SV_WC_Payment_Gateway_Payment_Form {
 
 		$defaults = $this->get_gateway()->get_payment_method_defaults();
 
-		$fields = array(
-			'card-number' => array(
+		$fields = [
+			'card-number' => [
 				'type'              => 'tel',
 				'label'             => esc_html__( 'Card Number', 'woocommerce-plugin-framework' ),
 				'id'                => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-account-number',
 				'name'              => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-account-number',
 				'placeholder'       => '•••• •••• •••• ••••',
 				'required'          => true,
-				'class'             => array( 'form-row-wide' ),
-				'input_class'       => array( 'js-sv-wc-payment-gateway-credit-card-form-input js-sv-wc-payment-gateway-credit-card-form-account-number' ),
+				'class'             => [ 'form-row-wide' ],
+				'input_class'       => [ 'js-sv-wc-payment-gateway-credit-card-form-input js-sv-wc-payment-gateway-credit-card-form-account-number' ],
 				'maxlength'         => 20,
-				'custom_attributes' => array(
+				'custom_attributes' => [
 					'autocomplete'   => 'cc-number',
 					'autocorrect'    => 'no',
 					'autocapitalize' => 'no',
 					'spellcheck'     => 'no',
-				),
+				],
 				'value' => $defaults['account-number'],
-			),
-			'card-expiry' => array(
+			],
+			'card-expiry' => [
 				'type'              => 'text',
 				'label'             => esc_html__( 'Expiration (MM/YY)', 'woocommerce-plugin-framework' ),
 				'id'                => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-expiry',
 				'name'              => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-expiry',
 				'placeholder'       => esc_html__( 'MM / YY', 'woocommerce-plugin-framework' ),
 				'required'          => true,
-				'class'             => array( 'form-row-first' ),
-				'input_class'       => array( 'js-sv-wc-payment-gateway-credit-card-form-input js-sv-wc-payment-gateway-credit-card-form-expiry' ),
-				'custom_attributes' => array(
+				'class'             => [ 'form-row-first' ],
+				'input_class'       => [ 'js-sv-wc-payment-gateway-credit-card-form-input js-sv-wc-payment-gateway-credit-card-form-expiry' ],
+				'custom_attributes' => [
 					'autocomplete'   => 'cc-exp',
 					'autocorrect'    => 'no',
 					'autocapitalize' => 'no',
 					'spellcheck'     => 'no',
-				),
+				],
 				'value' => $defaults['expiry'],
-			),
-		);
+			],
+		];
 
 		if ( $this->get_gateway()->csc_enabled() ) {
 
-			$fields['card-csc'] = array(
+			$fields['card-csc'] = [
 				'type'              => 'tel',
 				'label'             => esc_html__( 'Card Security Code', 'woocommerce-plugin-framework' ),
 				'id'                => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-csc',
 				'name'              => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-csc',
 				'placeholder'       => esc_html__( 'CSC', 'woocommerce-plugin-framework' ),
 				'required'          => true,
-				'class'             => array( 'form-row-last' ),
-				'input_class'       => array( 'js-sv-wc-payment-gateway-credit-card-form-input js-sv-wc-payment-gateway-credit-card-form-csc' ),
+				'class'             => [ 'form-row-last' ],
+				'input_class'       => [ 'js-sv-wc-payment-gateway-credit-card-form-input js-sv-wc-payment-gateway-credit-card-form-csc' ],
 				'maxlength'         => 4,
-				'custom_attributes' => array(
+				'custom_attributes' => [
 					'autocomplete'   => 'off',
 					'autocorrect'    => 'no',
 					'autocapitalize' => 'no',
 					'spellcheck'     => 'no',
-				),
+				],
 				'value' => $defaults['csc'],
-			);
+			];
 		}
 
 		/**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -327,7 +327,7 @@ class SV_WC_Payment_Gateway_Payment_Form {
 				'value' => $defaults['account-number'],
 			],
 			'card-expiry' => [
-				'type'              => 'text',
+				'type'              => 'tel',
 				'label'             => esc_html__( 'Expiration (MM/YY)', 'woocommerce-plugin-framework' ),
 				'id'                => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-expiry',
 				'name'              => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-expiry',


### PR DESCRIPTION
# Summary

This PR tweaks the expiry input to use the `tel` type and to be limited to 7 characters (to only accept `MM/YY`)

### Story: [CH 50841](https://app.clubhouse.io/skyverge/story/50841/improve-payment-form-credit-card-input-fields)
### Release: #485 

## Details

Browsers tested:
- Desktop:
   - Chrome 80 on macOS
   - Safari 13 on macOS
   - Firefox 73 on macOS
   - IE 11 on Windows 10 (Browserstack)
- Mobile:
   - Chrome 80 on Android 10
   - Samsung Internet 11 on Android 10
   - Safari on iOS v10 on iPhone 7 (Browserstack)

**Known issue**: clearing the expiry by holding the delete key does not work well: https://cloud.skyver.ge/d5u072x6 
This is an existing issue, unrelated to the changes in this branch. It seems to be related to the [jQuery.payment format function](https://github.com/stripe-archive/jquery.payment#fnpaymentformatcardexpiry).

## QA

### Setup

- Configure a credit card gateway to use this branch

### Desktop

1. Add a product to cart and proceed to checkout
1. Select the credit card gateway using this branch as the payment method
    - [x] The expiry input only accepts 4 characters (MM/YY)
    - [x] The expiry input only accepts numbers
    - [x] The expiry input automatically formats to MM/YY
    - [x] The expiry input can be cleared

### Mobile

1. Add a product to cart and proceed to checkout
1. Select the credit card gateway using this branch as the payment method
    - [x] The expiry input brings up the `tel` keyboard, not the regular text keyboard
    - [x] The expiry input only accepts 4 characters (MM/YY)
    - [x] The expiry input only accepts numbers
    - [x] The expiry input automatically formats to MM/YY
    - [x] The expiry input can be cleared