### PR TITLE
Address a PHP warning if no card logos are configured to be displayed at checkout

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,7 @@
 
 2020.nn.nn - version x.y.z-dev.1
  * Feature - Add helper method to detect whether the current request is a REST API request
+ * Fix - Harden code to avoid a potential PHP warning at checkout if no card logos are configured for a gateway
 
 2020.07.31 - version 5.8.1
  * Fix - Ensure that some payment gateway scripts used for handling tokens reference the current version of the Framework

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -1055,7 +1055,13 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 		];
 
 		if ( $this->get_gateway()->supports_card_types() ) {
-			$args['enabled_card_types'] = array_map( array( 'SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ), $this->get_gateway()->get_card_types() );
+
+			$card_types = $this->get_gateway()->get_card_types();
+
+			if ( is_array( $card_types ) && ! empty( $card_types ) ) {
+
+				$args['enabled_card_types'] = array_map( [ 'SkyVerge\WooCommerce\PluginFramework\v5_8_1\SV_WC_Payment_Gateway_Helper', 'normalize_card_type' ], $card_types );
+			}
 		}
 
 		return $args;


### PR DESCRIPTION
## Summary

Hardens code so that a non-array is not passed to `array_map`.

### Story: [CH 57834](https://app.clubhouse.io/skyverge/story/57834)

## Details

There are already tests for the functions involved, I'm not sure how to make `get_js_handler_args()` return the additional array key that would make use of the piece involved in this fix without modifying the mock plugin we use to run our integration tests. 

## QA

- [x] Code review
