### PR TITLE
Use the right format specifier in sprintf

### DIFF
--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -326,10 +326,9 @@ abstract class Admin {
 		if ( ! empty( $errors ) ) {
 
 			$message = sprintf(
-				/* translators: Placeholders:  - external checkout label, %2$s - <strong> tag, %3$s - </strong> tag */
-				__( '%2$S%1$s is disabled.%3$S', 'woocommerce-plugin-framework' ),
-				$this->handler->get_label(),
-				'<strong>', '</strong>'
+				/* translators: Placeholder: %s - external checkout label */
+				'<strong>' . __( '%s is disabled.', 'woocommerce-plugin-framework' ) . '</strong>',
+				$this->handler->get_label()
 			);
 
 			if ( 1 === count( $errors ) ) {


### PR DESCRIPTION
## Summary

Fixes an issue with `sprintf()` in the external checkout admin handler as twi of the placeholders were `$S` (uppercase) and thus invalid. 

While fixing this I figured we didn't need as many placeholders for the HTML `<strong>` tags as these could be part of the same string, hardcoded and untranslatable (see diff).

#### Story: [MWC-257](https://jira.godaddy.com/browse/MWC-257)

## QA

- [x] Code review

