### PR TITLE
Add a sanity check to render_payment_field

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -977,10 +977,11 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 	 */
 	protected function render_payment_field( $field ) {
 
-		if ( isset( $field['name'] ) ) {
-
-			woocommerce_form_field( $field['name'], $field, $field['value'] );
-		}
+		woocommerce_form_field(
+			isset ( $field['name'] ) ? $field['name'] : null,
+			$field,
+			isset ( $field['value'] ) ? $field['value'] : null
+		);
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -978,9 +978,9 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 	protected function render_payment_field( $field ) {
 
 		woocommerce_form_field(
-			isset ( $field['name'] ) ? $field['name'] : null,
+			isset( $field['name'] ) ? $field['name'] : null,
 			$field,
-			isset ( $field['value'] ) ? $field['value'] : null
+			isset( $field['value'] ) ? $field['value'] : null
 		);
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -977,7 +977,10 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 	 */
 	protected function render_payment_field( $field ) {
 
-		woocommerce_form_field( $field['name'], $field, $field['value'] );
+		if ( isset( $field['name'] ) ) {
+
+			woocommerce_form_field( $field['name'], $field, $field['value'] );
+		}
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds a sanity check to prevent fields to be created if the name parameter is not informed.

### Story: [CH 67034](https://app.clubhouse.io/skyverge/story/67034/extend-the-payment-form-get-credit-card-fields-parent-method)
### Release: #510 

## Details

Similar to #514: _branched of `5.8.1` tag so that we can use these changes on Elavon Converge without having to update the framework namespace._

## QA

### Steps

- [ ] Code review

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version