### PR TITLE
Update Pre-Orders and Subscriptions integrations to use 2 digits expiration years

### DIFF
--- a/tests/integration/SV_WC_Payment_Gateway_Helper_Test.php
+++ b/tests/integration/SV_WC_Payment_Gateway_Helper_Test.php
@@ -1,0 +1,40 @@
+<?php
+
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Helper;
+
+/**
+ * Tests for the Payment Gateway Helper class.
+ *
+ * @see \SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Helper
+ */
+class SV_WC_Payment_Gateway_Helper_Test extends \Codeception\TestCase\WPTestCase {
+
+
+	/** @var \IntegrationTester */
+	protected $tester;
+
+
+	/** Tests *********************************************************************************************************/
+
+
+	/**
+	 * @see SV_WC_Payment_Gateway_Helper::format_exp_year()
+	 *
+	 * @dataProvider provider_format_exp_year
+	 */
+	public function test_format_exp_year( $exp_year, $expected_result ) {
+
+		$this->assertEquals( $expected_result, SV_WC_Payment_Gateway_Helper::format_exp_year( $exp_year ) );
+	}
+
+
+	public function provider_format_exp_year() {
+
+		return [
+			[ '2022', '22' ],
+			[ '20',   '20' ],
+		];
+	}
+
+
+}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -265,6 +265,20 @@ class SV_WC_Payment_Gateway_Helper {
 	}
 
 
+	/**
+	 * Formats the given expiration year to include the last two digits only.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $exp_year a credit card expiration year
+	 * @return string
+	 */
+	public static function format_exp_year( $exp_year ) {
+
+		return substr( $exp_year, -2 );
+	}
+
+
 }
 
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -170,7 +170,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 					// exp month/year
 					$order->payment->exp_month = $token->get_exp_month();
-					$order->payment->exp_year  = $token->get_exp_year();
+					$order->payment->exp_year  = SV_WC_Payment_Gateway_Helper::format_exp_year( $token->get_exp_year() );
 
 				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
 
@@ -196,7 +196,7 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 						list( $exp_year, $exp_month ) = explode( '-', $expiry_date );
 
 						$order->payment->exp_month = $exp_month;
-						$order->payment->exp_year  = $exp_year;
+						$order->payment->exp_year  = SV_WC_Payment_Gateway_Helper::format_exp_year( $exp_year );
 					}
 
 				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -169,8 +169,8 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 					$order->payment->card_type = $token->get_card_type();
 
 					// exp month/year
-					$order->payment->exp_month  = $token->get_exp_month();
-					$order->payment->exp_year   = $token->get_exp_year();
+					$order->payment->exp_month = $token->get_exp_month();
+					$order->payment->exp_year  = $token->get_exp_year();
 
 				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {
 
@@ -195,8 +195,8 @@ class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway
 
 						list( $exp_year, $exp_month ) = explode( '-', $expiry_date );
 
-						$order->payment->exp_month  = $exp_month;
-						$order->payment->exp_year   = $exp_year;
+						$order->payment->exp_month = $exp_month;
+						$order->payment->exp_year  = $exp_year;
 					}
 
 				} elseif ( $this->get_gateway()->is_echeck_gateway() ) {

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -399,7 +399,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 			$order->payment->card_type = $token->get_card_type();
 			$order->payment->exp_month = $token->get_exp_month();
-			$order->payment->exp_year  = $token->get_exp_year();
+			$order->payment->exp_year  = SV_WC_Payment_Gateway_Helper::format_exp_year( $token->get_exp_year() );
 
 		} elseif ( $token->is_echeck() ) {
 


### PR DESCRIPTION
# Summary

This PR updates the Pre-Orders and Subscriptions integrations to use the same format as `SV_WC_Payment_Gateway_Direct::get_order()` to represent credit card/payment tokens expiration years.

### Story: [CH 63869](https://app.clubhouse.io/skyverge/story/63869)

## Details

The direct payment gateway class uses 2 digits to represent the expiration years attached to the order object when a payment is being processed:

https://github.com/skyverge/wc-plugin-framework/blob/6439de5786401efeae1990ab122d810af44970c5/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php#L632-L635

The documentation for the `get_order()` method [indicates](https://github.com/skyverge/wc-plugin-framework/blob/6439de5786401efeae1990ab122d810af44970c5/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php#L541) that `$order->payment->exp_year` will be a 2 digit credit card expiration year. That expectation is enforced for regular payments using the lines highlighted above.

However, we don't do the same verification on the Pre-Orders and Subscriptions integrations that use the`wc_payment_gateway_{gateway_id}_get_order` filter triggered in `get_order()` to also add payment information to an order object. In that case, the integrations rely on the format returned by [`SV_WC_Payment_Gateway_Payment_Token::get_exp_year()`](https://github.com/skyverge/wc-plugin-framework/blob/6439de5786401efeae1990ab122d810af44970c5/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php#L403-L415).

The documentation for `SV_WC_Payment_Gateway_Payment_Token::get_exp_year()` indicates that it returns a 4 digit expiration year, but that wasn't true before we added support for core tokens. Before that update, I think the format used for expiration years matched the information we received in API responses.

When we started enforcing a 4 digit expiration year on payment token objects, we introduced a bug in First Data triggered because the Subscriptions integration set `$order->payment->exp_year` to a 4 digit expiration year and that was used to initiate an API request that assumed that value to be a 2 digit expiration year (See [CH 63839](https://app.clubhouse.io/skyverge/story/63839)).

I couldn't find a similar problem in any of the other gateways. Some don't use payment tokens. The ones that support tokenization do set `$order->payment->exp_year` to a 4 digit expiration year when a subscription renewal payment is being processed, but they don't include that information on API requests, so no issue occurs.

While I think each gateway should ensure that the information included in API requests use the correct format, regardless of the information attached on the order object, I submitted this PR because I also think that anyone using the `wc_payment_gateway_{gateway_id}_get_order` should return results  that are consistent with what `SV_WC_Payment_Gateway_Direct::get_order()` would return. In the expiration year case, that means the integrations should format `$order->payment->exp_year` to use 2 digits.

## QA

### Steps

- [x] `codecept run integration` pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version