### PR TITLE
Abstract the "safe" script loading to the base script handler

### DIFF
--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -273,6 +273,8 @@ abstract class Script_Handler {
 
 			$this->log_event( $message );
 
+			wp_send_json_success();
+
 		} catch ( SV_WC_Plugin_Exception $exception ) {
 
 			wp_send_json_error( $exception->getMessage() );

--- a/woocommerce/payment-gateway/Frontend/Script_Handler.php
+++ b/woocommerce/payment-gateway/Frontend/Script_Handler.php
@@ -84,6 +84,19 @@ abstract class Script_Handler {
 
 
 	/**
+	 * Returns the JS handler object name.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	protected function get_js_handler_object_name() {
+
+		return 'wc_' . $this->get_id() . '_handler';
+	}
+
+
+	/**
 	 * Gets the JS event triggered after the JS handler class is loaded.
 	 *
 	 * @since x.y.z
@@ -93,6 +106,100 @@ abstract class Script_Handler {
 	protected function get_js_loaded_event() {
 
 		return sprintf( '%s_loaded', strtolower( $this->get_js_handler_class_name() ) );
+	}
+
+
+	/**
+	 * Gets the handler instantiation JS wrapped in a safe load technique.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $additional_args additional handler arguments, if any
+	 * @param string $handler_name handler name, if different from self::get_js_handler_class_name()
+	 * @param string $object_name object name, if different from self::get_js_handler_object_name()
+	 * @return string
+	 */
+	protected function get_safe_handler_js( array $additional_args = [], $handler_name = '', $object_name = '' ) {
+
+		if ( ! $handler_name ) {
+			$handler_name = $this->get_js_handler_class_name();
+		}
+
+		$load_function = 'load_' . $this->get_id() . '_handler';
+		$loaded_event  = $this->get_js_loaded_event();
+
+		ob_start();
+
+		?>
+		function <?php echo esc_js( $load_function ) ?>() {
+			<?php echo $this->get_handler_js( $additional_args, $handler_name, $object_name ); ?>
+		}
+
+		try {
+
+			if ( 'undefined' !== typeof <?php echo esc_js( $handler_name ); ?> ) {
+				<?php echo esc_js( $load_function ); ?>();
+			} else {
+				window.jQuery( document.body ).on( '<?php echo esc_js( $this->get_js_loaded_event() ); ?>', <?php echo esc_js( $load_function ); ?> );
+				<?php echo $this->get_js_handler_event_debug_log_request(); ?>
+			}
+
+		} catch( err ) {
+			window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
+			<?php echo $this->get_js_handler_event_debug_log_request(); ?>
+		}
+		<?php
+
+		return ob_get_clean();
+	}
+
+
+	/**
+	 * Gets the handler instantiation JS.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $additional_args additional handler arguments, if any
+	 * @param string $handler_name handler name, if different from self::get_js_handler_class_name()
+	 * @param string $object_name object name, if different from self::get_js_handler_object_name()
+	 * @return string
+	 */
+	protected function get_handler_js( array $additional_args = [], $handler_name = '', $object_name = '' ) {
+
+		$args = array_merge( $additional_args, $this->get_js_handler_args() );
+
+		/**
+		 * Filters the JavaScript handler arguments.
+		 *
+		 * @since x.y.z
+		 *
+		 * @param array $args arguments to pass to the JS handler
+		 * @param Script_Handler $handler script handler instance
+		 */
+		$args = apply_filters( 'wc_' . $this->get_id() . '_js_args', $args, $this );
+
+		if ( ! $handler_name ) {
+			$handler_name = $this->get_js_handler_class_name();
+		}
+
+		if ( ! $object_name ) {
+			$object_name = $this->get_js_handler_object_name();
+		}
+
+		return sprintf( 'window.%1$s = new %2$s( %3$s );', esc_js( $object_name ), esc_js( $handler_name ), json_encode( $args ) );
+	}
+
+
+	/**
+	 * Gets the JS handler arguments.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	protected function get_js_handler_args() {
+
+		return [];
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -116,7 +116,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	 */
 	public function get_id() {
 
-		return $this->get_gateway()->get_id();
+		return $this->get_gateway()->get_id() . '_apple_pay';
 	}
 
 
@@ -129,7 +129,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	 */
 	public function get_id_dasherized() {
 
-		return $this->get_gateway()->get_id_dasherized();
+		return $this->get_gateway()->get_id_dasherized() . '-apple-pay';
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -159,7 +159,14 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	}
 
 
-	protected function get_js_handler_params() {
+	/**
+	 * Gets the JS handler arguments.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return array
+	 */
+	protected function get_js_handler_args() {
 
 		/**
 		 * Filters the Apple Pay JS handler params.
@@ -192,42 +199,27 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	 */
 	protected function enqueue_js_handler( array $args, $object_name = '', $handler_name = '' ) {
 
-		if ( ! $object_name ) {
-			$object_name = 'wc_' . $this->get_gateway()->get_id() . '_apple_pay_handler';
-		}
+		wc_enqueue_js( $this->get_safe_handler_js( $args, $handler_name, $object_name ) );
+	}
 
-		if ( ! $handler_name ) {
-			$handler_name = parent::get_js_handler_class_name();
-		}
 
-		$args = array_merge( $args, $this->get_js_handler_params() );
+	/**
+	 * Gets the handler instantiation JS.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $additional_args additional handler arguments, if any
+	 * @param string $handler_name handler name, if different from self::get_js_handler_class_name()
+	 * @param string $object_name object name, if different from self::get_js_handler_object_name()
+	 * @return string
+	 */
+	protected function get_handler_js( array $additional_args = [], $handler_name = '', $object_name = '' ) {
 
-		ob_start();
+		$js = parent::get_handler_js( $additional_args, $handler_name );
 
-		$load_function = 'load_' . $this->get_gateway()->get_id() . '_apple_pay_handler';
-		$loaded_event  = $this->get_js_loaded_event();
+		$js .= sprintf( 'window.%s.init();', $object_name ?: $this->get_js_handler_object_name() );
 
-		?>
-		function <?php echo esc_js( $load_function ) ?>() {
-
-			window.<?php echo esc_js( $object_name ); ?> = new <?php echo esc_js( $handler_name ); ?>( <?php echo json_encode( $args ); ?> );
-			window.<?php echo esc_js( $object_name ); ?>.init();
-		}
-
-		try {
-			if ( 'undefined' !== typeof <?php echo esc_js( $handler_name ); ?> ) {
-				<?php echo esc_js( $load_function ); ?>();
-			} else {
-				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
-				<?php echo $this->get_js_handler_event_debug_log_request(); ?>
-			}
-		} catch( err ) {
-			window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
-			<?php echo $this->get_js_handler_event_debug_log_request(); ?>
-		}
-		<?php
-
-		wc_enqueue_js( ob_get_clean() );
+		return $js;
 	}
 
 
@@ -607,6 +599,25 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Frontend\Script_Handler {
 	protected function get_handler() {
 
 		return $this->handler;
+	}
+
+
+	/** Deprecated methods ********************************************************************************************/
+
+
+	/**
+	 * Gets the JS handler parameters.
+	 *
+	 * @since 4.7.0
+	 * @deprecated x.y.z
+	 *
+	 * @return array
+	 */
+	protected function get_js_handler_params() {
+
+		wc_deprecated_function( __METHOD__, 'x.y.z', __CLASS__ . '::get_js_handler_args()' );
+
+		return $this->get_js_handler_args();
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -98,7 +98,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	 */
 	public function get_id() {
 
-		return $this->get_plugin()->get_id();
+		return $this->get_plugin()->get_id() . '_payment_methods';
 	}
 
 
@@ -111,7 +111,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	 */
 	public function get_id_dasherized() {
 
-		return $this->get_plugin()->get_id_dasherized();
+		return $this->get_plugin()->get_id_dasherized() . '-payment-methods';
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -256,47 +256,12 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	 */
 	public function render_js() {
 
-		if ( $this->has_tokens ) {
-
-			$args = $this->get_js_handler_params();
-
-			/**
-			 * Filters the payment gateway payment methods JavaScript args.
-			 *
-			 * @since 5.1.0
-			 *
-			 * @param array $args arguments
-			 * @param SV_WC_Payment_Gateway_My_Payment_Methods $handler payment methods handler
-			 */
-			$args = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_payment_methods_js_args', $args, $this );
-
-			ob_start();
-
-			$handler_name  = $this->get_js_handler_class_name();
-			$window_object = 'wc_' . $this->get_plugin()->get_id() . '_payment_methods_handler';
-			$load_function = 'load_' . $this->get_plugin()->get_id() . '_payment_methods_handler';
-			$loaded_event  = $this->get_js_loaded_event();
-
-			?>
-			function <?php echo esc_js( $load_function ) ?>() {
-				window.<?php echo esc_js( $window_object ); ?> = new <?php echo esc_js( $handler_name ); ?>( <?php echo json_encode( $args ); ?> );
-			}
-
-			try {
-				if ( 'undefined' !== typeof <?php echo esc_js( $handler_name ); ?> ) {
-					<?php echo esc_js( $load_function ); ?>();
-				} else {
-					window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
-					<?php echo $this->get_js_handler_event_debug_log_request(); ?>
-				}
-			} catch( err ) {
-				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
-				<?php echo $this->get_js_handler_event_debug_log_request(); ?>
-			}
-			<?php
-
-			wc_enqueue_js( ob_get_clean() );
+		// bail if the gateways have no tokens
+		if ( ! $this->has_tokens ) {
+			return;
 		}
+
+		wc_enqueue_js( $this->get_safe_handler_js() );
 	}
 
 
@@ -310,7 +275,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Frontend\Script_Handler {
 	 *
 	 * @return array
 	 */
-	protected function get_js_handler_params() {
+	protected function get_js_handler_args() {
 
 		$args = [
 			'id'              => $this->get_plugin()->get_id(),

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1008,54 +1008,27 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 */
 	public function render_js() {
 
-		$args = $this->get_js_handler_params();
+		wc_enqueue_js( $this->get_safe_handler_js() );
+	}
 
-		/**
-		 * Payment Gateway Payment Form JS Arguments Filter.
-		 *
-		 * Filter the arguments passed to the Payment Form handler JS class
-		 *
-		 * @since 4.0.0
-		 * @param array $result {
-		 *   @type string $plugin_id plugin ID
-		 *   @type string $id gateway ID
-		 *   @type string $id_dasherized gateway ID dasherized
-		 *   @type string $type gateway payment type (e.g. 'credit-card')
-		 *   @type bool $csc_required true if CSC field display is required
-		 * }
-		 * @param SV_WC_Payment_Gateway_Payment_Form $this payment form instance
-		 */
-		$args = apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_js_args', $args, $this );
 
-		ob_start();
+	/**
+	 * Gets the handler instantiation JS.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $additional_args additional handler arguments, if any
+	 * @param string $handler_name handler name, if different from self::get_js_handler_class_name()
+	 * @param string $object_name object name, if different from self::get_js_handler_object_name()
+	 * @return string
+	 */
+	protected function get_handler_js( array $additional_args = [], $handler_name = '', $object_name = '' ) {
 
-		$handler_name  = $this->get_js_handler_class_name();
-		$window_object = 'wc_' . $this->get_gateway()->get_id() . '_payment_form_handler';
-		$load_function = 'load_' . $this->get_gateway()->get_id() . '_payment_form_handler';
-		$loaded_event  = $this->get_js_loaded_event();
+		$js = parent::get_handler_js( $additional_args, $handler_name, $object_name );
 
-		?>
-		function <?php echo esc_js( $load_function ) ?>() {
+		$js .= 'window.jQuery( document.body ).trigger( "update_checkout" );';
 
-			window.<?php echo esc_js( $window_object ); ?> = new <?php echo esc_js( $handler_name ); ?>( <?php echo json_encode( $args ); ?> );
-
-			window.jQuery( document.body ).trigger( 'update_checkout' );
-		}
-
-		try {
-			if ( 'undefined' !== typeof <?php echo esc_js( $handler_name ); ?> ) {
-				<?php echo esc_js( $load_function ); ?>();
-			} else {
-				window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
-				<?php echo $this->get_js_handler_event_debug_log_request(); ?>
-			}
-		} catch( err ) {
-			window.jQuery( document.body ).on( '<?php echo esc_js( $loaded_event ); ?>', <?php echo esc_js( $load_function ); ?> );
-			<?php echo $this->get_js_handler_event_debug_log_request(); ?>
-		}
-		<?php
-
-		wc_enqueue_js( ob_get_clean() );
+		return $js;
 	}
 
 
@@ -1069,7 +1042,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 *
 	 * @return array
 	 */
-	protected function get_js_handler_params() {
+	protected function get_js_handler_args() {
 
 		$args = [
 			'plugin_id'               => $this->get_gateway()->get_plugin()->get_id(),

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -112,7 +112,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 */
 	public function get_id() {
 
-		return $this->get_gateway()->get_id();
+		return $this->get_gateway()->get_id() . '_payment_form';
 	}
 
 
@@ -125,7 +125,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Frontend\Script_Handler {
 	 */
 	public function get_id_dasherized() {
 
-		return $this->get_gateway()->get_id_dasherized();
+		return $this->get_gateway()->get_id_dasherized() . '-payment-form';
 	}
 
 


### PR DESCRIPTION
# Summary

Moves the common code for try/catching during script loading into the base script handler.

### Stories:
- [CH 51310](https://app.clubhouse.io/skyverge/story/51310)
- [CH 51383](https://app.clubhouse.io/skyverge/story/51383)
### Release: #470 

## Details

Most of the code was duplicated in each concrete handler.

Note: filters like `wc_{gateway_id}_payment_form_js_args` are preserved as a result of adding suffixes to the concrete script handler IDs in f7aa3ca41e651f0650081e9fc6d7b3d83988d903

## UI Changes

_None_

## QA

- Pull this branch into Authorize.Net (no namespace updating needed)
- Rename `\WC_Gateway_Authorize_Net_CIM::init_payment_form_instance()` to `init_payment_form_instance()`
- Update `window.WC_Authorize_Net_Payment_Form_Handler` to extend `SV_WC_Payment_Form_Handler_v5_6_1` in `assets/js/frontend/wc-authorize-net-cim.coffee`
- Enable Apple Pay ([config here](https://github.com/skyverge/wc-plugins/wiki/Authorize.net-AIM-CIM-SIM#apple-pay))

1. Load a single product page
    - [x] Apple Pay button is visible
1. Add the product to your cart
1. Load checkout
    - [x] The payment form is formatted and loaded by JS properly
1. Load My Account -> Payment methods
1. Add a payment method if you don't already have one
    - [x] The payment methods JS is loaded

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version