### PR TITLE
Remove admin_head action call for wizard steps

### DIFF
--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -323,7 +323,6 @@ abstract class Setup_Wizard {
 				<?php wp_print_scripts( 'wc-setup' ); ?>
 				<?php do_action( 'admin_print_scripts' ); ?>
 				<?php do_action( 'admin_print_styles' ); ?>
-				<?php do_action( 'admin_head' ); ?>
 			</head>
 			<body class="wc-setup wp-core-ui <?php echo esc_attr( $this->get_slug() ); ?>">
 				<?php $this->render_header(); ?>

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,7 @@
 
 2020.nn.nn - version 5.10.1-dev.1
  * Fix - Prevent a deprecated notice for SV_WC_Payment_Gateway_Hosted::do_invalid_transaction_response() in PHP 8
+ * Fix - Prevent PHP Notices and fatal errors on wizard steps
 
 2020.11.06 - version 5.10.0
  * Feature - Add Google Pay support


### PR DESCRIPTION
# Summary

Due to WordPress action calls workflow, `Setup_Wizard` was calling `<?php do_action( 'admin_head' ); ?>` before `current_screen` hook ([more details here](https://app.clubhouse.io/skyverge/story/67775/investigate-and-fix-php-notices-thrown-in-some-wizard-steps#activity-68207)).

Apparently, this action is not necessary as wizard steps don't include the admin header.

This PR will remove this action call because after PHP 8.0, what is now restricted to PHP Notices will become fatal errors and will prevent the wizard steps to be presented to users.

### Story: [CH 1234](https://app.clubhouse.io/skyverge/story/67775/investigate-and-fix-php-notices-thrown-in-some-wizard-steps)
### Release: #519 (release PR)

## QA

### Setup

1. Make sure you're running a PHP 8.0 environment

### Steps

1. Pick a plugin that has wizard steps, like Intuit (it will be used for the next steps, but it'd be good if this PR could also be validated with another plugin)
1. Activate Intuit
1. In the plugins page click on **Setup** below WooCommerce Intuit Payments Gateway then you'll be redirected to its wizard steps
1. A fatal error is thrown, preventing the first step to show
1. Open `composer.json` and bump `skyverge/wc-plugin-framework` version to `dev-ch67775/investigate-and-fix-php-notices-thrown-in`
1. Run `composer update skyverge/wc-plugin-framework`
1. You also may have to run a "replace all" from `5_8_1` to `5_10_0` to bump framework version and also disable other gateways and plugins that make use of the FW
1. Refresh the wizard steps page
    - [x] No PHP Notices nor errors are shown
    - [x] The wizard style remains the same
    - [x] The wizard scripts remain the same
    - [x] The wizard flow remains the same

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version