### PR TITLE
Add Visa Checkout settings

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -16,11 +16,82 @@
  *
  * @SuppressWarnings(PHPMD)
 */
-class AcceptanceTester extends \Codeception\Actor
-{
+class AcceptanceTester extends \Codeception\Actor {
+
     use _generated\AcceptanceTesterActions;
 
-   /**
-    * Define custom actions here
-    */
+
+	/** Visa Checkout settings screen *****************************************/
+
+
+	/**
+	 * @since 5.10.0-dev.1
+	 */
+	public function haveVisaCheckoutActivated( $plugin_id ) {
+
+		$this->haveMuPlugin(
+			'activate-visa-checkout.php',
+			"add_filter( 'wc_payment_gateway_{$plugin_id}_activate_visa_checkout', '__return_true' );"
+		);
+	}
+
+
+	/**
+	 * @since 5.10.0-dev.1
+	 */
+	public function amOnVisaCheckoutSettingsPage() {
+
+		$this->amOnAdminPage( 'admin.php?page=wc-settings&tab=checkout&section=visa-checkout' );
+	}
+
+
+	/**
+	 * @since 5.10.0-dev.1
+	 */
+	public function checkVisaCheckoutEnableSetting() {
+
+		$this->checkOption( '[name="sv_wc_visa_checkout_enabled"]' );
+	}
+
+
+	/**
+	 * @since 5.10.0-dev.1
+	 *
+	 * @param string $api_key the desired value for the API Key field
+	 */
+	public function fillVisaCheckoutApiKeyField( string $api_key ) {
+
+		$this->fillField( '[name="sv_wc_visa_checkout_api_key"]', $api_key );
+	}
+
+
+	/**
+	 * @since 5.10.0-dev.1
+	 */
+	public function saveVisaCheckoutSettings() {
+
+		$this->click( '[name="save"][type="submit"]' );
+	}
+
+
+	/**
+	 * @since 5.10.0-dev.1
+	 */
+	public function seeVisaCheckoutEnableSettingIsChecked() {
+
+		$this->seeCheckboxIsChecked( '[name="sv_wc_visa_checkout_enabled"]' );
+	}
+
+
+	/**
+	 * @since 5.10.0-dev.1
+	 *
+	 * @param string $api_key the expected value for the API Key field
+	 */
+	public function seeVisaCheckoutApiKeyField( string $api_key ) {
+
+		$this->seeInField( '[name="sv_wc_visa_checkout_api_key"]', $api_key );
+	}
+
+
 }

--- a/tests/_support/plugins/gateway-test-plugin/includes/Gateway.php
+++ b/tests/_support/plugins/gateway-test-plugin/includes/Gateway.php
@@ -18,6 +18,7 @@ class Gateway extends Framework\SV_WC_Payment_Gateway {
 				'supports'           => [
 					self::FEATURE_PAYMENT_FORM,
 					self::FEATURE_APPLE_PAY,
+					self::FEATURE_VISA_CHECKOUT,
 				],
 			]
 		);

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -10,6 +10,7 @@ modules:
     enabled:
         - WPDb
         - WPBrowser
+        - WPFilesystem
         - \Helper\Acceptance
     config:
         WPDb:
@@ -28,3 +29,5 @@ modules:
             adminUsername: '%ADMIN_USERNAME%'
             adminPassword: '%ADMIN_PASSWORD%'
             adminPath: '%WP_ADMIN_PATH%'
+        WPFilesystem:
+            wpRootFolder: '%WP_ROOT_FOLDER%'

--- a/tests/acceptance/payment-gateway/Visa_Checkout/SettingsCest.php
+++ b/tests/acceptance/payment-gateway/Visa_Checkout/SettingsCest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SkyVerge\WooCommerce\PluginFramework\Tests\Payment_Gateway\Visa_Checkout;
+
+use AcceptanceTester;
+
+class SettingsCest {
+
+    public function _before( AcceptanceTester $I ) {
+
+    	$I->loginAsAdmin();
+    }
+
+	public function try_save_settings( AcceptanceTester $I ) {
+
+		$I->haveVisaCheckoutActivated( 'gateway_test_plugin' );
+
+		$I->amOnVisaCheckoutSettingsPage();
+
+		$I->wantTo( 'See the Visa Checkout settings' );
+		$I->see( 'Accept Visa Checkout' );
+
+		$I->checkVisaCheckoutEnableSetting();
+		$I->fillVisaCheckoutApiKeyField( '123456' );
+
+		$I->saveVisaCheckoutSettings();
+
+		$I->see( 'Your settings have been saved.' );
+
+		$I->seeVisaCheckoutEnableSettingIsChecked();
+		$I->seeVisaCheckoutApiKeyField( '123456' );
+    }
+
+
+}

--- a/woocommerce/payment-gateway/Settings_Screen.php
+++ b/woocommerce/payment-gateway/Settings_Screen.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( __NAMESPACE__ . '\\Settings_Screen' ) ) :
+
+/**
+ * Base class to set up a Payments settings screen.
+ *
+ * @since 5.10.0-dev.1
+ */
+abstract class Settings_Screen {
+
+
+	/** @var string settings section ID */
+	protected $section_id;
+
+
+	/**
+	 * Construct the class.
+	 *
+	 * @since 5.10.0-dev.1
+	 */
+	public function __construct() {
+
+		$this->add_hooks();
+	}
+
+
+	/**
+	 * Sets up the necessary hooks.
+	 *
+	 * @since 5.10.0-dev.1
+	 */
+	protected function add_hooks() {
+
+		add_filter( 'woocommerce_get_sections_checkout',  [ $this, 'add_settings_section' ], 99 );
+		add_action( 'woocommerce_settings_checkout',      [ $this, 'add_settings' ] );
+		add_action( 'woocommerce_settings_save_checkout', [ $this, 'save_settings' ] );
+
+		// render the special "static" gateway select
+		if ( ! has_action( 'woocommerce_admin_field_static' ) ) {
+			add_action( 'woocommerce_admin_field_static', [ $this, 'render_static_setting' ] );
+		}
+	}
+
+
+	/**
+	 * Adds the checkout settings section.
+	 *
+	 * @internal
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @param array $sections the existing sections
+	 * @return array
+	 */
+	public function add_settings_section( $sections ) {
+
+		$sections[ $this->section_id ] = $this->get_settings_section_name();
+
+		return $sections;
+	}
+
+
+	/**
+	 * Gets the name of the settings section.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return string
+	 */
+	abstract protected function get_settings_section_name();
+
+
+	/**
+	 * Gets all of the combined settings.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array $settings combined settings.
+	 */
+	abstract public function get_settings();
+
+
+	/**
+	 * Adds the definition for a Processing Gateway setting.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @param array $settings setting definitions
+	 * @return array
+	 */
+	protected function add_processing_gateway_settings( $settings ) {
+
+		$gateway_options = $this->get_processing_gateway_options();
+
+		if ( 1 === count( $gateway_options ) ) {
+
+			$settings[] = [
+				'id'    => $this->get_processing_gateway_setting_id(),
+				'title' => __( 'Processing Gateway', 'woocommerce-plugin-framework' ),
+				'type'  => 'static',
+				'value' => key( $gateway_options ),
+				'label' => current( $gateway_options ),
+			];
+
+		} else {
+
+			$settings[] = [
+				'id'    => $this->get_processing_gateway_setting_id(),
+				'title'   => __( 'Processing Gateway', 'woocommerce-plugin-framework' ),
+				'type'    => 'select',
+				'options' => $gateway_options
+			];
+		}
+
+		return $settings;
+	}
+
+
+	/**
+	 * Gets the ID for the Processing Gateway setting.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return string
+	 */
+	protected function get_processing_gateway_setting_id() {
+
+		return sprintf( 'sv_wc_%s_payment_gateway', str_replace( '-', '_', $this->section_id ) );
+	}
+
+
+	/**
+	 * Gets an array IDs and names of payment gateways that declare support.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array
+	 */
+	protected function get_processing_gateway_options() {
+
+		return array_map(
+			function( $gateway ) {
+				return $gateway->get_method_title();
+			},
+			$this->get_supporting_gateways()
+		);
+	}
+
+
+	/**
+	 * Gets the gateways that declare support.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array the supporting gateways as `$gateway_id => \SV_WC_Payment_Gateway`
+	 */
+	abstract protected function get_supporting_gateways();
+
+
+	/**
+	 * Outputs the settings fields.
+	 *
+	 * @internal
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @global string $current_section current settings section.
+	 */
+	public function add_settings() {
+		global $current_section;
+
+		if ( $current_section === $this->section_id ) {
+			\WC_Admin_Settings::output_fields( $this->get_settings() );
+		}
+	}
+
+
+	/**
+	 * Saves the settings.
+	 *
+	 * @internal
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @global string $current_section current settings section.
+	 */
+	public function save_settings() {
+		global $current_section;
+
+		if ( $current_section === $this->section_id ) {
+			\WC_Admin_Settings::save_fields( $this->get_settings() );
+		}
+	}
+
+
+	/**
+	 * Renders a static setting.
+	 *
+	 * This "setting" just displays simple text instead of a <select> with only one option.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @param array $setting
+	 */
+	public function render_static_setting( $setting ) {
+
+		?>
+
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="<?php echo esc_attr( $setting['id'] ); ?>"><?php echo esc_html( $setting['title'] ); ?></label>
+			</th>
+			<td class="forminp forminp-<?php echo sanitize_title( $setting['type'] ) ?>">
+				<?php echo esc_html( $setting['label'] ); ?>
+				<input
+					name="<?php echo esc_attr( $setting['id'] ); ?>"
+					id="<?php echo esc_attr( $setting['id'] ); ?>"
+					value="<?php echo esc_html( $setting['value'] ); ?>"
+					type="hidden"
+					>
+			</td>
+		</tr><?php
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/Visa_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/Visa_Checkout/Admin.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Apple-Pay
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Visa_Checkout;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Settings_Screen;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( __NAMESPACE__ . '\\Admin' ) ) :
+
+/**
+ * Sets up the Visa Checkout settings screen.
+ *
+ * @since 5.10.0-dev.1
+ */
+class Admin extends Settings_Screen {
+
+
+	/** @var Visa_Checkout the Visa Checkout handler instance */
+	protected $handler;
+
+
+	/**
+	 * Construct the class.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @param Visa_Checkout $handler main Visa Checkout handler instance
+	 */
+	public function __construct( $handler ) {
+
+		parent::__construct();
+
+		$this->section_id = 'visa-checkout';
+		$this->handler    = $handler;
+	}
+
+
+	/**
+	 * Sets up the necessary hooks.
+	 *
+	 * @since 5.10.0-dev.1
+	 */
+	protected function add_hooks() {
+
+		parent::add_hooks();
+	}
+
+
+	/**
+	 * Gets the name of the Visa Checkout settings section.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return string
+	 */
+	protected function get_settings_section_name() {
+
+		return __( 'Visa Checkout', 'woocommerce-plugin-framework' );
+	}
+
+
+	/**
+	 * Gets all of the combined settings.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array $settings combined settings.
+	 */
+	public function get_settings() {
+
+		$settings = [
+
+			[
+				'title' => __( 'Visa Checkout', 'woocommerce-plugin-framework' ),
+				'type'  => 'title',
+			],
+
+			[
+				'id'      => 'sv_wc_visa_checkout_enabled',
+				'title'   => __( 'Enable / Disable', 'woocommerce-plugin-framework' ),
+				'desc'    => __( 'Accept Visa Checkout', 'woocommerce-plugin-framework' ),
+				'type'    => 'checkbox',
+				'default' => 'no',
+			],
+
+			[
+				'type' => 'sectionend',
+			],
+		];
+
+		$settings = array_merge( $settings, $this->get_connection_settings() );
+
+		/**
+		 * Filter the settings fields for Visa Checkout.
+		 *
+		 * @since 5.10.0-dev.1
+		 *
+		 * @param array $settings combined settings.
+		 */
+		return apply_filters( 'woocommerce_get_settings_visa_checkout', $settings );
+	}
+
+
+	/**
+	 * Gets the connection settings for Visa Checkout.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array $settings connection settings
+	 */
+	protected function get_connection_settings() {
+
+		$connection_settings = [
+			[
+				'title' => __( 'Connection Settings', 'woocommerce-plugin-framework' ),
+				'type'  => 'title',
+			],
+		];
+
+		$connection_settings[] = [
+			'id'       => 'sv_wc_visa_checkout_environment',
+			'title'    => esc_html__( 'Environment', 'woocommerce-plugin-framework' ),
+			'type'     => 'select',
+			'default'  => Framework\SV_WC_Payment_Gateway::ENVIRONMENT_PRODUCTION,
+			'desc_tip' => esc_html__( 'Select the gateway environment to use for Visa Checkout transactions.', 'woocommerce-plugin-framework' ),
+			'options'  => [
+				Framework\SV_WC_Payment_Gateway::ENVIRONMENT_PRODUCTION => esc_html__( 'Production', 'woocommerce-plugin-framework' ),
+				Framework\SV_WC_Payment_Gateway::ENVIRONMENT_TEST       => esc_html__( 'Test', 'woocommerce-plugin-framework' ),
+			]
+		];
+
+		if ( $this->handler->requires_api_key() ) {
+
+			$connection_settings[] = [
+				'id'      => 'sv_wc_visa_checkout_api_key',
+				'title'   => __( 'API Key', 'woocommerce-plugin-framework' ),
+				'type'    => 'text',
+				'desc'  => sprintf(
+					__( 'The API key is required by Visa Checkout for encryption of sensitive payment credentials.', 'woocommerce-plugin-framework' )
+				),
+			];
+		}
+
+		$connection_settings = $this->add_processing_gateway_settings( $connection_settings );
+
+		$connection_settings[] = array(
+			'type' => 'sectionend',
+		);
+
+		return $connection_settings;
+	}
+
+
+	/**
+	 * Gets the gateways that declare support for Visa Checkout.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array
+	 */
+	protected function get_supporting_gateways() {
+
+		return $this->handler->get_supporting_gateways();
+	}
+
+
+}
+
+endif;

--- a/woocommerce/payment-gateway/Visa_Checkout/Visa_Checkout.php
+++ b/woocommerce/payment-gateway/Visa_Checkout/Visa_Checkout.php
@@ -41,6 +41,9 @@ class Visa_Checkout {
 	/** @var string option used to store the ID of the gateway configured to process Visa Checkout transactionns */
 	const OPTION_PROCESSING_GATEWAY = 'sv_wc_visa_checkout_payment_gateway';
 
+	/** @var Admin the admin handler instance */
+	protected $admin;
+
 
 	/**
 	 * Constructs the class.
@@ -52,6 +55,67 @@ class Visa_Checkout {
 	public function __construct( Framework\SV_WC_Payment_Gateway_Plugin $plugin ) {
 
 		$this->plugin = $plugin;
+
+		$this->init();
+	}
+
+
+	/**
+	 * Initializes the Visa Checkout handlers.
+	 *
+	 * @since 5.10.0-dev.1
+	 */
+	protected function init() {
+
+		if ( is_admin() && ! is_ajax() ) {
+			$this->init_admin();
+		}
+	}
+
+
+	/**
+	 * Initializes the admin handler.
+	 *
+	 * @since 5.10.0-dev.1
+	 */
+	protected function init_admin() {
+
+		$this->admin = new Admin( $this );
+	}
+
+
+	/**
+	 * Determines if Visa Checkout is available.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+
+		// TODO: add implementation {WV 2020-10-14}
+		$is_available = true;
+
+		/**
+		 * Filters whether Visa Checkout should be made available to users.
+		 *
+		 * @since 5.10.0-dev.1
+		 * @param bool $is_available
+		 */
+		return apply_filters( 'sv_wc_visa_checkout_is_available', $is_available );
+	}
+
+
+	/**
+	 * Determines whether an API Key is required for configuration.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function requires_api_key() {
+
+		return true;
 	}
 
 

--- a/woocommerce/payment-gateway/Visa_Checkout/Visa_Checkout.php
+++ b/woocommerce/payment-gateway/Visa_Checkout/Visa_Checkout.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * WooCommerce Payment Gateway Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Payment-Gateway/Visa-Checkout
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Visa_Checkout;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1 as Framework;
+
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( __NAMESPACE__ . '\\Visa_Checkout' ) ) :
+
+/**
+ * Sets up Visa Checkout support.
+ *
+ * @since 5.10.0-dev.1
+ */
+class Visa_Checkout {
+
+
+	/** @var string option used to store the ID of the gateway configured to process Visa Checkout transactionns */
+	const OPTION_PROCESSING_GATEWAY = 'sv_wc_visa_checkout_payment_gateway';
+
+
+	/**
+	 * Constructs the class.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @param SV_WC_Payment_Gateway_Plugin $plugin plugin instance
+	 */
+	public function __construct( Framework\SV_WC_Payment_Gateway_Plugin $plugin ) {
+
+		$this->plugin = $plugin;
+	}
+
+
+	/**
+	 * Gets the gateways that declare Visa Checkout support.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array the supporting gateways as `$gateway_id => \SV_WC_Payment_Gateway`
+	 */
+	public function get_supporting_gateways() {
+
+		return array_filter( $this->get_plugin()->get_gateways(), function ( $gateway ) {
+			return $gateway->supports_visa_checkout();
+		} );
+	}
+
+
+	/**
+	 * Gets the gateway set to process Visa Checkout transactions.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return SV_WC_Payment_Gateway|null
+	 */
+	public function get_processing_gateway() {
+
+		$gateways = $this->get_supporting_gateways();
+
+		$gateway_id = get_option( self::OPTION_PROCESSING_GATEWAY );
+
+		return isset( $gateways[ $gateway_id ] ) ? $gateways[ $gateway_id ] : null;
+	}
+
+
+	/**
+	 * Gets the gateway plugin instance.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return SV_WC_Payment_Gateway_Plugin
+	 */
+	public function get_plugin() {
+
+		return $this->plugin;
+	}
+
+
+}
+
+
+endif;

--- a/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -59,7 +59,9 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin {
 		add_action( 'woocommerce_settings_checkout', array( $this, 'add_settings' ) );
 
 		// render the special "static" gateway select
-		add_action( 'woocommerce_admin_field_static', array( $this, 'render_static_setting' ) );
+		if ( ! has_action( 'woocommerce_admin_field_static' ) ) {
+			add_action( 'woocommerce_admin_field_static', [ $this, 'render_static_setting' ] );
+		}
 
 		// save the settings
 		add_action( 'woocommerce_settings_save_checkout', array( $this, 'save_settings' ) );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -305,6 +305,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 		// visa checkout
 		require_once "{$payment_gateway_framework_path}/Visa_Checkout/Visa_Checkout.php";
+		require_once "{$payment_gateway_framework_path}/Visa_Checkout/Admin.php";
 
 		// apple pay
 		require_once( "{$payment_gateway_framework_path}/apple-pay/class-sv-wc-payment-gateway-apple-pay.php" );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -26,6 +26,7 @@ namespace SkyVerge\WooCommerce\PluginFramework\v5_8_1;
 
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+use SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Visa_Checkout\Visa_Checkout;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -99,6 +100,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 	/** @var SV_WC_Payment_Gateway_My_Payment_Methods adds My Payment Method functionality */
 	private $my_payment_methods;
+
+	/** @var Visa_Checkout Visa Checkout handler instance */
+	private $visa_checkout;
 
 	/** @var SV_WC_Payment_Gateway_Apple_Pay the Apple Pay handler instance */
 	private $apple_pay;
@@ -181,6 +185,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 		// my payment methods feature
 		add_action( 'init', array( $this, 'maybe_init_my_payment_methods' ) );
+
+		// visa checkout feature
+		add_action( 'init', [ $this, 'maybe_init_visa_checkout' ] );
 
 		// apple pay feature
 		add_action( 'init', array( $this, 'maybe_init_apple_pay' ) );
@@ -416,6 +423,67 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 
 	/** Visa Checkout ********************************************************/
+
+
+	/**
+	 * Initializes Visa Checkout if it's supported.
+	 *
+	 * @since 5.10.0-dev.1
+	 */
+	public function maybe_init_visa_checkout() {
+
+		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.2' ) && $this->is_visa_checkout_activated() && $this->supports_visa_checkout() ) {
+			$this->visa_checkout = $this->build_visa_checkout_instance();
+		}
+	}
+
+
+	/**
+	 * Determines whether Visa Checkout is activated.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return bool
+	 */
+	private function is_visa_checkout_activated() {
+
+		/**
+		 * Filters whether Visa Checkout is activated.
+		 *
+		 * @since 5.10.0-dev.1
+		 *
+		 * @param bool $activated whether Visa Checkout is activated
+		 */
+		return (bool) apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_activate_visa_checkout', false );
+	}
+
+
+	/**
+	 * Builds the Visa Checkout handler instance.
+	 *
+	 * Gateways can override this to define their own Visa Checkout class.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return Visa_Checkout
+	 */
+	protected function build_visa_checkout_instance() {
+
+		return new Visa_Checkout( $this );
+	}
+
+
+	/**
+	 * Gets the Visa Checkout handler instance.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return Visa_Checkout
+	 */
+	public function get_visa_checkout_instance() {
+
+		return $this->visa_checkout;
+	}
 
 
 	/**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -294,6 +294,8 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		require_once( $payment_gateway_framework_path . '/Handlers/Abstract_Hosted_Payment_Handler.php' );
 		require_once( $payment_gateway_framework_path . '/Handlers/Capture.php' );
 
+		require_once "{$payment_gateway_framework_path}/Settings_Screen.php";
+
 		// apple pay
 		require_once( "{$payment_gateway_framework_path}/apple-pay/class-sv-wc-payment-gateway-apple-pay.php" );
 		require_once( "{$payment_gateway_framework_path}/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php" );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -412,6 +412,29 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	}
 
 
+	/** Visa Checkout ********************************************************/
+
+
+	/**
+	 * Determines if this plugin has any gateways with Visa Checkout support.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function supports_visa_checkout() {
+
+		foreach ( $this->get_gateways() as $gateway ) {
+
+			if ( $gateway->supports_visa_checkout() ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
 	/** Apple Pay *************************************************************/
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -296,6 +296,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 		require_once "{$payment_gateway_framework_path}/Settings_Screen.php";
 
+		// visa checkout
+		require_once "{$payment_gateway_framework_path}/Visa_Checkout/Visa_Checkout.php";
+
 		// apple pay
 		require_once( "{$payment_gateway_framework_path}/apple-pay/class-sv-wc-payment-gateway-apple-pay.php" );
 		require_once( "{$payment_gateway_framework_path}/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php" );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -121,6 +121,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/** Add new payment method feature */
 	const FEATURE_ADD_PAYMENT_METHOD = 'add_payment_method';
 
+	/** Visa Checkout feature */
+	const FEATURE_VISA_CHECKOUT = 'visa_checkout';
+
 	/** Apple Pay feature */
 	const FEATURE_APPLE_PAY = 'apple_pay';
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1063,6 +1063,22 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	}
 
 
+	/** Visa Checkout Feature *****************************************************/
+
+
+	/**
+	 * Determines whether this gateway supports Visa Checkout.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return bool
+	 */
+	public function supports_visa_checkout() {
+
+		return $this->supports( self::FEATURE_VISA_CHECKOUT );
+	}
+
+
 	/** Apple Pay Feature *****************************************************/
 
 


### PR DESCRIPTION
# Summary

This PR updates the framework to define the Visa Checkout feature and show a basic set of settings for plugins that support it.

### Story: [CH 65911](https://app.clubhouse.io/skyverge/story/65911)

## Details

I branched of version v5.8.1 so that it's easy to test these changes on plugins without having to update the namespaces. We will likely have to rebase the changes here and integrate them with the Google Pay modifications before we start thinking about merging this one into a new framework version. So, for now, the target version is `feature/visa-checkout` which is the same as the `5.8.1` tag.

The Visa Checkout settings borrow almost everything from Apple Pay. This PR doesn't modify the existing Apple Pay handlers, but I chose to copy the different methods and classes into base handlers and handlers specific to Visa Checkout. 

I tried to put some of the logic on a trait, but I couldn't come with a set of methods that we would want to re-use for something other than creating settings for providers such as Apple Pay, Google Pay, and Visa Checkout. **Maybe the entire base handler is a trait?**

Perhaps the one I wanted to move the most was `Settings_Screen:: render_static_setting()` because I would rather have the `static` setting type globally available when our plugins are loaded, instead of having each class that uses settings and needs something like that define a custom type that does the same (we have something similar on Facebook settings). However, I don't think we have a place where we can register new field types globally and I chose not to introduce one here.

This PR introduces a `SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Settings_Screen` that provides the common functionality to add, render, and save a settings section such as the Apple Pay settings section.

The `SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Visa_Checkout\Admin` extends `Settings_Screens` to define the new **Visa Checkout** settings section.

This PR also introduces `SkyVerge\WooCommerce\PluginFramework\v5_8_1\Payment_Gateway\Visa_Checkout\Visa_Checkout` the main handler for the Visa Checkout feature. This one also copies a lot from the corresponding handler for Apple Pay and I think it makes sense to split some of that into a base handler that we can use for Visa Checkout and Google Pay. Here I just copied the parts that I ended to setup the settings section.

**What would be a good name for a common handler for Google Pay, Apple Pay, Visa Checkout, and others like them?** 

CyberSource docs kind of refer to them as *Online Authorizations*, *Payment Network Tokenization Providers*, or *Digital Payment Solutions*.

## UI Changes

- New Visa Checkout settings: https://cloud.skyver.ge/qGuvXYoz

## QA

### Setup

1. Install the `TBD` branch of CyberSource
1. Add the following snippet to activate Visa Checkout:

        add_filter( 'wc_payment_gateway_cybersource_activate_visa_checkout', '__return_true' );


### Steps

#### Settings

1. Go to WooCommerce > Settings > Payments > Visa Checkout
    - [ ] The Enable/Disable Visa Checkout setting is shown
    - [ ] The Environment select is shown
    - [ ] The API Key setting is shown
    - [ ] The Processing Gateway static setting is shown
1. Enable Visa Checkout
1. Select a different environment
1. Enter a value in the API Key field
1. Save changes
    - [ ] The fields are saved 

#### Tests 

- [ ] `codecept run acceptance` pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version