### PR TITLE
Add sanity checks to SV_WC_Payment_Gateway::payment_fields()

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -777,7 +777,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 */
 	public function payment_fields() {
 
-		if ( $this->supports_payment_form() ) {
+		if ( $this->get_payment_form_instance() && is_callable( [ $this->get_payment_form_instance(), 'render' ] ) && $this->supports_payment_form() ) {
 
 			$this->get_payment_form_instance()->render();
 


### PR DESCRIPTION
# Summary

This PR will add sanity checks in `SV_WC_Payment_Gateway::payment_fields()` to prevent incompatibility with page builders like Divi Builder and Elementor.

### Story: [CH 64341](https://app.clubhouse.io/skyverge/story/64341)
### Release: #525 (release PR)

## Details

Some page builders like Divi Builder and Elementor may allow users to edit the checkout page. And while editing, the page may be rendered without any items in the cart, causing `$this->get_payment_form_instance()->render();` to be called while the payment form is `null`.

## QA

- [x] Code review

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version