### PR TITLE
Release: 5.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "skyverge/wc-plugin-framework",
     "description": "The official SkyVerge WooCommerce plugin framework",
-    "version": "5.8.0",
+    "version": "5.8.1",
     "require-dev": {
         "lucatume/wp-browser": "^2.1"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,58 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+      "dev": true
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
+      "integrity": "sha1-vWf5bAfvtjA7f+lMHpefiEeOCjk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^2.5.0"
+      }
+    },
+    "dargs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+      "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "title": "WooCommerce Plugin Framework",
   "author": "SkyVerge Team",
   "homepage": "https://github.com/skyverge/wc-plugin-framework#readme",

--- a/tests/_archive/unit/Addresses/Address.php
+++ b/tests/_archive/unit/Addresses/Address.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit\Addresses;
 
 use SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for PluginFramework\Addresses\Address

--- a/tests/_archive/unit/Addresses/Customer_Address.php
+++ b/tests/_archive/unit/Addresses/Customer_Address.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit\Addresses;
 
 use SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for PluginFramework\Addresses\Address

--- a/tests/_archive/unit/helper.php
+++ b/tests/_archive/unit/helper.php
@@ -4,7 +4,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
 use \Patchwork as p;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Helper Class Unit Tests

--- a/tests/_archive/unit/helper.php
+++ b/tests/_archive/unit/helper.php
@@ -31,7 +31,7 @@ class Helper extends Test_Case {
 	public function test_str_starts_with_ascii( $asserts_as_true, $haystack, $needle ) {
 
 		// force ASCII handling
-		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_3_0\SV_WC_Helper::multibyte_loaded', function() { return false; } );
+		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Helper::multibyte_loaded', function() { return false; } );
 
 		if ( $asserts_as_true ) {
 			$this->assertTrue( PluginFramework\SV_WC_Helper::str_starts_with( $haystack, $needle ) );
@@ -116,7 +116,7 @@ class Helper extends Test_Case {
 	public function test_str_ends_with_ascii( $asserts_as_true, $haystack, $needle ) {
 
 		// force ASCII handling
-		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_3_0\SV_WC_Helper::multibyte_loaded', function() { return false; } );
+		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Helper::multibyte_loaded', function() { return false; } );
 
 		if ( $asserts_as_true ) {
 			$this->assertTrue( PluginFramework\SV_WC_Helper::str_ends_with( $haystack, $needle ) );
@@ -265,7 +265,7 @@ class Helper extends Test_Case {
 	public function test_str_exists_ascii( $asserts_as_true, $haystack, $needle ) {
 
 		// force ASCII handling
-		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_3_0\SV_WC_Helper::multibyte_loaded', function() { return false; } );
+		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Helper::multibyte_loaded', function() { return false; } );
 
 		if ( $asserts_as_true ) {
 			$this->assertTrue( PluginFramework\SV_WC_Helper::str_exists( $haystack, $needle ) );
@@ -346,7 +346,7 @@ class Helper extends Test_Case {
 	public function test_str_truncate_ascii() {
 
 		// force ASCII handling
-		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_3_0\SV_WC_Helper::multibyte_loaded', function() { return false; } );
+		p\redefine( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Helper::multibyte_loaded', function() { return false; } );
 
 		$the_string = 'The quick brown fox jumps ಠ_ಠ';
 

--- a/tests/_archive/unit/payment-gateway-api-response-message-helper.php
+++ b/tests/_archive/unit/payment-gateway-api-response-message-helper.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_API_Response_Message_Helper

--- a/tests/_archive/unit/payment-gateway-helper.php
+++ b/tests/_archive/unit/payment-gateway-helper.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Helper

--- a/tests/_archive/unit/payment-gateway-payment-token.php
+++ b/tests/_archive/unit/payment-gateway-payment-token.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Payment_Token

--- a/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
@@ -21,7 +21,7 @@ class Payment_Gateway_Apple_Pay_API_Request extends Test_Case {
 	 */
 	public function test_set_merchant_data( $merchant_id, $domain_name, $display_name, $expected ) {
 
-		$gateway = $this->getMockBuilder( '\SkyVerge\WooCommerce\PluginFramework\v5_3_0\SV_WC_Payment_Gateway' )->getMock();
+		$gateway = $this->getMockBuilder( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway' )->getMock();
 
 		$request = new PluginFramework\SV_WC_Payment_Gateway_Apple_Pay_API_Request( $gateway );
 

--- a/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-api-request.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_API_Request

--- a/tests/_archive/unit/payment-gateway/apple-pay-api-response.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-api-response.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_API_Response

--- a/tests/_archive/unit/payment-gateway/apple-pay-payment-response.php
+++ b/tests/_archive/unit/payment-gateway/apple-pay-payment-response.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Unit tests for \SV_WC_Payment_Gateway_Apple_Pay_Payment_Response

--- a/tests/_archive/unit/plugin.php
+++ b/tests/_archive/unit/plugin.php
@@ -15,7 +15,7 @@ class Plugin extends Test_Case {
 
 	public function test_constructor() {
 
-		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_3_0\SV_WC_Plugin', $this->plugin() );
+		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin', $this->plugin() );
 	}
 
 	public function test_clone() {
@@ -135,7 +135,7 @@ MSG;
 			),
 		);
 
-		return $this->getMockBuilder( '\SkyVerge\WooCommerce\PluginFramework\v5_3_0\SV_WC_Plugin' )
+		return $this->getMockBuilder( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin' )
 							 ->setConstructorArgs( $args )
 							 ->getMockForAbstractClass();
 	}

--- a/tests/_archive/unit/plugin.php
+++ b/tests/_archive/unit/plugin.php
@@ -3,7 +3,7 @@
 namespace SkyVerge\WooCommerce\PluginFramework\Tests\Unit;
 
 use \WP_Mock as Mock;
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as PluginFramework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as PluginFramework;
 
 /**
  * Plugin Test

--- a/tests/_support/plugins/gateway-test-plugin/includes/API.php
+++ b/tests/_support/plugins/gateway-test-plugin/includes/API.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SkyVerge\WooCommerce\GatewayTestPlugin;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
+
+defined( 'ABSPATH' ) or exit;
+
+class API implements Framework\SV_WC_Payment_Gateway_API {
+
+	public function credit_card_authorization( \WC_Order $order ) { }
+
+	public function credit_card_charge( \WC_Order $order ) { }
+
+	public function credit_card_capture( \WC_Order $order ) { }
+
+	public function check_debit( \WC_Order $order ) { }
+
+	public function refund( \WC_Order $order ) { }
+
+	public function void( \WC_Order $order ) { }
+
+	public function tokenize_payment_method( \WC_Order $order ) { }
+
+	public function update_tokenized_payment_method( \WC_Order $order ) { }
+
+	public function supports_update_tokenized_payment_method() { }
+
+	public function remove_tokenized_payment_method( $token, $customer_id ) { }
+
+	public function supports_remove_tokenized_payment_method() {
+
+		return false;
+	}
+
+	public function get_tokenized_payment_methods( $customer_id ) { }
+
+	public function supports_get_tokenized_payment_methods() { }
+
+	public function get_request() { }
+
+	public function get_response() { }
+
+	public function get_order() { }
+}
+

--- a/tests/_support/plugins/gateway-test-plugin/includes/Gateway.php
+++ b/tests/_support/plugins/gateway-test-plugin/includes/Gateway.php
@@ -28,4 +28,12 @@ class Gateway extends Framework\SV_WC_Payment_Gateway {
 
 		return [];
 	}
+
+
+	public function get_api() {
+
+		return new API();
+	}
+
+
 }

--- a/tests/_support/plugins/gateway-test-plugin/includes/Gateway.php
+++ b/tests/_support/plugins/gateway-test-plugin/includes/Gateway.php
@@ -2,7 +2,7 @@
 
 namespace SkyVerge\WooCommerce\GatewayTestPlugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/_support/plugins/gateway-test-plugin/includes/Plugin.php
+++ b/tests/_support/plugins/gateway-test-plugin/includes/Plugin.php
@@ -1,7 +1,7 @@
 <?php
 namespace SkyVerge\WooCommerce\GatewayTestPlugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/_support/plugins/test-plugin/includes/API.php
+++ b/tests/_support/plugins/test-plugin/includes/API.php
@@ -1,7 +1,7 @@
 <?php
 namespace SkyVerge\WooCommerce\TestPlugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/_support/plugins/test-plugin/includes/Gateway.php
+++ b/tests/_support/plugins/test-plugin/includes/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 namespace SkyVerge\WooCommerce\TestPlugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/_support/plugins/test-plugin/includes/Plugin.php
+++ b/tests/_support/plugins/test-plugin/includes/Plugin.php
@@ -1,7 +1,7 @@
 <?php
 namespace SkyVerge\WooCommerce\TestPlugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 

--- a/tests/integration/DependenciesTest.php
+++ b/tests/integration/DependenciesTest.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the SV_WC_Plugin_Dependencies class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Dependencies
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Dependencies
  */
 class DependenciesTest extends \Codeception\TestCase\WPTestCase {
 
@@ -31,7 +31,7 @@ class DependenciesTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Dependencies::get_active_scripts_optimization_plugins()
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Dependencies::get_active_scripts_optimization_plugins()
 	 */
 	public function test_get_active_scripts_optimization_plugins() {
 
@@ -40,7 +40,7 @@ class DependenciesTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Dependencies::is_scripts_optimization_plugin_active()
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Dependencies::is_scripts_optimization_plugin_active()
 	 */
 	public function test_is_scripts_optimization_plugin_active() {
 

--- a/tests/integration/PluginTest.php
+++ b/tests/integration/PluginTest.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the base plugin class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin
  */
 class PluginTest extends \Codeception\TestCase\WPTestCase {
 
@@ -152,7 +152,7 @@ class PluginTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_get_dependency_handler() {
 
-		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Dependencies', $this->get_plugin()->get_dependency_handler() );
+		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Dependencies', $this->get_plugin()->get_dependency_handler() );
 	}
 
 
@@ -161,7 +161,7 @@ class PluginTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_get_lifecycle_handler() {
 
-		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_8_0\Plugin\Lifecycle', $this->get_plugin()->get_lifecycle_handler() );
+		$this->assertInstanceOf( '\SkyVerge\WooCommerce\PluginFramework\v5_8_1\Plugin\Lifecycle', $this->get_plugin()->get_lifecycle_handler() );
 	}
 
 

--- a/tests/integration/REST_API/Controllers/SettingsTest.php
+++ b/tests/integration/REST_API/Controllers/SettingsTest.php
@@ -1,14 +1,14 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\REST_API\Controllers\Settings;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Abstract_Settings;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Control;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\REST_API\Controllers\Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Control;
 
 /**
  * Tests for the Settings class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\REST_API\Controllers\Settings
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\REST_API\Controllers\Settings
  */
 class SettingsTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/REST_API/RESTAPITest.php
+++ b/tests/integration/REST_API/RESTAPITest.php
@@ -1,13 +1,13 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Abstract_Settings;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Helper;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Helper;
 
 /**
  * Tests for the REST_API class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\REST_API
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\REST_API
  */
 class RESTAPITest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/Settings_API/AbstractSettingsTest.php
+++ b/tests/integration/Settings_API/AbstractSettingsTest.php
@@ -1,15 +1,15 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Abstract_Settings;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Control;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Control;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Exception;
 
 /**
  * Tests for the Abstract_Settings class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Abstract_Settings
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Abstract_Settings
  */
 class AbstractSettingsTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/Settings_API/SettingTest.php
+++ b/tests/integration/Settings_API/SettingTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Exception;
 
 class SettingTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/payment-gateway/GatewayPluginTest.php
+++ b/tests/integration/payment-gateway/GatewayPluginTest.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the gateway plugin class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Plugin
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Plugin
  */
 class GatewayPluginTest extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/payment-gateway/MyPaymentMethodsTest.php
+++ b/tests/integration/payment-gateway/MyPaymentMethodsTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_My_Payment_Methods;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_My_Payment_Methods;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Plugin;
 
 /**
  * Tests for the SV_WC_Payment_Gateway_My_Payment_Methods class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_My_Payment_Methods
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_My_Payment_Methods
  */
 class MyPaymentMethodsTest extends \Codeception\TestCase\WPTestCase {
 
@@ -116,7 +116,7 @@ class MyPaymentMethodsTest extends \Codeception\TestCase\WPTestCase {
 		$payment_methods->render_js();
 
 		$this->assertStringContainsString( 'function load_gateway_test_plugin_payment_methods_handler', $wc_queued_js );
-		$this->assertStringContainsString( 'window.jQuery( document.body ).on( \'sv_wc_payment_methods_handler_v5_8_0_loaded\', load_gateway_test_plugin_payment_methods_handler );', $wc_queued_js );
+		$this->assertStringContainsString( 'window.jQuery( document.body ).on( \'sv_wc_payment_methods_handler_v5_8_1_loaded\', load_gateway_test_plugin_payment_methods_handler );', $wc_queued_js );
 	}
 
 

--- a/tests/integration/payment-gateway/PaymentFormTest.php
+++ b/tests/integration/payment-gateway/PaymentFormTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Payment_Form;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Payment_Form;
 
 /**
  * Tests for the SV_WC_Payment_Gateway_Payment_Form class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Payment_Form
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Payment_Form
  */
 class PaymentFormTest extends \Codeception\TestCase\WPTestCase {
 
@@ -90,7 +90,7 @@ class PaymentFormTest extends \Codeception\TestCase\WPTestCase {
 		$this->get_plugin()->get_gateway()->get_payment_form_instance()->render_js();
 
 		$this->assertStringContainsString( 'function load_test_gateway_payment_form_handler', $wc_queued_js );
-		$this->assertStringContainsString( 'window.jQuery( document.body ).on( \'sv_wc_payment_form_handler_v5_8_0_loaded\', load_test_gateway_payment_form_handler );', $wc_queued_js );
+		$this->assertStringContainsString( 'window.jQuery( document.body ).on( \'sv_wc_payment_form_handler_v5_8_1_loaded\', load_test_gateway_payment_form_handler );', $wc_queued_js );
 	}
 
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Token_Test.php
@@ -1,11 +1,11 @@
 <?php
 
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 /**
  * Tests for the payment token object
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Payment_Token
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Payment_Token
  */
 class SV_WC_Payment_Gateway_Payment_Token_Test extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
+++ b/tests/integration/payment-gateway/SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test.php
@@ -1,11 +1,11 @@
 <?php
 
-use \SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use \SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 /**
  * Tests for the payment tokens handler object
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Payment_Tokens_Handler
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Payment_Tokens_Handler
  */
 class SV_WC_Payment_Gateway_Payment_Tokens_Handler_Test extends \Codeception\TestCase\WPTestCase {
 

--- a/tests/integration/payment-gateway/apple-pay/ApplePayFrontendTest.php
+++ b/tests/integration/payment-gateway/apple-pay/ApplePayFrontendTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Apple_Pay;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Apple_Pay_Frontend;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Apple_Pay;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Apple_Pay_Frontend;
 
 /**
  * Tests for the SV_WC_Payment_Gateway_Apple_Pay_Frontend class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Apple_Pay_Frontend
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Apple_Pay_Frontend
  */
 class ApplePayFrontendTest extends \Codeception\TestCase\WPTestCase {
 
@@ -114,7 +114,7 @@ class ApplePayFrontendTest extends \Codeception\TestCase\WPTestCase {
 		$method->invokeArgs( $frontend, [[]] );
 
 		$this->assertStringContainsString( 'function load_test_gateway_apple_pay_handler', $wc_queued_js );
-		$this->assertStringContainsString( 'window.jQuery( document.body ).on( \'sv_wc_apple_pay_handler_v5_8_0_loaded\', load_test_gateway_apple_pay_handler );', $wc_queued_js );
+		$this->assertStringContainsString( 'window.jQuery( document.body ).on( \'sv_wc_apple_pay_handler_v5_8_1_loaded\', load_test_gateway_apple_pay_handler );', $wc_queued_js );
 	}
 
 

--- a/tests/unit/CountryHelperTest.php
+++ b/tests/unit/CountryHelperTest.php
@@ -19,7 +19,7 @@ class CountryHelperTest extends \Codeception\Test\Unit {
 	}
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Country_Helper::convert_alpha_country_code()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Country_Helper::convert_alpha_country_code()
 	 *
 	 * @param string $code input country code
 	 * @param string $expected expected return value
@@ -28,7 +28,7 @@ class CountryHelperTest extends \Codeception\Test\Unit {
 	 */
 	public function test_convert_alpha_country_code( $code, $expected ) {
 
-		$result = \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Country_Helper::convert_alpha_country_code( $code );
+		$result = \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Country_Helper::convert_alpha_country_code( $code );
 
 		$this->assertEquals( $expected, $result );
 	}

--- a/tests/unit/Settings_API/ControlTest.php
+++ b/tests/unit/Settings_API/ControlTest.php
@@ -2,8 +2,8 @@
 
 namespace Settings_API;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Control;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Control;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Exception;
 use TypeError;
 
 define( 'ABSPATH', true );

--- a/tests/unit/Settings_API/SettingTest.php
+++ b/tests/unit/Settings_API/SettingTest.php
@@ -2,9 +2,9 @@
 
 namespace Settings_API;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Control;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Control;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Exception;
 
 define( 'ABSPATH', true );
 
@@ -33,7 +33,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_id()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_id()
 	 *
 	 * @param string $input input ID
 	 * @param string $expected expected return ID
@@ -50,7 +50,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_type()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_type()
 	 *
 	 * @param string $input input type
 	 * @param string $expected expected return type
@@ -67,7 +67,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_name()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_name()
 	 *
 	 * @param string $input input name
 	 * @param string $expected expected return name
@@ -84,7 +84,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_description()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_description()
 	 *
 	 * @param string $input input description
 	 * @param string $expected expected return description
@@ -101,7 +101,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_is_multi()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_is_multi()
 	 *
 	 * @param bool $input input value
 	 * @param bool $expected expected return value
@@ -118,7 +118,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_options()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_options()
 	 *
 	 * @param array $input input options
 	 * @param array $expected expected return options
@@ -135,7 +135,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_default()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_default()
 	 *
 	 * @param int|float|string|bool|array $input input default value
 	 * @param int|float|string|bool|array $expected expected return default value
@@ -152,7 +152,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_value()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_value()
 	 *
 	 * @param int|float|string|bool|array $input input value
 	 * @param int|float|string|bool|array $expected expected return value
@@ -169,7 +169,7 @@ class SettingTest extends \Codeception\Test\Unit {
 
 
 	/**
-	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting::set_control()
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting::set_control()
 	 *
 	 * @param Control $input input control
 	 * @param Control $expected expected return control

--- a/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce-framework-plugin-loader-sample.php
@@ -58,7 +58,7 @@ class SV_WC_Framework_Plugin_Loader {
 	const MINIMUM_WC_VERSION = '3.0.9';
 
 	/** SkyVerge plugin framework version used by this plugin */
-	const FRAMEWORK_VERSION = '5.7.0'; // TODO: framework version
+	const FRAMEWORK_VERSION = '5.8.1'; // TODO: framework version
 
 	/** the plugin name, for displaying notices */
 	const PLUGIN_NAME = 'WooCommerce Framework Plugin'; // TODO: plugin name

--- a/woocommerce/Addresses/Address.php
+++ b/woocommerce/Addresses/Address.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Addresses;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Addresses;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Addresses\\Address' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Addresses\\Address' ) ) :
 
 
 /**

--- a/woocommerce/Addresses/Customer_Address.php
+++ b/woocommerce/Addresses/Customer_Address.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Addresses;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Addresses;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Addresses\\Customer_Address' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Addresses\\Customer_Address' ) ) :
 
 
 /**

--- a/woocommerce/Country_Helper.php
+++ b/woocommerce/Country_Helper.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Country_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Country_Helper' ) ) :
 
 
 /**

--- a/woocommerce/Handlers/Script_Handler.php
+++ b/woocommerce/Handlers/Script_Handler.php
@@ -22,14 +22,14 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Helper;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Helper;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Exception;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Handlers\\Script_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Handlers\\Script_Handler' ) ) :
 
 
 /**
@@ -79,7 +79,7 @@ abstract class Script_Handler {
 	 */
 	protected function get_js_handler_class_name() {
 
-		return sprintf( '%s_v5_8_0', $this->js_handler_base_class_name );
+		return sprintf( '%s_v5_8_1', $this->js_handler_base_class_name );
 	}
 
 

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -22,16 +22,16 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Plugin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Plugin;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Admin\Notes_Helper;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Plugin;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Plugin_Compatibility;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Admin\Notes_Helper;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Plugin_Compatibility;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Plugin\\Lifecycle' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Plugin\\Lifecycle' ) ) :
 
 
 /**

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Settings_API\\Abstract_Settings' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Settings_API\\Abstract_Settings' ) ) :
 
 /**
  * The base settings handler.

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Settings_API\\Control' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Settings_API\\Control' ) ) :
 
 /**
  * The base control object.

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Settings_API\\Setting' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Settings_API\\Setting' ) ) :
 
 /**
  * The base setting object.

--- a/woocommerce/admin/Notes_Helper.php
+++ b/woocommerce/admin/Notes_Helper.php
@@ -21,13 +21,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Admin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Admin;
 
 use Automattic\WooCommerce\Admin\Notes as WooCommerce_Admin_Notes;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Admin\\Notes_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Admin\\Notes_Helper' ) ) :
 
 /**
  * Helper class for WooCommerce enhanced admin notes.

--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -21,13 +21,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Admin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Admin\\Setup_Wizard' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Admin\\Setup_Wizard' ) ) :
 
 
 /**

--- a/woocommerce/api/abstract-sv-wc-api-json-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_JSON_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_JSON_Request' ) ) :
 
 
 /**

--- a/woocommerce/api/abstract-sv-wc-api-json-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_JSON_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_JSON_Response' ) ) :
 
 
 /**

--- a/woocommerce/api/abstract-sv-wc-api-xml-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_XML_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_XML_Request' ) ) :
 
 
 /**

--- a/woocommerce/api/abstract-sv-wc-api-xml-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_XML_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_XML_Response' ) ) :
 
 
 /**

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_Base' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_Base' ) ) :
 
 
 /**

--- a/woocommerce/api/class-sv-wc-api-exception.php
+++ b/woocommerce/api/class-sv-wc-api-exception.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_Exception' ) ) :
 
 
 /**

--- a/woocommerce/api/interface-sv-wc-api-request.php
+++ b/woocommerce/api/interface-sv-wc-api-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_Request' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_Request' ) ) :
 
 
 /**

--- a/woocommerce/api/interface-sv-wc-api-response.php
+++ b/woocommerce/api/interface-sv-wc-api-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_Response' ) ) :
 
 
 /**

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2020.nn.nn - version 5.8.1-dev
+
 2020.07.29 - version 5.8.0
  * Tweak - Migrate payment tokens to be compatible with WooCommerce core payment tokens
  * Fix - Unblock the UI when removing a token from the admin token editor that was just added but not saved yet

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.8.1-dev
+ * Fix - Ensure that some payment gateway scripts used for handling tokens reference the current version of the Framework
 
 2020.07.29 - version 5.8.0
  * Tweak - Migrate payment tokens to be compatible with WooCommerce core payment tokens

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Admin_Notice_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Admin_Notice_Handler' ) ) :
 
 
 /**

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 use Automattic\WooCommerce\Admin\Loader;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Helper' ) ) :
 
 
 /**

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Hook_Deprecator' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Hook_Deprecator' ) ) :
 
 
 /**

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Plugin_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Plugin_Compatibility' ) ) :
 
 
 /**

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Plugin_Dependencies' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Plugin_Dependencies' ) ) :
 
 
 /**

--- a/woocommerce/class-sv-wc-plugin-exception.php
+++ b/woocommerce/class-sv-wc-plugin-exception.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Plugin_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Plugin_Exception' ) ) :
 
 
 /**

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -43,7 +43,7 @@ abstract class SV_WC_Plugin {
 
 
 	/** Plugin Framework Version */
-	const VERSION = '5.8.0';
+	const VERSION = '5.8.1';
 
 	/** @var object single instance of plugin */
 	protected static $instance;
@@ -497,7 +497,7 @@ abstract class SV_WC_Plugin {
 			$deprecated_hooks[ $deprecated_filter ] = [
 				'removed'     => true,
 				'replacement' => false,
-				'version'     => '5.8.0'
+				'version'     => '5.8.1'
 			];
 		}
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Plugin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Plugin' ) ) :
 
 
 /**

--- a/woocommerce/class-sv-wp-admin-message-handler.php
+++ b/woocommerce/class-sv-wp-admin-message-handler.php
@@ -22,11 +22,11 @@
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WP_Admin_Message_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WP_Admin_Message_Handler' ) ) :
 
 
 /**

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Data_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Data_Compatibility' ) ) :
 
 
 /**

--- a/woocommerce/compatibility/class-sv-wc-datetime.php
+++ b/woocommerce/compatibility/class-sv-wc-datetime.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 use DateTimeZone;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_DateTime' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_DateTime' ) ) :
 
 
 /**

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Order_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Order_Compatibility' ) ) :
 
 
 /**

--- a/woocommerce/compatibility/class-sv-wc-product-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-product-compatibility.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Product_Compatibility' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Product_Compatibility' ) ) :
 
 
 /**

--- a/woocommerce/i18n/languages/woocommerce-plugin-framework-et.po
+++ b/woocommerce/i18n/languages/woocommerce-plugin-framework-et.po
@@ -256,7 +256,7 @@ msgstr "%s eksemplari ei saa deserialiseerida (unserialize)."
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version
 #. number, %3$s - opening <a> HTML link tag, %4$s - closing </a> HTML link tag
-#: class-sv-wc-plugin.php:573
+#: class-sv-wc-plugin.php:615
 msgid ""
 "Heads up! %1$s will soon discontinue support for WooCommerce %2$s. Please "
 "%3$supdate WooCommerce%4$s to take advantage of the latest updates and "
@@ -264,19 +264,19 @@ msgid ""
 msgstr ""
 
 #. translators: Docs as in Documentation
-#: class-sv-wc-plugin.php:616
+#: class-sv-wc-plugin.php:658
 msgid "Docs"
 msgstr "Dokumentatsioon"
 
-#: class-sv-wc-plugin.php:709
+#: class-sv-wc-plugin.php:751
 msgid "%1$s - A minimum of %2$s is required."
 msgstr ""
 
-#: class-sv-wc-plugin.php:718
+#: class-sv-wc-plugin.php:760
 msgid "Set as %1$s - %2$s is required."
 msgstr ""
 
-#: class-sv-wc-plugin.php:998
+#: class-sv-wc-plugin.php:1040
 #: payment-gateway/class-sv-wc-payment-gateway-plugin.php:789
 msgid "Configure"
 msgstr "Seadista"
@@ -292,7 +292,7 @@ msgstr ""
 
 #: payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php:217
 #: payment-gateway/class-sv-wc-payment-gateway.php:2813
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:489
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:512
 msgid ""
 "An error occurred, please try again or try an alternate form of payment."
 msgstr "Esines viga, palun proovi uuesti või kasuta teistsugust makseviisi."
@@ -308,7 +308,7 @@ msgstr ""
 #. - payment request response status message
 #: payment-gateway/Handlers/Abstract_Payment_Handler.php:152
 #: payment-gateway/class-sv-wc-payment-gateway.php:2406
-#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:165
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:173
 msgid "Status code %1$s: %2$s"
 msgstr "Staatuse kood %1$s: %2$s"
 
@@ -316,7 +316,7 @@ msgstr "Staatuse kood %1$s: %2$s"
 #. translators: Placeholders: %s - payment request response status code
 #: payment-gateway/Handlers/Abstract_Payment_Handler.php:155
 #: payment-gateway/class-sv-wc-payment-gateway.php:2409
-#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:168
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:176
 msgid "Status code: %s"
 msgstr "Staatuse kood: %s"
 
@@ -324,13 +324,13 @@ msgstr "Staatuse kood: %s"
 #. translators: Placeholders: %s - payment request response status message
 #: payment-gateway/Handlers/Abstract_Payment_Handler.php:158
 #: payment-gateway/class-sv-wc-payment-gateway.php:2412
-#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:171
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:179
 msgid "Status message: %s"
 msgstr "Staatuse teade: %s"
 
 #: payment-gateway/Handlers/Abstract_Payment_Handler.php:163
 #: payment-gateway/class-sv-wc-payment-gateway.php:2417
-#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:178
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:186
 msgid "Transaction ID %s"
 msgstr "Tehingu ID %s"
 
@@ -473,67 +473,67 @@ msgstr ""
 msgid "An error occurred. Please try again."
 msgstr "Sinu päringuga esines viga, palun proovi uuesti."
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:454
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:491
 #: payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:305
 msgid "(%s)"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:484
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:754
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:521
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:900
 msgid "Default"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:520
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:553
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:557
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:590
 msgid "Token ID"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:525
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:562
 #: payment-gateway/class-sv-wc-payment-gateway-privacy.php:300
 msgid "Card Type"
 msgstr "Kaardi tüüp"
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:530
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:566
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:567
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:603
 #: payment-gateway/class-sv-wc-payment-gateway-privacy.php:192
 #: payment-gateway/class-sv-wc-payment-gateway-privacy.php:298
 msgid "Last Four"
 msgstr "Viimased 4 numbrit"
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:537
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:574
 #: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:358
 msgid "Expiration (MM/YY)"
 msgstr "Aegub (KK/AA)"
 
 #. translators: e-check account type, HTML form field label
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:558
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:595
 #: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:466
 #: payment-gateway/class-sv-wc-payment-gateway-privacy.php:299
 msgid "Account Type"
 msgstr "Konto tüüp"
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:561
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:598
 msgid "Checking"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:562
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:599
 msgid "Savings"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:663
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:700
 msgid "Refresh"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:665
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:702
 msgid "Add New"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:668
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:849
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:705
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:297
 msgid "Save"
 msgstr ""
 
-#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:691
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:728
 msgid "Remove"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgid "%s Payment Tokens"
 msgstr "%s maksevahendid"
 
 #: payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:302
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:779
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:841
 msgid "Customer ID"
 msgstr "Kliendi ID"
 
@@ -624,7 +624,7 @@ msgid "Capture %s"
 msgstr "Teosta makse"
 
 #: payment-gateway/admin/views/html-order-partial-capture.php:66
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:288
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:608
 #, fuzzy
 msgid "Cancel"
 msgstr "Tühista tellimus"
@@ -1162,7 +1162,7 @@ msgstr "Tühista tellimus"
 #. account, etc), %3$s - last four digits of the card/account, %4$s -
 #. card/account expiry date
 #: payment-gateway/class-sv-wc-payment-gateway-hosted.php:597
-#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:834
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:1115
 msgid "%1$s Payment Method Saved: %2$s ending in %3$s (expires %4$s)"
 msgstr ""
 "%1$s: maksevahend salvestatud: %2$s lõpeb numbritega in %3$s (aegub %4$s)"
@@ -1171,7 +1171,7 @@ msgstr ""
 #. NETbilling, etc), %2$s - account type (checking/savings - may or may not be
 #. available), %3$s - last four digits of the account
 #: payment-gateway/class-sv-wc-payment-gateway-hosted.php:608
-#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:845
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:1126
 msgid "%1$s eCheck Payment Method Saved: %2$s account ending in %3$s"
 msgstr ""
 "%1$s: e-tšeki maksevahend salvestatud: %2$s konto, lõpeb numbritega %3$s"
@@ -1189,100 +1189,53 @@ msgstr "Minu maksevahendid."
 msgid "Tokenization failed. %s"
 msgstr "Maksevahendi salvestamise päring ebaõnnestus: %s"
 
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:287
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:848
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:293
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:607
 msgid "Edit"
 msgstr ""
 
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:289
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:337
+#: payment-gateway/class-sv-wc-payment-gateway.php:1196
+msgid "Title"
+msgstr "Nimetus"
+
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:340
+msgid "Details"
+msgstr ""
+
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:343
+#, fuzzy
+msgid "Default?"
+msgstr "(vaikimisi)"
+
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:609
 #, fuzzy
 msgid ""
 "Oops, there was an error updating your payment method. Please try again."
 msgstr "Sinu päringuga esines viga, palun proovi uuesti."
 
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:290
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:610
 msgid "Are you sure you want to delete this payment method?"
 msgstr "Oled sa kindel, et soovid selle maksevahendi kustutada?"
 
 #. translators: Payment method as in a specific credit card, eCheck or bank
 #. account
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:377
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:697
 msgid "You do not have any saved payment methods."
 msgstr "Sul ei ole salvestatud maksevahendeid."
 
-#. translators: Payment method as in a specific credit card, eCheck or bank
-#. account
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:416
-msgid "My Payment Methods"
-msgstr "Minu maksevahendid."
-
-#. translators: Payment method as in a specific credit card, e-check or bank
-#. account
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:424
-msgid "Add New Payment Method"
-msgstr "Lisa uus maksevahend"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:512
-msgid "Method"
-msgstr "Maksevahend"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:513
-msgid "Details"
-msgstr ""
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:514
-msgid "Expires"
-msgstr "Aegub"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:515
-#, fuzzy
-msgid "Default?"
-msgstr "(vaikimisi)"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:516
-msgid "Actions"
-msgstr ""
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:552
-msgid "Credit/Debit Cards"
-msgstr "Deebet- ja krediitkaardid"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:561
-msgid "Bank Accounts"
-msgstr "Pangakontod"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:616
-msgid "N/A"
-msgstr "-"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:728
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:872
 #: payment-gateway/class-sv-wc-payment-gateway-privacy.php:200
 msgid "Nickname"
 msgstr ""
 
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:909
-msgid "Delete"
-msgstr "Kustuta"
-
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1063
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1118
 msgid "Oops, you took too long, please try again."
 msgstr "Oih, sul läks liiga kaua aega - palun proovi uuesti."
 
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1076
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1129
 msgid "There was an error with your request, please try again."
 msgstr "Sinu päringuga esines viga, palun proovi uuesti."
-
-#. translators: Payment method as in a specific credit card, e-check or bank
-#. account
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1089
-msgid "Error removing payment method"
-msgstr "Viga maksevahendi eemaldamisel"
-
-#. translators: Payment method as in a specific credit card, e-check or bank
-#. account
-#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1094
-msgid "Payment method deleted."
-msgstr "Maksevahend kustutatud."
 
 #: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:340
 msgid "Card Number"
@@ -1509,10 +1462,6 @@ msgstr "Maksa turvaliselt oma tšekikontoga."
 #: payment-gateway/class-sv-wc-payment-gateway.php:1190
 msgid "Enable this gateway"
 msgstr "Lülita see makseviis sisse"
-
-#: payment-gateway/class-sv-wc-payment-gateway.php:1196
-msgid "Title"
-msgstr "Nimetus"
 
 #: payment-gateway/class-sv-wc-payment-gateway.php:1198
 msgid "Payment method title that the customer will see during checkout."
@@ -1797,45 +1746,43 @@ msgstr ""
 msgid "Pre-Order Release Payment Failed: %s"
 msgstr "Eeltellimuse väljastamise makse ebaõnnestus: %s"
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:326
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:349
 msgid "Subscription Renewal: payment token is missing/invalid."
 msgstr ""
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:352
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:375
 msgid "%1$s - Subscription Renewal Order %2$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - error
 #. message; e.g. Order Note: [Payment method] Payment Change failed [error]
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:484
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:507
 #, fuzzy
 msgid "%1$s Payment Change Failed (%2$s)"
 msgstr "%1$s: makse ebaõnnestus (%2$s)"
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:627
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:650
 msgid "Via %s ending in %s"
 msgstr ""
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:654
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:677
 msgid "Subscriptions"
 msgstr ""
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:723
-msgid ""
-"This payment method is tied to a subscription and cannot be deleted. Please "
-"switch the subscription to another method first."
-msgstr ""
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:738
+msgid "N/A"
+msgstr "-"
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:775
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:837
 msgid "Payment Token"
 msgstr ""
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:804
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:809
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:866
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:871
 msgid "%s is required."
 msgstr ""
 
-#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:173
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:181
 msgid "Unknown Error"
 msgstr "Esines tundmatu viga"
 
@@ -2008,12 +1955,12 @@ msgctxt "coordinating conjunction for a list of items: a, b, and c"
 msgid "and"
 msgstr ""
 
-#: class-sv-wc-plugin.php:621
+#: class-sv-wc-plugin.php:663
 msgctxt "noun"
 msgid "Support"
 msgstr "Kasutajatugi"
 
-#: class-sv-wc-plugin.php:626
+#: class-sv-wc-plugin.php:668
 msgctxt "verb"
 msgid "Review"
 msgstr ""
@@ -2115,7 +2062,7 @@ msgctxt "hash before order number"
 msgid "#"
 msgstr "#"
 
-#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:684
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:732
 msgctxt "hash before order number"
 msgid "#%s"
 msgstr ""
@@ -2132,6 +2079,33 @@ msgstr ""
 msgctxt "software environment"
 msgid "Production"
 msgstr "Töö/avalik"
+
+#~ msgid "My Payment Methods"
+#~ msgstr "Minu maksevahendid."
+
+#~ msgid "Add New Payment Method"
+#~ msgstr "Lisa uus maksevahend"
+
+#~ msgid "Method"
+#~ msgstr "Maksevahend"
+
+#~ msgid "Expires"
+#~ msgstr "Aegub"
+
+#~ msgid "Credit/Debit Cards"
+#~ msgstr "Deebet- ja krediitkaardid"
+
+#~ msgid "Bank Accounts"
+#~ msgstr "Pangakontod"
+
+#~ msgid "Delete"
+#~ msgstr "Kustuta"
+
+#~ msgid "Error removing payment method"
+#~ msgstr "Viga maksevahendi eemaldamisel"
+
+#~ msgid "Payment method deleted."
+#~ msgstr "Maksevahend kustutatud."
 
 #, fuzzy
 #~ msgid "Pay with"

--- a/woocommerce/i18n/languages/woocommerce-plugin-framework.pot
+++ b/woocommerce/i18n/languages/woocommerce-plugin-framework.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the  package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Plugin Framework 5.7.1\n"
+"Project-Id-Version: WooCommerce Plugin Framework 5.8.1\n"
 "Report-Msgid-Bugs-To: https://support.woocommerce.com/hc/\n"
 "POT-Creation-Date: 2015-07-22 12:09:16+00:00\n"
 "MIME-Version: 1.0\n"

--- a/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as FrameworkBase;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as FrameworkBase;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Payment_Gateway\\Handlers\\Abstract_Hosted_Payment_Handler' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as FrameworkBase;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as FrameworkBase;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Payment_Gateway\\Handlers\\Abstract_Payment_Handler' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/Handlers/Capture.php
+++ b/woocommerce/payment-gateway/Handlers/Capture.php
@@ -22,13 +22,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Payment_Gateway\Handlers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Handlers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Payment_Gateway\\Handlers\\Capture' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Payment_Gateway\\Handlers\\Capture' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
+++ b/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
@@ -21,13 +21,13 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Payment_Gateway\Admin;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Payment_Gateway\\Admin\\Setup_Wizard' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Admin_Order' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Admin_Order' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Admin_User_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Admin_User_Handler' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
+++ b/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Response_Message_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Response_Message_Helper' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-authorization-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Authorization_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Authorization_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-create-payment-token-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Create_Payment_Token_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Create_Payment_Token_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-customer-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Customer_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Customer_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-get-tokenized-payment-methods-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_API_Get_Tokenized_Payment_Methods_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_API_Get_Tokenized_Payment_Methods_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-credit-card-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Payment_Notification_Credit_Card_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-echeck-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Payment_Notification_eCheck_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Payment_Notification_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Payment_Notification_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-payment-notification-tokenization-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Payment_Notification_Tokenization_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Request' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Request' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API_Response' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
+++ b/woocommerce/payment-gateway/api/interface-sv-wc-payment-gateway-api.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_API' ) ) :
+if ( ! interface_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_API' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_API_Request' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_API' ) ) :
 
 
 /**
@@ -57,7 +57,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 		$this->set_request_content_type_header( 'application/json' );
 		$this->set_request_accept_header( 'application/json' );
 
-		$this->set_response_handler( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' );
+		$this->set_response_handler( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_API_Response' );
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
+++ b/woocommerce/payment-gateway/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_Payment_Response' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_Payment_Response' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_Admin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_Admin' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_AJAX' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_AJAX' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_Frontend' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_Frontend' ) ) :
 
 
 /**
@@ -153,9 +153,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends Handlers\Script_Handler {
 	 */
 	public function enqueue_scripts() {
 
-		wp_enqueue_style( 'sv-wc-apple-pay-v5_8_0', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/sv-wc-payment-gateway-apple-pay.css', array(), $this->get_plugin()->get_version() ); // TODO: min
+		wp_enqueue_style( 'sv-wc-apple-pay-v5_8_1', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/sv-wc-payment-gateway-apple-pay.css', array(), $this->get_plugin()->get_version() ); // TODO: min
 
-		wp_enqueue_script( 'sv-wc-apple-pay-v5_8_0', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/sv-wc-payment-gateway-apple-pay.min.js', array( 'jquery' ), $this->get_plugin()->get_version(), true );
+		wp_enqueue_script( 'sv-wc-apple-pay-v5_8_1', $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/sv-wc-payment-gateway-apple-pay.min.js', array( 'jquery' ), $this->get_plugin()->get_version(), true );
 	}
 
 

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-orders.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay_Orders' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay_Orders' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Apple_Pay' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Apple_Pay' ) ) :
 
 
 /**
@@ -1025,7 +1025,7 @@ class SV_WC_Payment_Gateway_Apple_Pay {
 
 		$accepted_card_types = ( $this->get_processing_gateway() ) ? $this->get_processing_gateway()->get_card_types() : array();
 
-		$accepted_card_types = array_map( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Helper::normalize_card_type', $accepted_card_types );
+		$accepted_card_types = array_map( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Helper::normalize_card_type', $accepted_card_types );
 
 		$valid_networks = array(
 			SV_WC_Payment_Gateway_Helper::CARD_TYPE_AMEX       => 'amex',

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
@@ -14,7 +14,7 @@ jQuery( document ).ready ($) ->
 	# The WooCommerce Apple Pay handler base class.
 	#
 	# @since 4.7.0
-	class window.SV_WC_Apple_Pay_Handler_v5_7_1
+	class window.SV_WC_Apple_Pay_Handler_v5_8_1
 
 
 		# Constructs the handler.
@@ -434,4 +434,4 @@ jQuery( document ).ready ($) ->
 
 
 	# dispatch loaded event
-	$( document.body ).trigger( 'sv_wc_apple_pay_handler_v5_7_1_loaded' )
+	$( document.body ).trigger( 'sv_wc_apple_pay_handler_v5_8_1_loaded' )

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.min.js
@@ -13,8 +13,8 @@
 
   jQuery(document).ready(function($) {
     "use strict";
-    window.SV_WC_Apple_Pay_Handler_v5_7_1 = (function() {
-      function SV_WC_Apple_Pay_Handler_v5_7_1(args) {
+    window.SV_WC_Apple_Pay_Handler_v5_8_1 = (function() {
+      function SV_WC_Apple_Pay_Handler_v5_8_1(args) {
         this.get_payment_request = bind(this.get_payment_request, this);
         this.reset_payment_request = bind(this.reset_payment_request, this);
         this.on_cancel_payment = bind(this.on_cancel_payment, this);
@@ -41,7 +41,7 @@
         this.terms = '.sv-wc-apple-pay-terms';
       }
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.is_available = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.is_available = function() {
         if (!window.ApplePaySession) {
           return false;
         }
@@ -52,7 +52,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.init = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.init = function() {
         if (!this.is_available()) {
           return;
         }
@@ -104,11 +104,11 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.init_product_page = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.init_product_page = function() {
         return this.ui_element = $('form.cart');
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.init_cart_page = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.init_cart_page = function() {
         this.ui_element = $('form.woocommerce-cart-form').parents('div.woocommerce');
         return $(document.body).on('updated_cart_totals', (function(_this) {
           return function() {
@@ -117,7 +117,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.init_checkout_page = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.init_checkout_page = function() {
         this.ui_element = $('form.woocommerce-checkout');
         this.buttons = '.sv-wc-apply-pay-checkout';
         return $(document.body).on('updated_checkout', (function(_this) {
@@ -127,15 +127,15 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.get_new_session = function(payment_request) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.get_new_session = function(payment_request) {
         return new ApplePaySession(this.get_sdk_version(), payment_request);
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.get_sdk_version = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.get_sdk_version = function() {
         return 2;
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.on_validate_merchant = function(event) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.on_validate_merchant = function(event) {
         return this.validate_merchant(event.validationURL).then((function(_this) {
           return function(merchant_session) {
             merchant_session = $.parseJSON(merchant_session);
@@ -149,7 +149,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.validate_merchant = function(url) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.validate_merchant = function(url) {
         return new Promise((function(_this) {
           return function(resolve, reject) {
             var data;
@@ -170,7 +170,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.on_payment_method_selected = function(event) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.on_payment_method_selected = function(event) {
         return new Promise((function(_this) {
           return function(resolve, reject) {
             var data;
@@ -191,7 +191,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.on_shipping_contact_selected = function(event) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.on_shipping_contact_selected = function(event) {
         return new Promise((function(_this) {
           return function(resolve, reject) {
             var data;
@@ -213,7 +213,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.on_shipping_method_selected = function(event) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.on_shipping_method_selected = function(event) {
         return new Promise((function(_this) {
           return function(resolve, reject) {
             var data;
@@ -235,7 +235,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.on_payment_authorized = function(event) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.on_payment_authorized = function(event) {
         return this.process_authorization(event.payment).then((function(_this) {
           return function(response) {
             _this.set_payment_status(true);
@@ -249,7 +249,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.process_authorization = function(payment) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.process_authorization = function(payment) {
         return new Promise((function(_this) {
           return function(resolve, reject) {
             var data;
@@ -269,21 +269,21 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.on_cancel_payment = function(event) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.on_cancel_payment = function(event) {
         return this.unblock_ui();
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.complete_purchase = function(response) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.complete_purchase = function(response) {
         return window.location = response.redirect;
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.fail_payment = function(error) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.fail_payment = function(error) {
         console.error('[Apple Pay] ' + error);
         this.unblock_ui();
         return this.render_errors([this.generic_error]);
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.set_payment_status = function(success) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.set_payment_status = function(success) {
         var status;
         if (success) {
           status = ApplePaySession.STATUS_SUCCESS;
@@ -293,7 +293,7 @@
         return this.session.completePayment(status);
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.reset_payment_request = function(data) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.reset_payment_request = function(data) {
         if (data == null) {
           data = {};
         }
@@ -315,7 +315,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.get_payment_request = function(data) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.get_payment_request = function(data) {
         return new Promise((function(_this) {
           return function(resolve, reject) {
             var base_data;
@@ -334,7 +334,7 @@
         })(this));
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.render_errors = function(errors) {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.render_errors = function(errors) {
         $('.woocommerce-error, .woocommerce-message').remove();
         this.ui_element.prepend('<ul class="woocommerce-error"><li>' + errors.join('</li><li>') + '</li></ul>');
         this.ui_element.removeClass('processing').unblock();
@@ -343,7 +343,7 @@
         }, 1000);
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.block_ui = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.block_ui = function() {
         return this.ui_element.block({
           message: null,
           overlayCSS: {
@@ -353,14 +353,14 @@
         });
       };
 
-      SV_WC_Apple_Pay_Handler_v5_7_1.prototype.unblock_ui = function() {
+      SV_WC_Apple_Pay_Handler_v5_8_1.prototype.unblock_ui = function() {
         return this.ui_element.unblock();
       };
 
-      return SV_WC_Apple_Pay_Handler_v5_7_1;
+      return SV_WC_Apple_Pay_Handler_v5_8_1;
 
     })();
-    return $(document.body).trigger('sv_wc_apple_pay_handler_v5_7_1_loaded');
+    return $(document.body).trigger('sv_wc_apple_pay_handler_v5_8_1_loaded');
   });
 
 }).call(this);

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
@@ -12,7 +12,7 @@ jQuery( document ).ready ($) ->
 	# The My Payment Methods handler.
 	#
 	# @since 5.1.0
-	class window.SV_WC_Payment_Methods_Handler_v5_7_1
+	class window.SV_WC_Payment_Methods_Handler_v5_8_1
 
 
 		# Constructs the class.
@@ -269,4 +269,4 @@ jQuery( document ).ready ($) ->
 
 
 	# dispatch loaded event
-	$( document.body ).trigger( 'sv_wc_payment_methods_handler_v5_7_1_loaded' )
+	$( document.body ).trigger( 'sv_wc_payment_methods_handler_v5_8_1_loaded' )

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.min.js
@@ -13,8 +13,8 @@
 
   jQuery(document).ready(function($) {
     "use strict";
-    window.SV_WC_Payment_Methods_Handler_v5_7_1 = (function() {
-      function SV_WC_Payment_Methods_Handler_v5_7_1(args) {
+    window.SV_WC_Payment_Methods_Handler_v5_8_1 = (function() {
+      function SV_WC_Payment_Methods_Handler_v5_8_1(args) {
         this.cancel_edit = bind(this.cancel_edit, this);
         this.save_method = bind(this.save_method, this);
         this.edit_method = bind(this.edit_method, this);
@@ -62,7 +62,7 @@
         });
       }
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.replace_method_column = function() {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.replace_method_column = function() {
         return $('.woocommerce-MyAccount-paymentMethods').find('tr').each((function(_this) {
           return function(index, element) {
             var titleColumn;
@@ -79,7 +79,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.remove_duplicate_default_marks = function() {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.remove_duplicate_default_marks = function() {
         return $('.woocommerce-MyAccount-paymentMethods').find('tr').each((function(_this) {
           return function(index, element) {
             return $(element).find('td.woocommerce-PaymentMethod--default').find('mark.default:not(:first-child)').remove();
@@ -87,7 +87,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.edit_method = function(event) {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.edit_method = function(event) {
         var button, row;
         event.preventDefault();
         button = $(event.currentTarget);
@@ -102,7 +102,7 @@
         return this.enable_editing_ui();
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.save_method = function(event) {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.save_method = function(event) {
         var button, data, row;
         event.preventDefault();
         button = $(event.currentTarget);
@@ -143,7 +143,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.cancel_edit = function(event) {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.cancel_edit = function(event) {
         var button, row;
         event.preventDefault();
         button = $(event.currentTarget);
@@ -158,17 +158,17 @@
         return this.disable_editing_ui();
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.enable_editing_ui = function() {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.enable_editing_ui = function() {
         $(".woocommerce-MyAccount-paymentMethods").addClass('editing');
         return $('.button[href*="add-payment-method"]').addClass('disabled');
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.disable_editing_ui = function() {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.disable_editing_ui = function() {
         $(".woocommerce-MyAccount-paymentMethods").removeClass('editing');
         return $('.button[href*="add-payment-method"]').removeClass('disabled');
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.block_ui = function() {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.block_ui = function() {
         return $(".woocommerce-MyAccount-paymentMethods").parent('div').block({
           message: null,
           overlayCSS: {
@@ -178,11 +178,11 @@
         });
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.unblock_ui = function() {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.unblock_ui = function() {
         return $(".woocommerce-MyAccount-paymentMethods").parent('div').unblock();
       };
 
-      SV_WC_Payment_Methods_Handler_v5_7_1.prototype.display_error = function(row, error, message) {
+      SV_WC_Payment_Methods_Handler_v5_8_1.prototype.display_error = function(row, error, message) {
         var columns;
         if (message == null) {
           message = '';
@@ -195,10 +195,10 @@
         return $('<tr class="error"><td colspan="' + columns + '">' + message + '</td></tr>').insertAfter(row).find('td').delay(8000).slideUp(200);
       };
 
-      return SV_WC_Payment_Methods_Handler_v5_7_1;
+      return SV_WC_Payment_Methods_Handler_v5_8_1;
 
     })();
-    return $(document.body).trigger('sv_wc_payment_methods_handler_v5_7_1_loaded');
+    return $(document.body).trigger('sv_wc_payment_methods_handler_v5_8_1_loaded');
   });
 
 }).call(this);

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
@@ -10,7 +10,7 @@ jQuery( document ).ready ($) ->
 	"use strict"
 
 
-	class window.SV_WC_Payment_Form_Handler_v5_7_1
+	class window.SV_WC_Payment_Form_Handler_v5_8_1
 
 
 		# Public: Instantiate Payment Form Handler
@@ -385,4 +385,4 @@ jQuery( document ).ready ($) ->
 
 
 	# dispatch loaded event
-	$( document.body ).trigger( "sv_wc_payment_form_handler_v5_7_1_loaded" )
+	$( document.body ).trigger( "sv_wc_payment_form_handler_v5_8_1_loaded" )

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.min.js
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.min.js
@@ -13,8 +13,8 @@
 
   jQuery(document).ready(function($) {
     "use strict";
-    window.SV_WC_Payment_Form_Handler_v5_7_1 = (function() {
-      function SV_WC_Payment_Form_Handler_v5_7_1(args) {
+    window.SV_WC_Payment_Form_Handler_v5_8_1 = (function() {
+      function SV_WC_Payment_Form_Handler_v5_8_1(args) {
         this.id = args.id;
         this.id_dasherized = args.id_dasherized;
         this.plugin_id = args.plugin_id;
@@ -49,7 +49,7 @@
         });
       }
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.handle_checkout_page = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.handle_checkout_page = function() {
         if (this.type === 'credit-card') {
           $(document.body).on('updated_checkout', (function(_this) {
             return function() {
@@ -74,7 +74,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.handle_pay_page = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.handle_pay_page = function() {
         this.set_payment_fields();
         if (this.type === 'credit-card') {
           this.format_credit_card_inputs();
@@ -89,7 +89,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.handle_add_payment_method_page = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.handle_add_payment_method_page = function() {
         this.set_payment_fields();
         if (this.type === 'credit-card') {
           this.format_credit_card_inputs();
@@ -103,7 +103,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.set_payment_fields = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.set_payment_fields = function() {
         var $required_fields;
         this.payment_fields = $(".payment_method_" + this.id);
         $required_fields = this.payment_fields.find('.validate-required .input-text');
@@ -117,7 +117,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.validate_payment_data = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.validate_payment_data = function() {
         var handler, valid;
         if (this.form.is('.processing')) {
           return false;
@@ -131,7 +131,7 @@
         return valid && handler;
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.format_credit_card_inputs = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.format_credit_card_inputs = function() {
         var $card_number, $csc, $expiry;
         $card_number = $('.js-sv-wc-payment-gateway-credit-card-form-account-number').payment('formatCardNumber');
         $expiry = $('.js-sv-wc-payment-gateway-credit-card-form-expiry').payment('formatCardExpiry');
@@ -152,7 +152,7 @@
         })(this));
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.do_inline_credit_card_validation = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.do_inline_credit_card_validation = function() {
         var $card_number, $card_type, $csc, $expiry;
         $card_number = $('.js-sv-wc-payment-gateway-credit-card-form-account-number');
         $expiry = $('.js-sv-wc-payment-gateway-credit-card-form-expiry');
@@ -175,7 +175,7 @@
         }
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.validate_card_data = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.validate_card_data = function() {
         var account_number, csc, errors, expiry;
         errors = [];
         csc = this.payment_fields.find('.js-sv-wc-payment-gateway-credit-card-form-csc').val();
@@ -223,7 +223,7 @@
         }
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.validate_account_data = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.validate_account_data = function() {
         var account_number, errors, routing_number;
         if (this.saved_payment_method_selected) {
           return true;
@@ -260,7 +260,7 @@
         }
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.render_errors = function(errors) {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.render_errors = function(errors) {
         $('.woocommerce-error, .woocommerce-message').remove();
         this.form.prepend('<ul class="woocommerce-error"><li>' + errors.join('</li><li>') + '</li></ul>');
         this.form.removeClass('processing').unblock();
@@ -270,7 +270,7 @@
         }, 1000);
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.handle_saved_payment_methods = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.handle_saved_payment_methods = function() {
         var $csc_field, $new_payment_method_selection, csc_required, csc_required_for_tokens, id_dasherized;
         id_dasherized = this.id_dasherized;
         csc_required = this.csc_required;
@@ -310,7 +310,7 @@
         }
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.handle_sample_check_hint = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.handle_sample_check_hint = function() {
         var $sample_check;
         $sample_check = this.payment_fields.find('.js-sv-wc-payment-gateway-echeck-form-sample-check');
         if ($sample_check.is(":visible")) {
@@ -320,7 +320,7 @@
         }
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.block_ui = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.block_ui = function() {
         return this.form.block({
           message: null,
           overlayCSS: {
@@ -330,14 +330,14 @@
         });
       };
 
-      SV_WC_Payment_Form_Handler_v5_7_1.prototype.unblock_ui = function() {
+      SV_WC_Payment_Form_Handler_v5_8_1.prototype.unblock_ui = function() {
         return this.form.unblock();
       };
 
-      return SV_WC_Payment_Form_Handler_v5_7_1;
+      return SV_WC_Payment_Form_Handler_v5_8_1;
 
     })();
-    return $(document.body).trigger("sv_wc_payment_form_handler_v5_7_1_loaded");
+    return $(document.body).trigger("sv_wc_payment_form_handler_v5_8_1_loaded");
   });
 
 }).call(this);

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Direct' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Direct' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Helper' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Helper' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Hosted' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Hosted' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_My_Payment_Methods' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_My_Payment_Methods' ) ) :
 
 
 /**
@@ -169,9 +169,9 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Handlers\Script_Handler {
 
 		wp_register_script( 'jquery-tiptip', WC()->plugin_url() . '/assets/js/jquery-tiptip/jquery.tipTip.min.js', array( 'jquery' ), WC_VERSION, true );
 
-		wp_enqueue_style( "$handle-v5_8_0", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', array( 'dashicons' ), SV_WC_Plugin::VERSION );
+		wp_enqueue_style( "$handle-v5_8_1", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/frontend/' . $handle . '.min.css', array( 'dashicons' ), SV_WC_Plugin::VERSION );
 
-		wp_enqueue_script( "$handle-v5_8_0", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', array( 'jquery-tiptip', 'jquery' ), SV_WC_Plugin::VERSION );
+		wp_enqueue_script( "$handle-v5_8_1", $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', array( 'jquery-tiptip', 'jquery' ), SV_WC_Plugin::VERSION );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Payment_Form' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Payment_Form' ) ) :
 
 
 /**
@@ -1055,7 +1055,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 		];
 
 		if ( $this->get_gateway()->supports_card_types() ) {
-			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_8_0\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
+			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
 		}
 
 		return $args;

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -22,14 +22,14 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Plugin' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Plugin' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Privacy' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Privacy' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway' ) ) :
 
 
 /**
@@ -444,7 +444,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		}
 
 		$handle           = 'sv-wc-payment-gateway-payment-form';
-		$versioned_handle = $handle . '-v5_8_0';
+		$versioned_handle = $handle . '-v5_8_1';
 
 		// Frontend JS
 		wp_enqueue_script( $versioned_handle, $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/js/frontend/' . $handle . '.min.js', array( 'jquery-payment' ), SV_WC_Plugin::VERSION, true );

--- a/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
+++ b/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Exception' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Exception' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Integration' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Integration' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Integration_Pre_Orders' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Integration_Subscriptions' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Payment_Token' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Payment_Token' ) ) :
 
 
 /**

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WC_Payment_Gateway_Payment_Tokens_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WC_Payment_Gateway_Payment_Tokens_Handler' ) ) :
 
 
 

--- a/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
+++ b/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
@@ -22,18 +22,18 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\Payment_Gateway;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\REST_API as Plugin_REST_API;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\REST_API as Plugin_REST_API;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\Payment_Gateway\\REST_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\Payment_Gateway\\REST_API' ) ) :
 
 
 /**
  * The payment gateway plugin REST API handler class.
  *
- * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\REST_API
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\REST_API
  *
  * @since 5.2.0
  */
@@ -45,7 +45,7 @@ class REST_API extends Plugin_REST_API {
 	 *
 	 * Plugins can override this to add their own data.
 	 *
-	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_0\REST_API::get_system_status_data()
+	 * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\REST_API::get_system_status_data()
 	 *
 	 * @since 5.2.0
 	 *

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -22,14 +22,14 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0\REST_API\Controllers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\REST_API\Controllers;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Abstract_Settings;
-use SkyVerge\WooCommerce\PluginFramework\v5_8_0\Settings_API\Setting;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Abstract_Settings;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Settings_API\Setting;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\REST_API\\Controllers\\Settings' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\REST_API\\Controllers\\Settings' ) ) :
 
 /**
  * The settings controller class.

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\REST_API' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\REST_API' ) ) :
 
 
 /**

--- a/woocommerce/utilities/class-sv-wp-async-request.php
+++ b/woocommerce/utilities/class-sv-wp-async-request.php
@@ -23,11 +23,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WP_Async_Request' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WP_Async_Request' ) ) :
 
 
 /**

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -23,11 +23,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WP_Background_Job_Handler' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WP_Background_Job_Handler' ) ) :
 
 
 /**

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -22,11 +22,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
- namespace SkyVerge\WooCommerce\PluginFramework\v5_8_0;
+ namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
  defined( 'ABSPATH' ) or exit;
 
- if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_0\\SV_WP_Job_Batch_Handler' ) ) :
+ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_8_1\\SV_WP_Job_Batch_Handler' ) ) :
 
 
 /**


### PR DESCRIPTION
# Summary

* Bumps FW to 5.8.1 / namespaces to 5_8_1
* Ensures there are no scripts with namespaces pointing to 5_7_1

### Story: [CH 60330](https://app.clubhouse.io/skyverge/story/60330/fw-5-8-0-still-uses-some-5-7-1-namespaces-27)

## Before merge

- [x] Integration tests pass
- [x] I have confirmed these changes in each supported minor WooCommerce version
- [x] All required plugin changes have been documented for this new version

