### PR TITLE
Print JS initialization errors to console

### DIFF
--- a/woocommerce/Handlers/Script_Handler.php
+++ b/woocommerce/Handlers/Script_Handler.php
@@ -225,6 +225,12 @@ abstract class Script_Handler {
 			errorMessage = 'undefined' !== typeof err.message ? err.message : '';
 		}
 
+		<?php if ( $this->is_logging_enabled() ) : ?>
+
+		console.log( [ errorName, errorMessage ].filter( Boolean ).join( ' ' ) );
+
+		<?php endif; ?>
+
 		jQuery.post( '<?php echo esc_js( admin_url( 'admin-ajax.php' ) ) ; ?>', {
 			action:   '<?php echo esc_js( 'wc_' . $this->get_id() . '_log_script_event' ); ?>',
 			security: '<?php echo esc_js( wp_create_nonce( 'wc-' . $this->get_id_dasherized() . '-log-script-event' ) ); ?>',


### PR DESCRIPTION
# Summary

This PR prints JS initialization errors to the console if logging is enabled.

### Story: [CH 53864](https://app.clubhouse.io/skyverge/story/53864/print-js-initialization-errors-to-console)
### Release: #471

## QA

### Setup

- Authorize.Net is using branch `ch53695/authorize-net-js-handling` 
- Authorize.Net credit card gateway is configured with logging enabled
- Authorize.Net e-check gateway is disabled (because they both share the same JS, and we want to avoid any confusion about duplicate console logs)
- Update `composer.json` to use branch `dev-ch53864/print-errors-to-console` of the Framework
- Run `composer update skyverge/wc-plugin-framework`
- Force a JS init error:
   - Add `throw new Error( 'Whoops! Let\'s pretend this is a real error!' )` in the `WC_Authorize_Net_Payment_Form_Handler_v5_7_0` constructor
   - Run `npx sake scripts` to compile your JS

### Steps

1. Add a product to your cart
1. Proceed to checkout
    - [x] The error is printed to the console
    - [x] The error is logged in the gateway log