### PR TITLE
Blank text fields are added for settings marked as shared but not implemented in the gateway

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,7 @@
 
 2020.nn.nn - version 5.10.0
  * Feature - Add Google Pay support
+ * Fix - Ensure blank settings inputs aren't added when a base abstract gateway defines shared settings that a child gateway doesn't support
 
 2020.10.09 - version 5.9.0
  * Feature - Add helper method to detect whether the current request is a REST API request

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1343,7 +1343,10 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		// add the special 'shared-settings-field' class name to any shared settings fields
 		foreach ( $this->shared_settings as $field_name ) {
-			$this->form_fields[ $field_name ]['class'] = trim( isset( $this->form_fields[ $field_name ]['class'] ) ? $this->form_fields[ $field_name ]['class'] : '' ) . ' shared-settings-field';
+
+			if ( ! empty( $this->form_fields[ $field_name ] ) ) {
+				$this->form_fields[ $field_name ]['class'] = trim( isset( $this->form_fields[ $field_name ]['class'] ) ? $this->form_fields[ $field_name ]['class'] : '' ) . ' shared-settings-field';
+			}
 		}
 
 		/**


### PR DESCRIPTION
# Summary

If a gateway has any setting IDs in its `shared_settings` array that aren't actually present in the `$form_fields` array, then a blank text field will be displayed for those missing IDs.

### Story: [CH 67118](https://app.clubhouse.io/skyverge/story/67118)
### Release: #510 

## Details

More details in [the story](https://app.clubhouse.io/skyverge/story/67118), but essentially we're not checking if a setting exists for the gateway before we [add the shared setting class](https://github.com/skyverge/wc-plugin-framework/blob/5.9.0/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php#L1272-L1274) and that results in it being added to the array without a type or other properties.

This can happen if a plugin has multiple gateways with a shared base abstract class that defines `shared_settings`, but some of the child gateways don't support all of those shared settings, for instance tokenization fields.

## UI Changes

N/A

## QA

### Setup

- Check out the [Cybersource `release-2.3.0`](https://github.com/skyverge/woocommerce-gateway-cybersource/tree/release-2.3.0) branch and install/activate the plugin
- Point the composer framework version to `dev-ch67118/blank-test-fields-are-added-for-settings-marked-as-shared`

### Steps

1. Visit the Visa Checkout gateway settings page
1. Toggle the "Share connection settings" checkbox on & off
    - [x] No blank field is displayed as in [this screenshot](https://docs.google.com/document/d/19E9VmWzHcPkcFJK8PnXVqqYNReX2zhm7DR737oEgjlk/edit#bookmark=id.5eu6o1pic373)

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version