### PR TITLE
Prevent jQuery conflict with Disable Admin Notices plugin

### DIFF
--- a/tests/integration/Integrations/DisableAdminNoticesTest.php
+++ b/tests/integration/Integrations/DisableAdminNoticesTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use SkyVerge\WooCommerce\PluginFramework\v5_7_1\Integrations\Disable_Admin_Notices;
+
+class DisableAdminNoticesTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Tests *********************************************************************************************************/
+
+
+	/** @see Integrations::get_integrations() */
+	public function test_constructor() {
+
+		$integration = new Disable_Admin_Notices();
+
+		$this->assertEquals( 10, has_action( 'admin_footer', [ $integration, 'enqueue_conflict_fix_script' ] ) );
+	}
+
+
+}

--- a/tests/integration/Integrations/IntegrationsTest.php
+++ b/tests/integration/Integrations/IntegrationsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use SkyVerge\WooCommerce\PluginFramework\v5_7_1\Integrations\Disable_Admin_Notices;
+use SkyVerge\WooCommerce\PluginFramework\v5_7_1\Integrations\Integrations;
+use SkyVerge\WooCommerce\PluginFramework\v5_7_1\SV_WC_Plugin;
+
+class IntegrationsTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+	/** @var Integrations */
+	protected $integrations;
+
+
+	protected function _before() {
+
+		// include plugins with integrations as active
+		// wp-browser also adds a handler for pre_option_active_plugins to return the plugins in Codeception's configuration
+		// See wp_tests_options() in vendor/lucatume/wp-browser/src/includes/bootstrap.php
+		add_filter( 'pre_option_active_plugins', function( $plugins ) {
+
+			if ( ! in_array( 'disable-admin-notices/disable-admin-notices.php', $plugins, true ) ) {
+				$plugins[] = 'disable-admin-notices/disable-admin-notices.php';
+			}
+
+			return $plugins;
+		} );
+
+		// remove active plugins cache
+		$property = new ReflectionProperty( SV_WC_Plugin::class, 'active_plugins' );
+		$property->setAccessible( true );
+		$property->setValue( sv_wc_test_plugin(), [] );
+
+		$this->integrations = new Integrations( sv_wc_test_plugin() );
+	}
+
+
+	/** Tests *********************************************************************************************************/
+
+
+	/** @see Integrations::get_integrations() */
+	public function test_get_integrations() {
+
+		$integrations = $this->integrations->get_integrations();
+
+		$this->assertArrayHasKey( Integrations::INTEGRATION_DISABLE_ADMIN_NOTICES, $integrations );
+	}
+
+
+	/** @see Integrations\Integrations::get_integration() */
+	public function test_get_integration() {
+
+		$integration = $this->integrations->get_integration( Integrations::INTEGRATION_DISABLE_ADMIN_NOTICES );
+
+		$this->assertInstanceOf( Disable_Admin_Notices::class, $integration );
+	}
+
+
+}

--- a/woocommerce/Integrations/Disable_Admin_Notices.php
+++ b/woocommerce/Integrations/Disable_Admin_Notices.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_7_1\Integrations;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_7_1\\Integrations\\Disable_Admin_Notices' ) ) :
+
+
+/**
+ * Disable Admin Notices Integration
+ *
+ * @link https://wordpress.org/plugins/disable-admin-notices/
+ *
+ * @since 5.7.2-dev.1
+ */
+class Disable_Admin_Notices {
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 5.7.2-dev.1
+	 */
+	public function __construct() {
+
+		$this->add_hooks();
+	}
+
+
+	/**
+	 * Setup integration hooks.
+	 *
+	 * @since 5.7.2-dev.1
+	 */
+	protected function add_hooks() {
+
+		// priority must be strictly less than 20 - see callback description
+		add_action( 'admin_footer',  [ $this, 'enqueue_conflict_fix_script' ], 10 );
+	}
+
+
+	/**
+	 * Enqueues a JavaScript snippet used to prevent an Uncaught DOMException when Disable Admin Notices is active.
+	 *
+	 * The snippet must be rendered in all pages to prevent the error when other SkyVerge plugins using previous versions of the framework render notices.
+	 * The snippet must be rendered on callback for the admin_footer action with a priority less than 20 to make sure it runs before the JS code that triggers the error.
+	 * The conflict was detected on Disable Admin Notices 1.1.1 and we don't know whether there is a solution on the roadmap.
+	 *
+	 * @internal
+	 *
+	 * @since 5.7.2-dev.1
+	 */
+	public function enqueue_conflict_fix_script() {
+
+		ob_start();
+
+		?>
+
+		// prevent Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The new child element contains the parent.
+		// Webcraftic's Disable Admin Notices can cause the placeholder to be included inside one of the notices
+		// here we make sure that the placeholder and other visible notices are siblings
+		$( '[class*="admin-notice-placeholder"]' ).each( function() {
+
+			$placeholder = $( this );
+			$container   = $placeholder.closest( '.js-wc-plugin-framework-admin-notice' );
+
+			if ( $container.length ) {
+
+				try {
+					$container.find( '.wbcr-dan-hide-notice-link' ).insertAfter( $container.find( '.wbcr-dan-hide-notices' ) );
+					$placeholder.insertAfter( $container );
+				} catch ( e ) {
+					// we tried...
+				}
+			}
+		} );
+
+		<?php
+
+		wc_enqueue_js( ob_get_clean() );
+	}
+
+
+}
+
+
+endif;

--- a/woocommerce/Integrations/Integrations.php
+++ b/woocommerce/Integrations/Integrations.php
@@ -54,7 +54,7 @@ class Integrations {
 	 *
 	 * @since 4.1.0
 	 *
-	 * @param SV_WC_Payment_Gateway $gateway direct gateway instance
+	 * @param Framework\SV_WC_Plugin $gateway direct gateway instance
 	 */
 	public function __construct( Framework\SV_WC_Plugin $plugin ) {
 

--- a/woocommerce/Integrations/Integrations.php
+++ b/woocommerce/Integrations/Integrations.php
@@ -38,6 +38,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_7_1\\Integrat
  */
 class Integrations {
 
+
 	/** Disable Admin Notice integration ID */
 	const INTEGRATION_DISABLE_ADMIN_NOTICES = 'disable-admin-notices';
 

--- a/woocommerce/Integrations/Integrations.php
+++ b/woocommerce/Integrations/Integrations.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_7_1\Integrations;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_7_1 as Framework;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_7_1\\Integrations\\Integrations' ) ) :
+
+
+/**
+ * Plugin integrations class.
+ *
+ * @since 5.7.2-dev.1
+ */
+class Integrations {
+
+	/** @var Framework\SV_WC_Plugin plugin instance */
+	protected $plugin;
+
+	/** @var array of plugin integration objects */
+	protected $integrations = [];
+
+
+	/**
+	 * Bootstraps the class.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param SV_WC_Payment_Gateway $gateway direct gateway instance
+	 */
+	public function __construct( Framework\SV_WC_Plugin $plugin ) {
+
+		$this->plugin = $plugin;
+
+		$this->init_integrations();
+	}
+
+
+	/** Integrations Feature **************************************************/
+
+
+	/**
+	 * Initializes supported integrations.
+	 *
+	 * @since 5.7.2-dev.1
+	 */
+	protected function init_integrations() {
+
+	}
+
+
+	/**
+	 * Gets the plugin instance
+	 *
+	 * @since 5.7.2-dev.1
+	 *
+	 * @return Framework\SV_WC_Plugin
+	 */
+	public function get_plugin() {
+
+		return $this->plugin;
+	}
+
+
+	/**
+	 * Gets an array of available integration objects
+	 *
+	 * @since 5.7.2-dev.1
+	 *
+	 * @return array
+	 */
+	public function get_integrations() {
+
+		return $this->integrations;
+	}
+
+
+	/**
+	 * Gets the integration object for the given ID.
+	 *
+	 * @since 5.7.2-dev.1
+	 *
+	 * @param string $id the integration ID, e.g. disable-admin-notices
+	 * @return object|null
+	 */
+	public function get_integration( $id ) {
+
+		return isset( $this->integrations[ $id ] ) ? $this->integrations[ $id ] : null;
+	}
+
+
+}
+
+
+endif;

--- a/woocommerce/Integrations/Integrations.php
+++ b/woocommerce/Integrations/Integrations.php
@@ -38,6 +38,9 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_7_1\\Integrat
  */
 class Integrations {
 
+	/** Disable Admin Notice integration ID */
+	const INTEGRATION_DISABLE_ADMIN_NOTICES = 'disable-admin-notices';
+
 	/** @var Framework\SV_WC_Plugin plugin instance */
 	protected $plugin;
 
@@ -70,6 +73,35 @@ class Integrations {
 	 */
 	protected function init_integrations() {
 
+		if ( $this->is_disable_admin_notices_active() ) {
+			$this->integrations[ self::INTEGRATION_DISABLE_ADMIN_NOTICES ] = $this->build_disable_admin_notices_integration();
+		}
+	}
+
+
+	/**
+	 * Determines whether the Disable Admin Notices plugin is active.
+	 *
+	 * @since 5.7.2-dev.1
+	 *
+	 * @return bool
+	 */
+	protected function is_disable_admin_notices_active() {
+
+		return $this->get_plugin()->is_plugin_active( 'disable-admin-notices.php' );
+	}
+
+
+	/**
+	 * Creates an instance of the integration class for Disable Admin Notices plugin.
+	 *
+	 * @since 5.7.2-dev.1
+	 *
+	 * @return object
+	 */
+	protected function build_disable_admin_notices_integration() {
+
+		return new Disable_Admin_Notices();
 	}
 
 

--- a/woocommerce/Integrations/Integrations.php
+++ b/woocommerce/Integrations/Integrations.php
@@ -64,9 +64,6 @@ class Integrations {
 	}
 
 
-	/** Integrations Feature **************************************************/
-
-
 	/**
 	 * Initializes supported integrations.
 	 *

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -63,11 +63,11 @@ class SV_WC_Admin_Notice_Handler {
 
 		$this->plugin      = $plugin;
 
-		// render any admin notices, delayed notices, and
-		add_action( 'admin_notices', array( $this, 'render_admin_notices'         ), 15 );
+		// render any admin notices, delayed notices, and admin notice JS
+		add_action( 'admin_notices', [ $this, 'render_admin_notices'         ],              15 );
 		add_action( 'admin_footer',  [ $this, 'render_disable_admin_notices_conflict_fix' ], 10 );
-		add_action( 'admin_footer',  array( $this, 'render_delayed_admin_notices' ), 15 );
-		add_action( 'admin_footer',  array( $this, 'render_admin_notice_js'       ), 20 );
+		add_action( 'admin_footer',  [ $this, 'render_delayed_admin_notices' ],              15 );
+		add_action( 'admin_footer',  [ $this, 'render_admin_notice_js'       ],              20 );
 
 		// AJAX handler to dismiss any warning/error notices
 		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', array( $this, 'handle_dismiss_notice' ) );

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -64,9 +64,9 @@ class SV_WC_Admin_Notice_Handler {
 		$this->plugin      = $plugin;
 
 		// render any admin notices, delayed notices, and admin notice JS
-		add_action( 'admin_notices', [ $this, 'render_admin_notices'         ],              15 );
-		add_action( 'admin_footer',  [ $this, 'render_delayed_admin_notices' ],              15 );
-		add_action( 'admin_footer',  [ $this, 'render_admin_notice_js'       ],              20 );
+		add_action( 'admin_notices', [ $this, 'render_admin_notices'         ], 15 );
+		add_action( 'admin_footer',  [ $this, 'render_delayed_admin_notices' ], 15 );
+		add_action( 'admin_footer',  [ $this, 'render_admin_notice_js'       ], 20 );
 
 		// AJAX handler to dismiss any warning/error notices
 		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', array( $this, 'handle_dismiss_notice' ) );

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -65,7 +65,6 @@ class SV_WC_Admin_Notice_Handler {
 
 		// render any admin notices, delayed notices, and admin notice JS
 		add_action( 'admin_notices', [ $this, 'render_admin_notices'         ],              15 );
-		add_action( 'admin_footer',  [ $this, 'render_disable_admin_notices_conflict_fix' ], 10 );
 		add_action( 'admin_footer',  [ $this, 'render_delayed_admin_notices' ],              15 );
 		add_action( 'admin_footer',  [ $this, 'render_admin_notice_js'       ],              20 );
 
@@ -235,48 +234,6 @@ class SV_WC_Admin_Notice_Handler {
 			( ! $params['is_visible'] ) ? 'style="display:none;"' : '',
 			wp_kses_post( $message )
 		);
-	}
-
-
-	/**
-	 * Renders a JavaScript snippet used to prevent an Uncaught DOMException when Disable Admin Notices is active.
-	 *
-	 * The snippet must be rendered in all pages to prevent the error when other SkyVerge plugins using previous versions of the framework render notices.
-	 * The snippet must be rendered on callback for the admin_footer action with a priority less than 20 to make sure it runs before the JS code that triggers the error.
-	 * The conflict was detected on Disable Admin Notices 1.1.1 and we don't know whether there is a solution on the roadmap.
-	 *
-	 * @internal
-	 *
-	 * @since 5.7.2
-	 */
-	public function render_disable_admin_notices_conflict_fix() {
-
-		ob_start();
-
-		?>
-
-		// prevent Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The new child element contains the parent.
-		// Webcraftic's Disable Admin Notices can cause the placeholder to be included inside one of the notices
-		// here we make sure that the placeholder and other visible notices are siblings
-		$( '[class*="admin-notice-placeholder"]' ).each( function() {
-
-			$placeholder = $( this );
-			$container   = $placeholder.closest( '.js-wc-plugin-framework-admin-notice' );
-
-			if ( $container.length ) {
-
-				try {
-					$container.find( '.wbcr-dan-hide-notice-link' ).insertAfter( $container.find( '.wbcr-dan-hide-notices' ) );
-					$placeholder.insertAfter( $container );
-				} catch ( e ) {
-					// we tried...
-				}
-			}
-		} );
-
-		<?php
-
-		wc_enqueue_js( ob_get_clean() );
 	}
 
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -295,8 +295,27 @@ class SV_WC_Admin_Notice_Handler {
 			);
 		}
 
-		// move any delayed notices up into position .show();
-		$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ).show();
+		(function() {
+
+			var $placeholder = $( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ),
+			    $container   = $placeholder.closest( '.js-wc-plugin-framework-admin-notice' );
+
+			// prevent Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The new child element contains the parent.
+			// Webcraftic's Disable Admin Notices can cause the placeholder to be included inside one of the notices
+			// here we make sure that the placeholder and other visible notices are siblings
+			if ( $container.length ) {
+
+				try {
+					$container.find( '.wbcr-dan-hide-notice-link' ).insertAfter( $container.find( '.wbcr-dan-hide-notices' ) );
+					$placeholder.insertAfter( $container );
+				} catch ( e ) {
+					// we tried...
+				}
+			}
+
+			// move any delayed notices up into position .show();
+			$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( $placeholder ).show();
+		})();
 		<?php
 		$javascript = ob_get_clean();
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -242,7 +242,8 @@ class SV_WC_Admin_Notice_Handler {
 	 * Renders a JavaScript snippet used to prevent an Uncaught DOMException when Disable Admin Notices is active.
 	 *
 	 * The snippet must be rendered in all pages to prevent the error when other SkyVerge plugins using previous versions of the framework render notices.
-	 * The conflict was detected on Disable Admin Notices 1.1.1 and we don't whether there is a solution on the roadmap.
+	 * The snippet must be rendered on callback for the admin_footer action with a priority less than 20 to make sure it runs before the JS code that triggers the error.
+	 * The conflict was detected on Disable Admin Notices 1.1.1 and we don't know whether there is a solution on the roadmap.
 	 *
 	 * @internal
 	 *

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -338,10 +338,8 @@ class SV_WC_Admin_Notice_Handler {
 			);
 		}
 
-		(function() {
-			// move any delayed notices up into position .show();
-			$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ).show();
-		})();
+		// move any delayed notices up into position .show();
+		$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ).show();
 		<?php
 		$javascript = ob_get_clean();
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -480,6 +480,7 @@ abstract class SV_WC_Plugin {
 
 		// Integrations
 		require_once( $framework_path . '/Integrations/Integrations.php' );
+		require_once( $framework_path . '/Integrations/Disable_Admin_Notices.php' );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -96,6 +96,8 @@ abstract class SV_WC_Plugin {
 	/** @var SV_WC_Admin_Notice_Handler the admin notice handler class */
 	private $admin_notice_handler;
 
+	/** @var Integrations\Integrations */
+	private $integrations;
 
 	/**
 	 * Initialize the plugin.
@@ -158,6 +160,8 @@ abstract class SV_WC_Plugin {
 
 		// build the setup handler instance
 		$this->init_setup_wizard_handler();
+
+		$this->init_integrations();
 
 		// add the action & filter hooks
 		$this->add_hooks();
@@ -262,6 +266,17 @@ abstract class SV_WC_Plugin {
 	protected function init_setup_wizard_handler() {
 
 		require_once( $this->get_framework_path() . '/admin/abstract-sv-wc-plugin-admin-setup-wizard.php' );
+	}
+
+
+	/**
+	 * Builds the Integrations instance.
+	 *
+	 * @return 5.7.2-dev.1
+	 */
+	protected function init_integrations() {
+
+		$this->integrations = new Integrations\Integrations( $this );
 	}
 
 
@@ -462,6 +477,9 @@ abstract class SV_WC_Plugin {
 		require_once( $framework_path . '/class-sv-wc-admin-notice-handler.php' );
 		require_once( $framework_path . '/Lifecycle.php' );
 		require_once( $framework_path . '/rest-api/class-sv-wc-plugin-rest-api.php' );
+
+		// Integrations
+		require_once( $framework_path . '/Integrations/Integrations.php' );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR fixes a JavaScript conflict between the framework's admin notice handler and the Disable Admin Notices plugin.

### Story: [CH 54179](https://app.clubhouse.io/skyverge/story/54179)
### Release: #496 

## Details

This is one is caused by a series of unfortunate events:

The JavaScript we see in the console is the result of an exception triggered in:

https://github.com/skyverge/wc-plugin-framework/blob/a9d6777e95377ce47c9d4d0f84f677c1c795d569/woocommerce/class-sv-wc-admin-notice-handler.php#L299

The exception occurs because the placeholder is being rendered inside one of the notices:

We render the notice and the placeholder correctly, but the Disable Admin Notices plugin [runs the callbacks attached to the `admin_notices` hook](https://plugins.trac.wordpress.org/browser/disable-admin-notices/trunk/includes/classes/class-configurate-notices.php?rev=2138539#L246) on its own and uses regular expressions to [inject](https://plugins.trac.wordpress.org/browser/disable-admin-notices/trunk/includes/classes/class-configurate-notices.php?rev=2138539#L294) the **Hide notification forever** link.

Unfortunately, the regular expression assumes that only one notice (or top level element) is rendered per callback. If two or more notifications (or top level elements) are rendered by the same callback, the regular expression causes the second and subsequent elements to become children of the first element.

In the notice handler case, the regular expression causes the placeholder to become a child of one of the notifications. That triggers an exception when we execute that JS line from above trying to move notifications after the placeholder.

Normally, that line shouldn't trigger an exception because the placeholder is rendered next to a visible notice, and the script tries to move hidden notices. However, WooCommerce has been rendering notices inside `<div class="woocommerce-layout__notice-list-hide" id="wp__notice-list"></div>` since v4.0. That causes our visible notices to become hidden when the page loads, and as a result, that JS line tries to move the container of an elment, next to that very same element.

This PR uses JavaScript to check whether there are framework placeholders inside notifications and move them out.

The snippet targets placeholders rendered by the admin notice handler included in any plugin, not just the plugin that loaded this version of the framework. The goal is to prevent the JavaScript exception without having to role out an update on every plugin.

To achieve that goal, however, I had to render the snippet on every admin page and make sure it was rendered before any other JavaScript generated by the admin notice handlers.

---

The snippet prevents the exception, but doesn't get the "Hide notification forever" link working on all of our notices. The main reason for that is that due to the bug in Disable Admin Notices plugin, only one link is injected regardless of the number of notices that we render. As a result, the second and subsequent notices from the same plugin don't get the link.

## QA

### Setup

- Activate Elavon Converge using this branch of the framework: `dev-ch54179/conflict-with-disable-admin-notices-by-webcraftic` (easiest because there is no need to change the framework namespace)
- Activate Facebook for WooCommerce (don't change the framework branch)
- Add the following snippet to render an admin notice

```php
add_action( 'admin_init', function() {

	if ( function_exists( 'wc_elavon_converge' ) ) {
		wc_elavon_converge()->get_admin_notice_handler()->add_admin_notice( 'Hello World 1!', 'wc-plugin-framework/ch54179-1' );
		wc_elavon_converge()->get_admin_notice_handler()->add_admin_notice( 'Hello World 2!', 'wc-plugin-framework/ch54179-2' );
		wc_elavon_converge()->get_admin_notice_handler()->add_admin_notice( 'Hello World 3!', 'wc-plugin-framework/ch54179-3' );
	}

	if ( function_exists( 'facebook_for_woocommerce' ) ) {
		facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice( 'Hello Facebook 1!', 'wc-plugin-framework/ch54179-facebook-1' );
		facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice( 'Hello Facebook 2!', 'wc-plugin-framework/ch54179-facebook-2' );
		facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice( 'Hello Facebook 3!', 'wc-plugin-framework/ch54179-facebook-3' );
	}
} );
```

### Steps

1. Disable Elavon
1. Explore WooCommerce Orders, Edit Order, Products, Edit Products, and Settings pages to confirm there are JavaScript errors in the console
    - [x] The `Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The new child element contains the parent.` appears in the console
1. Enable Elavon
1. Explore WooCommerce Orders, Edit Order, Products, Edit Products, and Settings pages to confirm there are no JavaScript errors in the console
    - [x] There are no JavaScript errors in the console