### PR TITLE
Add framework method to detect enabled WC Admin features

### DIFF
--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -328,6 +328,22 @@ class SV_WC_Plugin_Compatibility {
 	}
 
 
+	/**
+	 * Determines whether an enhanced admin feature is available in the current installation.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string $feature_name WC Admin feature name, e.g. 'marketing'
+	 * @return bool
+	 */
+	public static function is_enhanced_admin_feature_enabled( $feature_name ) {
+
+		return self::is_enhanced_admin_available()
+			&& is_callable( 'Automattic\WooCommerce\Admin\Loader::is_feature_enabled' )
+			&& Automattic\WooCommerce\Admin\Loader::is_feature_enabled( $feature_name );
+	}
+
+
 	/** WordPress core ******************************************************/
 
 


### PR DESCRIPTION

## Summary

Adds a  `SV_WC_Plugin_Compatibility::is_enhanced_admin_feature_enabled()`

### Story: [CH 67229](https://app.clubhouse.io/skyverge/story/67229)

## Details

This can be helpful as the mere presence of WC Admin installed/bundled with WC core doesn't guarantee that some of its features are available and as more plugins are building on WC Admin it may be handy to have an helper.

## QA

To test this, you could try this PR for Facebook for WooCommerce: https://github.com/facebookincubator/facebook-for-woocommerce/pull/1663

Note that before commit https://github.com/facebookincubator/facebook-for-woocommerce/pull/1663/commits/19a119c14aa8bb2c53cd0275a79b89b056f55fc9 if you had running the latest WC Admin feature plugin (not just WC4.0+ alone) the return value of the method of `is_enhanced_admin_available` would have been false. 

- [ ] Code review