### PR TITLE
Harden get_sku() in get_order_line_items() method

### DIFF
--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -482,10 +482,11 @@ class SV_WC_Helper {
 			$product   = $item->get_product();
 			$name      = $item->get_name();
 			$quantity  = $item->get_quantity();
+			$sku       = $product instanceof \WC_Product ? $product->get_sku() : '';
 			$item_desc = [];
 
 			// add SKU to description if available
-			if ( $sku = $product->get_sku() ) {
+			if ( ! empty( $sku ) ) {
 				$item_desc[] = sprintf( 'SKU: %s', $sku );
 			}
 


### PR DESCRIPTION
## Summary

Hardens a `get_sku()` method call in `SV_WC_Helper::get_order_line_items()` where a product variable might be `false` and not an instance of `WC_Product`.

### Story: [CH 53356](https://app.clubhouse.io/skyverge/story/53356/if-product-is-not-found-from-order-item-calling-methods-on-it-will-trigger-a-php-error-3)

## Additional details

See https://github.com/skyverge/wc-plugins/pull/3657

I believe this should go inside the FW version we plan to attach to WC 4.1 compatibility updates.