### PR TITLE
Notices for non-standard tax behaviors

### DIFF
--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -549,6 +549,25 @@ class SV_WC_Helper {
 
 
 	/**
+	 * Determines if a shop has any published virtual products.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return bool
+	 */
+	public static function shop_has_virtual_products() {
+
+		$virtual_products = wc_get_products( [
+			'virtual' => true,
+			'status'  => 'publish',
+			'limit'   => - 1,
+		] );
+
+		return sizeof( $virtual_products ) > 0;
+	}
+
+
+	/**
 	 * Safely gets and trims data from $_POST.
 	 *
 	 * @since 3.0.0

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -560,7 +560,7 @@ class SV_WC_Helper {
 		$virtual_products = wc_get_products( [
 			'virtual' => true,
 			'status'  => 'publish',
-			'limit'   => - 1,
+			'limit'   => 1,
 		] );
 
 		return sizeof( $virtual_products ) > 0;

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -445,7 +445,8 @@ abstract class Admin {
 	 */
 	protected function should_display_shipping_based_tax_notice() {
 
-		return false;
+		return 'shipping' === get_option( 'woocommerce_tax_based_on' ) &&
+			   SV_WC_Helper::shop_has_virtual_products();
 	}
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -309,6 +309,8 @@ abstract class Admin {
 		}
 
 		$this->add_configuration_errors_notices();
+
+		$this->add_configuration_warnings_notices();
 	}
 
 
@@ -339,6 +341,38 @@ abstract class Admin {
 			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $this->section_id . '-configuration-issue', [
 				'notice_class' => 'error',
 				'dismissible'  => false,
+			] );
+		}
+	}
+
+
+	/**
+	 * Adds warning notices for configuration options that may need attention.
+	 *
+	 * @since 5.10.0
+	 */
+	protected function add_configuration_warnings_notices() {
+
+		$warnings = $this->get_configuration_warnings();
+
+		if ( ! empty( $warnings ) ) {
+
+			$message = sprintf(
+				/* translators: Placeholders:  - external checkout label, %2$s - <strong> tag, %3$s - </strong> tag */
+				__( '%2$S%1$s Notice!%3$S', 'woocommerce-plugin-framework' ),
+				$this->handler->get_label(),
+				'<strong>', '</strong>',
+			);
+
+			if ( 1 === count( $warnings ) ) {
+				$message .= ' ' . current( $warnings );
+			} else {
+				$message .= '<ul><li>' . implode( '</li><li>', $warnings ) . '</li></ul>';
+			}
+
+			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $this->section_id . '-configuration-issue-notice', [
+				'notice_class' => 'warning',
+				'dismissible'  => true,
 			] );
 		}
 	}
@@ -376,6 +410,21 @@ abstract class Admin {
 		}
 
 		return $errors;
+	}
+
+
+	/**
+	 * Gets the notice messages for configuration issues that may need attention.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return string[] error messages
+	 */
+	public function get_configuration_warnings() {
+
+		$warnings = [];
+
+		return $warnings;
 	}
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -385,7 +385,7 @@ abstract class Admin {
 	 *
 	 * @return string[] error messages
 	 */
-	public function get_configuration_errors() {
+	protected function get_configuration_errors() {
 
 		$errors = [];
 
@@ -420,7 +420,7 @@ abstract class Admin {
 	 *
 	 * @return string[] error messages
 	 */
-	public function get_configuration_warnings() {
+	protected function get_configuration_warnings() {
 
 		$warnings = [];
 

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -428,6 +428,58 @@ abstract class Admin {
 	}
 
 
+	/**
+	 * Checks if the shipping based tax notice should be displayed.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return bool
+	 */
+	protected function should_display_shipping_based_tax_notice() {
+
+		return false;
+	}
+
+
+	/**
+	 * Gets the shipping based tax notice text.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return string
+	 */
+	protected function get_shipping_based_tax_notice() {
+
+		return '';
+	}
+
+
+	/**
+	 * Checks if the  billing based tax notice should be displayed.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return bool
+	 */
+	protected function should_display_billing_based_tax_notice() {
+
+		return false;
+	}
+
+
+	/**
+	 * Gets the billing based tax notice text.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return string
+	 */
+	protected function get_billing_based_tax_notice() {
+
+		return '';
+	}
+
+
 }
 
 endif;

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -393,8 +393,8 @@ abstract class Admin {
 			$errors[] = sprintf(
 				/* translators: Placeholders: %1$s - plugin name, %2$s - a currency/comma-separated list of currencies, %3$s - <a> tag, %4$s - </a> tag, %5$s - external checkout label */
 				_n(
-					'Accepts payment in %1$s only. %2$sConfigure%3$s WooCommerce to accept %1$s to enable %5$s.',
-					'Accepts payment in one of %1$s only. %2$sConfigure%3$s WooCommerce to accept one of %1$s to enable %5$s.',
+					'Accepts payment in %1$s only. %2$sConfigure%3$s WooCommerce to accept %1$s to enable %4$s.',
+					'Accepts payment in one of %1$s only. %2$sConfigure%3$s WooCommerce to accept one of %1$s to enable %4$s.',
 					count( $accepted_currencies ),
 					'woocommerce-plugin-framework'
 				),

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -358,7 +358,7 @@ abstract class Admin {
 			$message = $this->get_shipping_based_tax_notice();
 
 			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $this->section_id . '-shipping-based-tax', [
-				'notice_class' => 'warning',
+				'notice_class' => 'notice-warning',
 				'dismissible'  => true,
 			] );
 		}
@@ -367,7 +367,7 @@ abstract class Admin {
 			$message = $this->get_billing_based_tax_notice();
 
 			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $this->section_id . '-billing-based-tax', [
-				'notice_class' => 'warning',
+				'notice_class' => 'notice-warning',
 				'dismissible'  => true,
 			] );
 		}

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -470,7 +470,7 @@ abstract class Admin {
 
 
 	/**
-	 * Checks if the  billing based tax notice should be displayed.
+	 * Checks if the billing based tax notice should be displayed.
 	 *
 	 * @since 5.10.0
 	 *
@@ -478,7 +478,8 @@ abstract class Admin {
 	 */
 	protected function should_display_billing_based_tax_notice() {
 
-		return false;
+		return 'billing' === get_option( 'woocommerce_tax_based_on' ) &&
+				! $this->handler->is_billing_address_available_before_payment();
 	}
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -461,7 +461,7 @@ abstract class Admin {
 
 		return sprintf(
 			/** translators: Placeholders: %1$s - external checkout label, %2$s - <a> tag, %3$s - </a> tag, %4$s - <strong> tag, %5$s - </strong> tag */
-			__( 'Your store %2$scalculates taxes%3$s based on the shipping address, but %1$s $4%sdoes not%5$s share customer shipping information with your store for orders with only virtual products. These orders will have their taxes calculated based on the shop address instead.', 'woocommerce-plugin-framework' ),
+			__( 'Your store %2$scalculates taxes%3$s based on the shipping address, but %1$s %4$sdoes not%5$s share customer shipping information with your store for orders with only virtual products. These orders will have their taxes calculated based on the shop address instead.', 'woocommerce-plugin-framework' ),
 			$this->handler->get_label(),
 			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=tax' ) ) . '">',
 			'</a>',
@@ -495,7 +495,7 @@ abstract class Admin {
 
 		return sprintf(
 			/** translators: Placeholders: %1$s - external checkout label, %2$s - <a> tag, %3$s - </a> tag, %4$s - <strong> tag, %5$s - </strong> tag */
-			__( 'Your store %2$scalculates taxes%3$s based on the billing address, but %1$s $4%sdoes not%5$s share the customer billing address with your store before payment. These orders will have their taxes calculated based on the shipping address (or shop address, for orders with only virtual products).', 'woocommerce-plugin-framework' ),
+			__( 'Your store %2$scalculates taxes%3$s based on the billing address, but %1$s %4$sdoes not%5$s share the customer billing address with your store before payment. These orders will have their taxes calculated based on the shipping address (or shop address, for orders with only virtual products).', 'woocommerce-plugin-framework' ),
 			$this->handler->get_label(),
 			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=tax' ) ) . '">',
 			'</a>',

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -329,7 +329,7 @@ abstract class Admin {
 				/* translators: Placeholders:  - external checkout label, %2$s - <strong> tag, %3$s - </strong> tag */
 				__( '%2$S%1$s is disabled.%3$S', 'woocommerce-plugin-framework' ),
 				$this->handler->get_label(),
-				'<strong>', '</strong>',
+				'<strong>', '</strong>'
 			);
 
 			if ( 1 === count( $errors ) ) {
@@ -401,7 +401,7 @@ abstract class Admin {
 				'<strong>' . implode( ', ', $accepted_currencies ) . '</strong>',
 				'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=general' ) ) . '">',
 				'</a>',
-				$this->handler->get_label(),
+				$this->handler->get_label()
 			);
 		}
 

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -458,7 +458,14 @@ abstract class Admin {
 	 */
 	protected function get_shipping_based_tax_notice() {
 
-		return '';
+		return sprintf(
+			/** translators: Placeholders: %1$s - external checkout label, %2$s - <a> tag, %3$s - </a> tag, %4$s - <strong> tag, %5$s - </strong> tag */
+			__( 'Your store %2$scalculates taxes%3$s based on the shipping address, but %1$s $4%sdoes not%5$s share customer shipping information with your store for orders with only virtual products. These orders will have their taxes calculated based on the shop address instead.', 'woocommerce-plugin-framework' ),
+			$this->handler->get_label(),
+			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=tax' ) ) . '">',
+			'</a>',
+			'<strong>', '</strong>'
+		);
 	}
 
 
@@ -484,7 +491,14 @@ abstract class Admin {
 	 */
 	protected function get_billing_based_tax_notice() {
 
-		return '';
+		return sprintf(
+			/** translators: Placeholders: %1$s - external checkout label, %2$s - <a> tag, %3$s - </a> tag, %4$s - <strong> tag, %5$s - </strong> tag */
+			__( 'Your store %2$scalculates taxes%3$s based on the billing address, but %1$s $4%sdoes not%5$s share the customer billing address with your store before payment. These orders will have their taxes calculated based on the shipping address (or shop address, for orders with only virtual products).', 'woocommerce-plugin-framework' ),
+			$this->handler->get_label(),
+			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=tax' ) ) . '">',
+			'</a>',
+			'<strong>', '</strong>'
+		);
 	}
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -308,18 +308,18 @@ abstract class Admin {
 			return;
 		}
 
-		$this->add_configuration_errors_notices();
+		$this->add_configuration_errors_notice();
 
 		$this->add_configuration_warnings_notices();
 	}
 
 
 	/**
-	 * Adds error notices for configuration options that need attention.
+	 * Adds one error notice for all configuration options that need attention.
 	 *
 	 * @since 5.10.0
 	 */
-	protected function add_configuration_errors_notices() {
+	protected function add_configuration_errors_notice() {
 
 		$errors = $this->get_configuration_errors();
 
@@ -347,30 +347,26 @@ abstract class Admin {
 
 
 	/**
-	 * Adds warning notices for configuration options that may need attention.
+	 * Adds warning notices for each configuration option that may need attention.
 	 *
 	 * @since 5.10.0
 	 */
 	protected function add_configuration_warnings_notices() {
 
-		$warnings = $this->get_configuration_warnings();
+		if ( $this->should_display_shipping_based_tax_notice() ) {
 
-		if ( ! empty( $warnings ) ) {
+			$message = $this->get_shipping_based_tax_notice();
 
-			$message = sprintf(
-				/* translators: Placeholders:  - external checkout label, %2$s - <strong> tag, %3$s - </strong> tag */
-				__( '%2$s%1$s Notice!%3$s', 'woocommerce-plugin-framework' ),
-				$this->handler->get_label(),
-				'<strong>', '</strong>',
-			);
+			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $this->section_id . '-shipping-based-tax', [
+				'notice_class' => 'warning',
+				'dismissible'  => true,
+			] );
+		}
 
-			if ( 1 === count( $warnings ) ) {
-				$message .= ' ' . current( $warnings );
-			} else {
-				$message .= '<ul><li>' . implode( '</li><li>', $warnings ) . '</li></ul>';
-			}
+		if ( $this->should_display_billing_based_tax_notice() ) {
+			$message = $this->get_billing_based_tax_notice();
 
-			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $this->section_id . '-configuration-issue-notice', [
+			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, $this->section_id . '-billing-based-tax', [
 				'notice_class' => 'warning',
 				'dismissible'  => true,
 			] );
@@ -414,29 +410,6 @@ abstract class Admin {
 
 
 	/**
-	 * Gets the notice messages for configuration issues that may need attention.
-	 *
-	 * @since 5.10.0
-	 *
-	 * @return string[] error messages
-	 */
-	protected function get_configuration_warnings() {
-
-		$warnings = [];
-
-		if ( $this->should_display_shipping_based_tax_notice() ) {
-			$warnings[] = $this->get_shipping_based_tax_notice();
-		}
-
-		if ( $this->should_display_billing_based_tax_notice() ) {
-			$warnings[] = $this->get_billing_based_tax_notice();
-		}
-
-		return $warnings;
-	}
-
-
-	/**
 	 * Checks if the shipping based tax notice should be displayed.
 	 *
 	 * @since 5.10.0
@@ -461,7 +434,7 @@ abstract class Admin {
 
 		return sprintf(
 			/** translators: Placeholders: %1$s - external checkout label, %2$s - <a> tag, %3$s - </a> tag, %4$s - <strong> tag, %5$s - </strong> tag */
-			__( 'Your store %2$scalculates taxes%3$s based on the shipping address, but %1$s %4$sdoes not%5$s share customer shipping information with your store for orders with only virtual products. These orders will have their taxes calculated based on the shop address instead.', 'woocommerce-plugin-framework' ),
+			__( '%4$s%1$s Notice!%5$s Your store %2$scalculates taxes%3$s based on the shipping address, but %1$s %4$sdoes not%5$s share customer shipping information with your store for orders with only virtual products. These orders will have their taxes calculated based on the shop address instead.', 'woocommerce-plugin-framework' ),
 			$this->handler->get_label(),
 			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=tax' ) ) . '">',
 			'</a>',
@@ -495,7 +468,7 @@ abstract class Admin {
 
 		return sprintf(
 			/** translators: Placeholders: %1$s - external checkout label, %2$s - <a> tag, %3$s - </a> tag, %4$s - <strong> tag, %5$s - </strong> tag */
-			__( 'Your store %2$scalculates taxes%3$s based on the billing address, but %1$s %4$sdoes not%5$s share the customer billing address with your store before payment. These orders will have their taxes calculated based on the shipping address (or shop address, for orders with only virtual products).', 'woocommerce-plugin-framework' ),
+			__( '%4$s%1$s Notice!%5$s Your store %2$scalculates taxes%3$s based on the billing address, but %1$s %4$sdoes not%5$s share the customer billing address with your store before payment. These orders will have their taxes calculated based on the shipping address (or shop address, for orders with only virtual products).', 'woocommerce-plugin-framework' ),
 			$this->handler->get_label(),
 			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=tax' ) ) . '">',
 			'</a>',

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -359,7 +359,7 @@ abstract class Admin {
 
 			$message = sprintf(
 				/* translators: Placeholders:  - external checkout label, %2$s - <strong> tag, %3$s - </strong> tag */
-				__( '%2$S%1$s Notice!%3$S', 'woocommerce-plugin-framework' ),
+				__( '%2$s%1$s Notice!%3$s', 'woocommerce-plugin-framework' ),
 				$this->handler->get_label(),
 				'<strong>', '</strong>',
 			);

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -424,6 +424,14 @@ abstract class Admin {
 
 		$warnings = [];
 
+		if ( $this->should_display_shipping_based_tax_notice() ) {
+			$warnings[] = $this->get_shipping_based_tax_notice();
+		}
+
+		if ( $this->should_display_billing_based_tax_notice() ) {
+			$warnings[] = $this->get_billing_based_tax_notice();
+		}
+
 		return $warnings;
 	}
 

--- a/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
+++ b/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
@@ -133,10 +133,8 @@ abstract class External_Checkout {
 			return;
 		}
 
-		$prefix = ucwords( str_replace( '_', ' ', $this->id ) );
-
 		if ( $gateway->debug_log() ) {
-			$gateway->get_plugin()->log( "[$prefix] $message", $gateway->get_id() );
+			$gateway->get_plugin()->log( "[{$this->label}] $message", $gateway->get_id() );
 		}
 	}
 

--- a/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
+++ b/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
@@ -42,6 +42,9 @@ abstract class External_Checkout {
 	/** @var string external checkout ID */
 	protected $id;
 
+	/** @var string external checkout human-readable label (used in notices and log entries) */
+	protected $label;
+
 	/** @var SV_WC_Payment_Gateway_Plugin the plugin instance */
 	protected $plugin;
 

--- a/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
+++ b/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
@@ -105,6 +105,18 @@ abstract class External_Checkout {
 
 
 	/**
+	 * Checks if the external checkout provides the customer billing address to WC before payment confirmation.
+	 *
+	 * Each external checkout handler should implement this method according to the external checkout behavior.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return bool
+	 */
+	abstract public function is_billing_address_available_before_payment();
+
+
+	/**
 	 * Gets the configured display locations.
 	 *
 	 * @since 5.10.0

--- a/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
+++ b/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
@@ -300,6 +300,19 @@ abstract class External_Checkout {
 	}
 
 
+	/**
+	 * Gets the external checkout label.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+
+		return $this->label;
+	}
+
+
 }
 
 endif;

--- a/woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php
@@ -60,20 +60,6 @@ class Admin extends \SkyVerge\WooCommerce\PluginFramework\v5_10_0\Payment_Gatewa
 
 
 	/**
-	 * Sets up the necessary hooks.
-	 *
-	 * @since 5.10.0
-	 */
-	protected function add_hooks() {
-
-		parent::add_hooks();
-
-		// add admin notices for configuration options that need attention
-		add_action( 'admin_footer', [ $this, 'add_admin_notices' ], 10 );
-	}
-
-
-	/**
 	 * Gets the name of the Google Pay settings section.
 	 *
 	 * @since 5.10.0
@@ -192,62 +178,6 @@ class Admin extends \SkyVerge\WooCommerce\PluginFramework\v5_10_0\Payment_Gatewa
 	protected function get_supporting_gateways() {
 
 		return $this->handler->get_supporting_gateways();
-	}
-
-
-	/**
-	 * Adds admin notices for configuration options that need attention.
-	 *
-	 * @since 5.10.0
-	 */
-	public function add_admin_notices() {
-
-		// if the feature is not enabled, bail
-		if ( ! $this->handler->is_enabled() ) {
-			return;
-		}
-
-		// if not on the settings screen, bail
-		if ( ! $this->is_settings_screen() ) {
-			return;
-		}
-
-		$errors = [];
-
-		// Currency notice
-		$accepted_currencies = $this->handler->get_accepted_currencies();
-
-		if ( ! empty( $accepted_currencies ) && ! in_array( get_woocommerce_currency(), $accepted_currencies, true ) ) {
-
-			$errors[] = sprintf(
-				/* translators: Placeholders: %1$s - plugin name, %2$s - a currency/comma-separated list of currencies, %3$s - <a> tag, %4$s - </a> tag */
-				_n(
-					'Accepts payment in %1$s only. %2$sConfigure%3$s WooCommerce to accept %1$s to enable Google Pay.',
-					'Accepts payment in one of %1$s only. %2$sConfigure%3$s WooCommerce to accept one of %1$s to enable Google Pay.',
-					count( $accepted_currencies ),
-					'woocommerce-plugin-framework'
-				),
-				'<strong>' . implode( ', ', $accepted_currencies ) . '</strong>',
-				'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=general' ) ) . '">',
-				'</a>'
-			);
-		}
-
-		if ( ! empty( $errors ) ) {
-
-			$message = '<strong>' . __( 'Google Pay is disabled.', 'woocommerce-plugin-framework' ) . '</strong>';
-
-			if ( 1 === count( $errors ) ) {
-				$message .= ' ' . current( $errors );
-			} else {
-				$message .= '<ul><li>' . implode( '</li><li>', $errors ) . '</li></ul>';
-			}
-
-			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, 'google-pay-configuration-issue', [
-				'notice_class' => 'error',
-				'dismissible'  => false,
-			] );
-		}
 	}
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php
+++ b/woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php
@@ -107,6 +107,20 @@ class Google_Pay extends External_Checkout {
 
 
 	/**
+	 * Checks if the external checkout provides the customer billing address to WC before payment confirmation.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return bool
+	 */
+	public function is_billing_address_available_before_payment() {
+
+		// Google Pay does not provide billing information until the payment is confirmed
+		return false;
+	}
+
+
+	/**
 	 * Gets Google transaction info based on WooCommerce cart or product data.
 	 *
 	 * @since 5.10.0

--- a/woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php
+++ b/woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php
@@ -62,7 +62,8 @@ class Google_Pay extends External_Checkout {
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Plugin $plugin ) {
 
-		$this->id = 'google_pay';
+		$this->id    = 'google_pay';
+		$this->label = __( 'Google Pay', 'woocommerce-plugin-framework' );
 
 		parent::__construct( $plugin );
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -219,7 +219,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin extends Admin {
 	 *
 	 * @return string[] error messages
 	 */
-	public function get_configuration_errors() {
+	protected function get_configuration_errors() {
 
 		$errors = parent::get_configuration_errors();
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -60,20 +60,6 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin extends Admin {
 
 
 	/**
-	 * Sets up the necessary hooks.
-	 *
-	 * @since 5.10.0
-	 */
-	protected function add_hooks() {
-
-		parent::add_hooks();
-
-		// add admin notices for configuration options that need attention
-		add_action( 'admin_footer', [ $this, 'add_admin_notices' ], 10 );
-	}
-
-
-	/**
 	 * Gets the name of the Apple Pay settings section.
 	 *
 	 * @since 5.10.0
@@ -227,46 +213,19 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin extends Admin {
 
 
 	/**
-	 * Adds admin notices for configuration options that need attention.
+	 * Gets the error messages for configuration issues that need attention.
 	 *
-	 * @since 4.7.0
+	 * @since 5.10.0
+	 *
+	 * @return string[] error messages
 	 */
-	public function add_admin_notices() {
+	public function get_configuration_errors() {
 
-		// if the feature is not enabled, bail
-		if ( ! $this->handler->is_enabled() ) {
-			return;
-		}
-
-		// if not on the settings screen, bail
-		if ( ! $this->is_settings_screen() ) {
-			return;
-		}
-
-		$errors = array();
+		$errors = parent::get_configuration_errors();
 
 		// HTTPS notice
 		if ( ! wc_site_is_https() ) {
 			$errors[] = __( 'Your site must be served over HTTPS with a valid SSL certificate.', 'woocommerce-plugin-framework' );
-		}
-
-		// Currency notice
-		$accepted_currencies = $this->handler->get_accepted_currencies();
-
-		if ( ! empty( $accepted_currencies ) && ! in_array( get_woocommerce_currency(), $accepted_currencies, true ) ) {
-
-			$errors[] = sprintf(
-				/* translators: Placeholders: %1$s - plugin name, %2$s - a currency/comma-separated list of currencies, %3$s - <a> tag, %4$s - </a> tag */
-				_n(
-					'Accepts payment in %1$s only. %2$sConfigure%3$s WooCommerce to accept %1$s to enable Apple Pay.',
-					'Accepts payment in one of %1$s only. %2$sConfigure%3$s WooCommerce to accept one of %1$s to enable Apple Pay.',
-					count( $accepted_currencies ),
-					'woocommerce-plugin-framework'
-				),
-				'<strong>' . implode( ', ', $accepted_currencies ) . '</strong>',
-				'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=general' ) ) . '">',
-				'</a>'
-			);
 		}
 
 		// bad cert config notice
@@ -281,21 +240,7 @@ class SV_WC_Payment_Gateway_Apple_Pay_Admin extends Admin {
 			);
 		}
 
-		if ( ! empty( $errors ) ) {
-
-			$message = '<strong>' . __( 'Apple Pay is disabled.', 'woocommerce-plugin-framework' ) . '</strong>';
-
-			if ( 1 === count( $errors ) ) {
-				$message .= ' ' . current( $errors );
-			} else {
-				$message .= '<ul><li>' . implode( '</li><li>', $errors ) . '</li></ul>';
-			}
-
-			$this->handler->get_plugin()->get_admin_notice_handler()->add_admin_notice( $message, 'apple-pay-https-required', array(
-				'notice_class' => 'error',
-				'dismissible'  => false,
-			) );
-		}
+		return $errors;
 	}
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -61,7 +61,8 @@ class SV_WC_Payment_Gateway_Apple_Pay extends Payment_Gateway\External_Checkout\
 	 */
 	public function __construct( SV_WC_Payment_Gateway_Plugin $plugin ) {
 
-		$this->id = 'apple_pay';
+		$this->id    = 'apple_pay';
+		$this->label = __( 'Apple Pay', 'woocommerce-plugin-framework' );
 
 		parent::__construct( $plugin );
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -106,6 +106,20 @@ class SV_WC_Payment_Gateway_Apple_Pay extends Payment_Gateway\External_Checkout\
 
 
 	/**
+	 * Checks if the external checkout provides the customer billing address to WC before payment confirmation.
+	 *
+	 * @since 5.10.0
+	 *
+	 * @return bool
+	 */
+	public function is_billing_address_available_before_payment() {
+
+		// Apple Pay does not provide billing information until the payment is confirmed
+		return false;
+	}
+
+
+	/**
 	 * Processes the payment after an Apple Pay authorization.
 	 *
 	 * This method creates a new order and calls the gateway for processing.


### PR DESCRIPTION
# Summary

This PR contains the FW changes to add notices for Google and Apple Pay non-standard tax behaviors.

### Story: [CH 66812](https://app.clubhouse.io/skyverge/story/66812/notices-for-non-standard-tax-behaviors)
### Release: #510

## Details

I've extracted the notice handling to the parent Admin class. 

Apple Pay specific configuration checks (such as HTTPS and certificate) remained on the Apple Pay Admin handler.

I've preserved the behaviour for configuration errors (they are grouped into a single notice) but added the new notices as separate notices.

## UI Changes

- New Google Pay notice for shops with shipping based tax calculation and virtual products: https://cloud.skyver.ge/5zuwv9Ol
- New Apple Pay notice for shops with shipping based tax calculation and virtual products: https://cloud.skyver.ge/WnurXqGR
- New Google Pay notice for shops with billing based tax calculation: https://cloud.skyver.ge/P8uyw6yK
- New Apple Pay notice for shops with billing based tax calculation: https://cloud.skyver.ge/jkuD8mYk

## QA

### Setup

1. Shipping
1.1 Configure a shipping zone with at least one paid shipping method
1. CyberSource
1.1 Navigate to your CyberSource code folder
1.1 Checkout CyberSource branch `ch61993/cybersource-google-pay` 
1.1 Run `composer install`
1.1 Activate and configure CyberSource
1. Google Pay 
1.1 Navigate to WooCommerce > Settings > Payments > Google Pay
1.1 Enable Google Pay and configure it to use CyberSource gateway
1. Apple Pay 
1.1 Implement the `wc_payment_gateway_cybersource_activate_apple_pay` filter to activate Apple Pay for CyberSource
1.1 Navigate to WooCommerce > Settings > Payments > Apple Pay
1.1 Enable Apple Pay and configure it to use CyberSource gateway
1. Taxes
1.1 Navigate to WooCommerce > Settings > General
1.1 Check "Enable tax rates and calculations", if needed
1. Currency
1.1 Make sure your shop currency is not GBP

### Steps

#### Google Pay notice for shops with shipping based tax calculation and virtual products

1. Navigate to WooCommerce > Settings > Tax
1. Set "Calculate tax based on" to "Customer shipping address"
1. Make sure your shop has no published virtual products
1. Navigate to WooCommerce > Settings > Payments > Google Pay
   - [x] The corresponding notice is not displayed
1. Make sure your shop has at least one published virtual product
1. Navigate to WooCommerce > Settings > Payments > Google Pay
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97745910-cb249e00-1aa6-11eb-9cd3-bb86fcfaddde.png)
1. Dismiss the notice
1. Refresh the page
   - [x] The corresponding notice is not displayed

#### Apple Pay notice for shops with shipping based tax calculation and virtual products

1. Navigate to WooCommerce > Settings > Tax
1. Set "Calculate tax based on" to "Customer shipping address"
1. Make sure your shop has no published virtual products
1. Navigate to WooCommerce > Settings > Payments > Apple Pay
   - [x] The corresponding notice is not displayed
1. Make sure your shop has at least one published virtual product
1. Navigate to WooCommerce > Settings > Payments > Apple Pay
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97747129-b47f4680-1aa8-11eb-9ca1-010fd144457a.png)
1. Dismiss the notice
1. Refresh the page
   - [x] The corresponding notice is not displayed

#### Google Pay notice for shops with billing based tax calculation

1. Navigate to WooCommerce > Settings > Tax
1. Set "Calculate tax based on" to "Customer billing address"
1. Navigate to WooCommerce > Settings > Payments > Google Pay
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97747303-fdcf9600-1aa8-11eb-8647-db6f684f1060.png)
1. Dismiss the notice
1. Refresh the page
   - [x] The corresponding notice is not displayed

#### Apple Pay notice for shops with billing based tax calculation

1. Navigate to WooCommerce > Settings > Tax
1. Set "Calculate tax based on" to "Customer billing address"
1. Navigate to WooCommerce > Settings > Payments > Apple Pay
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97747350-0de77580-1aa9-11eb-958d-c6813da3fe8d.png)
1. Dismiss the notice
1. Refresh the page
   - [x] The corresponding notice is not displayed

#### Shops with shop address based tax calculation

1. Navigate to WooCommerce > Settings > Tax
1. Set "Calculate tax based on" to "Shop base address"
1. Navigate to WooCommerce > Settings > Payments > Apple Pay
   - [x] No taxes regarding tax calculation are displayed
1. Navigate to WooCommerce > Settings > Payments > Google Pay
   - [x] No taxes regarding tax calculation are displayed

#### Apple Pay certificate notice (backward compatibility)

1. Navigate to WooCommerce > Settings > Payments > Apple Pay
1. Clear the "Certificate Path" field and "Save changes"
1. Wait for the page to refresh
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97747543-5dc63c80-1aa9-11eb-83f6-9b1021f82e6f.png)

#### Apple Pay currency notice (backward compatibility)

1. Navigate to WooCommerce > Settings > Payments > Apple Pay
1. Set the "Certificate Path" field and "Save changes"
1. Implement the `sv_wc_apple_pay_accepted_currencies` filter to return `['GBP']`
1. Navigate to WooCommerce > Settings > Payments > Apple Pay
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97748546-db3e7c80-1aaa-11eb-974d-09a009803963.png)

#### Apple Pay multiple configuration errors notice (backward compatibility)

1. Navigate to WooCommerce > Settings > Payments > Apple Pay
1. Clear the "Certificate Path" field and "Save changes"
1. Implement the `sv_wc_apple_pay_accepted_currencies` filter to return `['GBP']`
1. Navigate to WooCommerce > Settings > Payments > Apple Pay
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97748669-12ad2900-1aab-11eb-85c0-8df91c8afe56.png)

#### Google Pay currency notice (backward compatibility)

1. Implement the `sv_wc_google_pay_accepted_currencies` filter to return `['GBP']`
1. Navigate to WooCommerce > Settings > Payments > Google Pay
   - [x] The corresponding notice is displayed:
![image](https://user-images.githubusercontent.com/4502503/97748960-87806300-1aab-11eb-9b2b-cabcc22e8597.png)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version