### PR TITLE
Add method to get IDs of gateways to inherit settings from

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -408,6 +408,19 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
+	 * Gets the IDs of sibling gateways that this gateway can inherit settings from.
+	 *
+	 * @since 5.10.0-dev.1
+	 *
+	 * @return array
+	 */
+	protected function get_ids_of_gateways_to_inherit_settings_from() {
+
+		return array_diff( $this->get_plugin()->get_gateway_ids(), [ $this->get_id() ] );
+	}
+
+
+	/**
 	 * Enqueue the necessary scripts & styles for the gateway, including the
 	 * payment form assets (if supported) and any gateway-specific assets.
 	 *

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -381,7 +381,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	protected function load_shared_settings() {
 
 		// get any other sibling gateways
-		$other_gateway_ids = array_diff( $this->get_plugin()->get_gateway_ids(), array( $this->get_id() ) );
+		$other_gateway_ids = $this->get_ids_of_gateways_to_inherit_settings_from();
 
 		// determine if any sibling gateways have any configured shared settings
 		foreach ( $other_gateway_ids as $other_gateway_id ) {
@@ -1348,7 +1348,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	protected function add_shared_settings_form_fields( $form_fields ) {
 
 		// get any sibling gateways
-		$other_gateway_ids                  = array_diff( $this->get_plugin()->get_gateway_ids(), array( $this->get_id() ) );
+		$other_gateway_ids                  = $this->get_ids_of_gateways_to_inherit_settings_from();
 		$configured_other_gateway_ids       = array();
 		$inherit_settings_other_gateway_ids = array();
 


### PR DESCRIPTION
# Summary

The framework currently doesn't support sharing settings between gateways when there are more than two gateways that share settings on the same plugin.

This adds a `SV_WC_Payment_Gateway::get_ids_of_gateways_to_inherit_settings_from()` helper method to allow gateways to control the IDs of gateways they can inherit settings from.

The method will be used in CyberSource to ensure that the eCheck and Visa Checkout inherit settings from the Credit Card gateway only.

### Story: [CH 66794](https://app.clubhouse.io/skyverge/story/66794)
### Release: #510 

## Details

This PR branches of `5.8.1` to facilitate testing on https://github.com/skyverge/woocommerce-gateway-cybersource/pull/13. However, the plan is to include this method the upcoming `v5.10.0`. That's why the since tag uses `5.10.0-dev.1`.

## QA

- [x] Code review only because user testing will be performed in https://github.com/skyverge/woocommerce-gateway-cybersource/pull/13

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version