### PR TITLE
Update SV_WC_Payment_Gateway_Hosted::do_invalid_transaction_response() parameters

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2020.nn.nn - version 5.10.1-dev.1
+ * Fix - Prevent a deprecated notice for SV_WC_Payment_Gateway_Hosted::do_invalid_transaction_response() in PHP 8
 
 2020.11.06 - version 5.10.0
  * Feature - Add Google Pay support

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -770,10 +770,10 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param \WC_Order $order Optional. The order object
+	 * @param \WC_Order $order WooCommerce order object
 	 * @param SV_WC_Payment_Gateway_API_Payment_Notification_Response $response the response object
 	 */
-	protected function do_invalid_transaction_response( $order = null, $response ) {
+	protected function do_invalid_transaction_response( $order, $response ) {
 
 		if ( $response->is_ipn() ) {
 


### PR DESCRIPTION
# Summary

Addresses a deprecated notice logged in PHP 8.

### Story: [CH 67787](https://app.clubhouse.io/skyverge/story/67787)
### Release: #519 

## UI Changes

N/A

## QA

### Setup

- `composer install`

### Steps

- [x] Run `vendor/bin/phpcs` with no errors

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version