### PR TITLE
Give payment token subclasses more control

### DIFF
--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -650,6 +650,25 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
+	 * Creates the WooCommerce core payment token object that store the data of this framework token.
+	 *
+	 * If it's not a credit card, we default to echeck, so there's always an instance.
+	 *
+	 * @since 5.10.5-dev.1
+	 *
+	 * @return \WC_Payment_Token
+	 */
+	protected function make_new_woocommerce_payment_token() {
+
+		if ( $this->is_credit_card() ) {
+			return new \WC_Payment_Token_CC();
+		}
+
+		return new \WC_Payment_Token_ECheck();
+	}
+
+
+	/**
 	 * Gets a representation of this token suitable for persisting to a datastore.
 	 *
 	 * Note: moving forward we will use {@see \WC_Data} and {@see \WC_Payment_Token} to handle data stores.

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -595,6 +595,27 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 
 	/**
+	 * Gets the framework token type based on the type of the associated WooCommerce core token.
+	 *
+	 * Defaults to 'echeck' if core token is not an instance of \WC_Payment_Token_CC
+	 *
+	 * @since 5.10.5-dev.1
+	 *
+	 * @param \WC_Payment_Token $token WooCommerce core token
+	 *
+	 * @return string
+	 */
+	protected function get_type_from_woocommerce_payment_token( \WC_Payment_Token $token ) {
+
+		if ( $token instanceof \WC_Payment_Token_CC ) {
+			return 'credit_card';
+		}
+
+		return 'echeck';
+	}
+
+
+	/**
 	 * Gets the WooCommerce core payment token object related to this framework token.
 	 *
 	 * @since 5.8.0

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -66,7 +66,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	/**
 	 * @var null|\WC_Payment_Token WooCommerce core token corresponding to the framework token, if set
 	 */
-	private $token;
+	protected $token;
 
 
 	/**

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -738,13 +738,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 		$token = $this->get_woocommerce_payment_token();
 
 		if ( ! $token instanceof \WC_Payment_Token ) {
-
-			// instantiate a new token: if it's not a credit card, we default to echeck, so there's always an instance
-			if ( $this->is_credit_card() ) {
-				$token = new \WC_Payment_Token_CC();
-			} elseif ( $this->is_echeck() ) {
-				$token = new \WC_Payment_Token_ECheck();
-			}
+			$token = $this->make_new_woocommerce_payment_token();
 		}
 
 		$token->set_token( $this->get_id() );

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -53,7 +53,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 	/**
 	 * @var array key-value array to map WooCommerce core token props to framework token `$data` keys
 	 */
-	private $props = [
+	protected $props = [
 		'gateway_id'   => 'gateway_id',
 		'user_id'      => 'user_id',
 		'is_default'   => 'default',

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -700,12 +700,7 @@ class SV_WC_Payment_Gateway_Payment_Token {
 
 		unset( $token_data['meta_data'] );
 
-		/** default to 'echeck' if core token is not an instance of \WC_Payment_Token_CC */
-		if ( $core_token instanceof \WC_Payment_Token_CC ) {
-			$this->data['type'] = 'credit_card';
-		} else {
-			$this->data['type'] = 'echeck';
-		}
+		$this->data['type'] = $this->get_type_from_woocommerce_payment_token( $core_token );
 
 		foreach ( $meta_data as $meta_datum ) {
 			$token_data[ $meta_datum->key ] = $meta_datum->value;


### PR DESCRIPTION
# Summary

Updates the `SV_WC_Payment_Gateway_Payment_Token` class to allow sub-classes to control the type of core token that is used to store the payment method information in core tables.

### Story: [MWC-263](https://jira.godaddy.com/browse/MWC-263)
### Release: #528

## UI Changes

N/A

## QA

### Steps

- [x] QA passes for https://github.com/woocommerce/woocommerce-gateway-paypal-powered-by-braintree/pull/342
- [x] Code review
- [x] Tests pass

## Before merge

- [x] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code