### PR TITLE
Fix JS conflict between framework versions

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2020.nn.nn - version 5.7.1
+
 2020.nn.nn - version 5.7.0
  * Feature - Add a Settings API for easily registering plugin settings for display and REST API handling
  * Feature - Introduce a base script handler for enqueueing and loading JavaScript objects

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.7.1
+ * Fix - Prevent JavaScript error triggered when different versions of the framework are used at the same time
+ * Fix - Fix URL for the Configure link in the admin notes shown for payment gateways that are not configured
 
 2020.nn.nn - version 5.7.0
  * Feature - Add a Settings API for easily registering plugin settings for display and REST API handling

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -153,9 +153,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Handlers\Script_Handler {
 	 */
 	public function enqueue_scripts() {
 
-		wp_enqueue_style( 'sv-wc-apple-pay', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/sv-wc-payment-gateway-apple-pay.css', array(), $this->get_plugin()->get_version() ); // TODO: min
+		wp_enqueue_style( 'sv-wc-apple-pay-v5_7_0', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/sv-wc-payment-gateway-apple-pay.css', array(), $this->get_plugin()->get_version() ); // TODO: min
 
-		wp_enqueue_script( 'sv-wc-apple-pay', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/sv-wc-payment-gateway-apple-pay.min.js', array( 'jquery' ), $this->get_plugin()->get_version(), true );
+		wp_enqueue_script( 'sv-wc-apple-pay-v5_7_0', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/sv-wc-payment-gateway-apple-pay.min.js', array( 'jquery' ), $this->get_plugin()->get_version(), true );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -156,9 +156,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Handlers\Script_Handler {
 
 			wp_register_script( 'jquery-tiptip', WC()->plugin_url() . '/assets/js/jquery-tiptip/jquery.tipTip.min.js', array( 'jquery' ), WC_VERSION, true );
 
-			wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', array( 'dashicons' ), SV_WC_Plugin::VERSION );
+			wp_enqueue_style( "$handle-v5_7_0", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', array( 'dashicons' ), SV_WC_Plugin::VERSION );
 
-			wp_enqueue_script( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', array( 'jquery-tiptip', 'jquery' ), SV_WC_Plugin::VERSION );
+			wp_enqueue_script( "$handle-v5_7_0", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', array( 'jquery-tiptip', 'jquery' ), SV_WC_Plugin::VERSION );
 		}
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -786,7 +786,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 						// add the action buttons if not on the gateway's configuration page
 						if ( ! $this->is_payment_gateway_configuration_page( $gateway->get_id() ) ) {
-							$note->add_action( 'configure', __( 'Configure', 'woocommerce-plugin-framework' ), $this->get_settings_url( $this->get_id() ), WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED, true );
+							$note->add_action( 'configure', __( 'Configure', 'woocommerce-plugin-framework' ), $this->get_settings_url( $gateway->get_id() ), WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED, true );
 							$note->add_action( 'dismiss', __( 'Dismiss', 'woocommerce-plugin-framework' ) );
 						}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -446,10 +446,10 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		$handle = 'sv-wc-payment-gateway-payment-form';
 
 		// Frontend JS
-		wp_enqueue_script( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', array( 'jquery-payment' ), SV_WC_Plugin::VERSION, true );
+		wp_enqueue_script( "$handle-v5_7_0", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', array( 'jquery-payment' ), SV_WC_Plugin::VERSION, true );
 
 		// Frontend CSS
-		wp_enqueue_style( $handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', array(), SV_WC_Plugin::VERSION );
+		wp_enqueue_style( "$handle-v5_7_0", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', array(), SV_WC_Plugin::VERSION );
 
 		// localized JS params
 		$this->localize_script( $handle, $this->get_payment_form_js_localized_script_params() );


### PR DESCRIPTION
# Summary

This PR adds the version namespace to the handle for the scripts and stylesheets associated with the Payment Form, Payment Methods, and Apple Pay Frontend handlers.

### Story: [CH 54362](https://app.clubhouse.io/skyverge/story/54362)
### Release: #493

## Details

Only one gateway is allowed to [process Apple Pay payments at the same time](https://github.com/skyverge/wc-plugin-framework/blob/e2ed37da2303b721feef02d61b0f481035ce7ecd/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php#L1088), so in theory the conflict does not occur for that script. I still added the namespace to keep it consistent with the other Script Handlers.

I also updated `SV_WC_Payment_Gateway_Plugin::add_gateway_not_configured_notices()` to pass the Gateway ID instead of the plugin ID to `get_settings_url()` so that the Configure link points to the settings page for the correct gateway. Previously, in plugins that have two or more gateways, the link pointed to the settings page of the first gateway.

## UI Changes

N/A

## QA

### Setup

- Install and configure WooCommerce Square (test credentials in the story)
- Install Authorize.Net (don't configure it yet)
- Update Authorize.Net to use version `dev-ch54362/js-conflict-between-framework-versions` of the framework.
- Modify `active_plugins` to load Square first

### Steps

#### Not configured notes

1. Go to WooCommerce > Settings > Payments
1. Enable Authorize.Net Credit Card and eCheck payment gateways and reload the page
    - [x] A note was added to inform Authorize.Net Credit Card is not configured
    - [x] The Configure button links to the settings page for Authorize.Net Credit Card
    - [x] A note was added to inform Authorize.Net eCheck is not configured
    - [x] The Configure button links to the settings page for Authorize.Net eCheck

#### Payment Form at Checkout

1. Add a product to the cart and go to Checkout
    - [x] Both Authorize.Net Credit Card and Square payment forms are shown
    - [x] There are no JS errors in the console
    - [x] You can process the order using Authorize.Net

#### My Payment Methods

1. Go to My Account > Payment Methods
1. Add a credit card using Authorize.Net
    - [x] The payment method is added successfully
1. Add a nickname to the payment method
    - [x] The nickname is added correctly
    - [x] There are no JS errors in the console
1. Reload the page
    - [x] The nickname is still shown

#### Apple Pay

We will check that the button is shown to confirm the handler is loaded correctly. The merchant ID and the certificate can be fake.

1. Enable Apple Pay with Authorize.Net
    - Merchant ID: `merchant.com.fake`
    - Certificate Path: set the path to an existing file (doesn't need to be a certificate - `{webroot}/readme.html`)
1. Open a product page in Safari
    - [x] The Apple Pay button is shown
    - [x] There are no JS errors in the console

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
