### PR TITLE
Refactor JS script event logging

### DIFF
--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -136,6 +136,8 @@ abstract class Script_Handler {
 	/**
 	 * Logs an event via AJAX.
 	 *
+	 * @internal
+	 *
 	 * @since x.y.z
 	 */
 	public function ajax_log_event() {

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -113,6 +113,58 @@ abstract class Script_Handler {
 	}
 
 
+	/**
+	 * Adds a log entry.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $message message to log
+	 */
+	abstract protected function log_event( $message );
+
+
+	/** Conditional methods *******************************************************************************************/
+
+
+	/**
+	 * Determines whether logging is enabled.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	protected function is_logging_enabled() {
+
+		return false;
+	}
+
+
+	/** Getter methods ************************************************************************************************/
+
+
+	/**
+	 * Gets the ID of this script handler.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	abstract public function get_id();
+
+
+	/**
+	 * Gets the ID, but dasherized.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id_dasherized() {
+
+		return str_replace( '_', '-', $this->get_id() );
+	}
+
+
 }
 
 endif;

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -24,7 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_6_1\Frontend;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Helper;
+use SkyVerge\WooCommerce\PluginFramework\v5_6_1\SV_WC_Plugin_Exception;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -80,9 +81,6 @@ abstract class Script_Handler {
 	 */
 	protected function get_js_handler_event_debug_log_request() {
 
-		$plugin    = is_callable( [ $this, 'get_plugin' ] ) ? $this->get_plugin() : null;
-		$plugin_id = $plugin instanceof SV_WC_Plugin ? $plugin->get_id() : '';
-
 		ob_start();
 
 		?>
@@ -94,15 +92,13 @@ abstract class Script_Handler {
 			errorName    = '<?php echo esc_js( 'A script error has occurred.' ); ?>';
 			errorMessage = '<?php echo esc_js( sprintf( 'The script %s could not be loaded.', $this->get_js_handler_class_name() ) ); ?>';
 		} else {
-			errorName    = err.name;
-			errorMessage = err.message;
+			errorName    = 'undefined' !== typeof err.name    ? err.name    : '';
+			errorMessage = 'undefined' !== typeof err.message ? err.message : '';
 		}
 
 		jQuery.post( '<?php echo esc_js( admin_url( 'admin-ajax.php' ) ) ; ?>', {
-			action:   '<?php echo esc_js( "wc_{$plugin_id}_log_script_event" ); ?>',
-			security: '<?php echo esc_js( wp_create_nonce( "wc-{$plugin_id}-log-script-event" ) ); ?>',
-			script:   '<?php echo esc_js( $this->get_js_handler_class_name() ); ?>',
-			type:     'error',
+			action:   '<?php echo esc_js( 'wc_' . $this->get_id() . '_log_script_event' ); ?>',
+			security: '<?php echo esc_js( wp_create_nonce( 'wc-' . $this->get_id_dasherized() . '-log-script-event' ) ); ?>',
 			name:     errorName,
 			message:  errorMessage,
 		} );

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -95,6 +95,32 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 
 
 	/**
+	 * Gets the script ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+
+		return $this->get_gateway()->get_id();
+	}
+
+
+	/**
+	 * Gets the script ID, dasherized.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id_dasherized() {
+
+		return $this->get_gateway()->get_id_dasherized();
+	}
+
+
+	/**
 	 * Gets the configured display locations.
 	 *
 	 * @since 4.7.0
@@ -207,6 +233,32 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 		wc_deprecated_function( __METHOD__, 'x.y.z', __CLASS__ . '::get_js_handler_class_name()' );
 
 		return parent::get_js_handler_class_name();
+	}
+
+
+	/**
+	 * Adds a log entry.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $message message to log
+	 */
+	protected function log_event( $message ) {
+
+		$this->get_gateway()->add_debug_message( $message );
+	}
+
+
+	/**
+	 * Determines whether logging is enabled.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	protected function is_logging_enabled() {
+
+		return $this->get_gateway()->debug_log();
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -66,7 +66,20 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 
 		$this->gateway = $this->get_handler()->get_processing_gateway();
 
+		parent::__construct();
+	}
+
+
+	/**
+	 * Adds the action and filter hooks.
+	 *
+	 * @since x.y.z
+	 */
+	protected function add_hooks() {
+
 		if ( $this->get_handler()->is_available() ) {
+
+			parent::add_hooks();
 
 			add_action( 'wp', array( $this, 'init' ) );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -79,6 +79,32 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 
 
 	/**
+	 * Gets the script ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+
+		return $this->get_plugin()->get_id();
+	}
+
+
+	/**
+	 * Gets the script ID, dasherized.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id_dasherized() {
+
+		return $this->get_plugin()->get_id_dasherized();
+	}
+
+
+	/**
 	 * Initializes the My Payment Methods table
 	 *
 	 * @since 5.1.0
@@ -308,6 +334,47 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 		wc_deprecated_function( __METHOD__, 'x.y.z', __CLASS__ . '::get_js_handler_class_name()' );
 
 		return parent::get_js_handler_class_name();
+	}
+
+
+	/**
+	 * Adds a log entry.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $message message to log
+	 */
+	protected function log_event( $message ) {
+
+		$this->get_plugin()->log( $message );
+	}
+
+
+	/**
+	 * Determines whether logging is enabled.
+	 *
+	 * Considers logging enabled at the plugin level if at least one gateway has logging enabled.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	protected function is_logging_enabled() {
+
+		$is_logging_enabled = parent::is_logging_enabled();
+
+		if ( ! $is_logging_enabled ) {
+
+			foreach ( $this->get_plugin()->get_gateways() as $gateway ) {
+
+				if ( $gateway->debug_log() ) {
+					$is_logging_enabled = true;
+					break;
+				}
+			}
+		}
+
+		return $is_logging_enabled;
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -62,14 +62,25 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	/**
 	 * Setup Class
 	 *
-	 * Note: this constructor executes during the `wp` action
-	 *
 	 * @param SV_WC_Payment_Gateway_Plugin $plugin gateway plugin
 	 * @since 4.0.0
 	 */
 	public function __construct( $plugin ) {
 
 		$this->plugin = $plugin;
+
+		parent::__construct();
+	}
+
+
+	/**
+	 * Adds the action and filter hooks.
+	 *
+	 * @since x.y.z
+	 */
+	protected function add_hooks() {
+
+		parent::add_hooks();
 
 		add_action( 'wp', array( $this, 'init' ) );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -106,6 +106,32 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 
 
 	/**
+	 * Gets the script ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+
+		return $this->get_gateway()->get_id();
+	}
+
+
+	/**
+	 * Gets the script ID, dasherized.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public function get_id_dasherized() {
+
+		return $this->get_gateway()->get_id_dasherized();
+	}
+
+
+	/**
 	 * Returns the active tokens for the current user/gateway
 	 *
 	 * @since 4.0.0
@@ -1058,6 +1084,32 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 		}
 
 		return $args;
+	}
+
+
+	/**
+	 * Adds a log entry.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $message message to log
+	 */
+	protected function log_event( $message ) {
+
+		$this->get_gateway()->add_debug_message( $message );
+	}
+
+
+	/**
+	 * Determines whether logging is enabled.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	protected function is_logging_enabled() {
+
+		return $this->get_gateway()->debug_log();
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -63,11 +63,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 
 		$this->gateway = $gateway;
 
-		// hook up rendering
-		$this->add_hooks();
-
-		// maybe load tokens
-		$this->get_tokens();
+		parent::__construct();
 	}
 
 
@@ -79,6 +75,8 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 * @since 4.0.0
 	 */
 	protected function add_hooks() {
+
+		parent::add_hooks();
 
 		$gateway_id = $this->get_gateway()->get_id();
 
@@ -842,6 +840,9 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 * @since 4.0.0
 	 */
 	public function render() {
+
+		// maybe load tokens
+		$this->get_tokens();
 
 		/**
 		 * Payment Gateway Payment Form Start Action.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -632,11 +632,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/**
 	 * Initializes the payment form handler.
 	 *
-	 * @internal
-	 *
 	 * @since x.y.z
 	 */
-	public function maybe_init_payment_form() {
+	protected function maybe_init_payment_form() {
 
 		// only if the gateway supports it
 		if ( ! $this->supports_payment_form() ) {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -199,6 +199,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/** @var array of SV_WC_Payment_Gateway_Integration objects for Subscriptions, Pre-Orders, etc. */
 	protected $integrations;
 
+	/** @var SV_WC_Payment_Gateway_Payment_Form|null payment form instance */
+	protected $payment_form;
+
 
 	/**
 	 * Initialize the gateway
@@ -302,6 +305,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		// initialize the capture handler
 		$this->init_capture_handler();
+
+		// initialize the payment form
+		$this->maybe_init_payment_form();
 
 		// pay page fallback
 		$this->add_pay_page_handler();
@@ -624,6 +630,42 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
+	 * Initializes the payment form handler.
+	 *
+	 * @internal
+	 *
+	 * @since x.y.z
+	 */
+	public function maybe_init_payment_form() {
+
+		// only if the gateway supports it
+		if ( ! $this->supports_payment_form() ) {
+			return;
+		}
+
+		// only load on the frontend and AJAX
+		if ( is_admin() && ! is_ajax() ) {
+			return;
+		}
+
+		$this->payment_form = $this->init_payment_form_instance();
+	}
+
+
+	/**
+	 * Initializes the payment form instance.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return SV_WC_Payment_Gateway_Payment_Form
+	 */
+	protected function init_payment_form_instance() {
+
+		return new SV_WC_Payment_Gateway_Payment_Form( $this );
+	}
+
+
+	/**
 	 * Returns true if on the pay page and this is the currently selected gateway
 	 *
 	 * @since 1.0.0
@@ -732,11 +774,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 4.1.2
 	 *
-	 * @return SV_WC_Payment_Gateway_Payment_Form
+	 * @return SV_WC_Payment_Gateway_Payment_Form|null
 	 */
 	public function get_payment_form_instance() {
 
-		return new SV_WC_Payment_Gateway_Payment_Form( $this );
+		return $this->payment_form;
 	}
 
 


### PR DESCRIPTION
# Summary

Based on discussion in https://github.com/skyverge/wc-plugin-framework/pull/478#issuecomment-607020731 this refactors how the base script handler supports logging events.

### Story: [CH 51170](https://app.clubhouse.io/skyverge/story/51170/refactor-script-handler-ajax-log-request-handling)
### Release: #470

## Details

Allows concrete script handlers to more easily log script events as they see fit, and direct to the appropriate log.

Replaces https://github.com/skyverge/wc-plugin-framework/pull/478

## UI Changes

None

## QA

- Load this branch in the Elavon gateway. Any gateway will work, but that has minimal payment form customizations.
- Rename `\WC_Gateway_Elavon_Converge::get_payment_form_instance()` to `init_payment_form_instance()`
- Rename `\WC_Gateway_Elavon_Converge_eCheck::get_payment_form_instance()` to `init_payment_form_instance()`
- Enable debug logging
- Purposefully add some error triggering code in the payment form and My Payment Methods `render_js` error catching

1. Visit checkout
    - [ ] Any entry is added to the gateway logs
1. Visit My Account -> Payment methods
    - [ ] Any entry is added to the plugin log

## Before merge

- [ ] Update the [wiki](https://github.com/skyverge/wc-plugin-framework/wiki/JavaScript-Handling) steps:

* Define the `get_id()` and optionally `get_id_dasherized()` methods to return the ID of your choosing, like a gateway or plugin ID
* Define the `log_event()` method
* Define the `is_logging_enabled()` method, if needed
* If a constructor is defined, be sure to call `parent::__construct()`
* If a `add_hooks()` method is defined, be sure to call `parent::add_hooks()`