### PR TITLE
Check if array key exist in token editor template

### DIFF
--- a/woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php
+++ b/woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php
@@ -29,7 +29,7 @@
 
 	<?php foreach ( $fields as $field_id => $field ) : ?>
 
-		<?php $is_select = 'select' === $field['type'] && isset( $field['options'] ) && ! empty( $field['options'] ); ?>
+		<?php $is_select = isset( $field['type'], $field['options'] ) && 'select' === $field['type'] && ! empty( $field['options'] ); ?>
 
 		<td class="token-<?php echo esc_attr( $field_id ); ?>">
 

--- a/woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php
+++ b/woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php
@@ -21,6 +21,15 @@
  * @copyright Copyright (c) 2013-2020, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
+
+/**
+ * @type string $index token index while adding tokens in AJAX requests
+ * @type string $input_name HTML name for the token fields
+ * @type array $fields token editor fields
+ * @type array $token default payment token
+ * @type string $type payment type
+ * @type array $actions payment token actions
+ */
 ?>
 
 <?php $token_input_name = $input_name . '[' . $index . ']'; ?>


### PR DESCRIPTION
## Summary 

While testing https://jira.godaddy.com/browse/MWC-263 I bumped in a PHP warning " Undefined array key "type" " in https://github.com/skyverge/wc-plugin-framework/blob/master/woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php#L32. Perhaps this happened because I only had PayPal tokens and no credit card tokens? Nonetheless, we do have an `isset()` check for the options key, and one such check should also exist for the $field type key.

#### Story: [MWC 276](https://jira.godaddy.com/browse/MWC-276)
#### PR: #528 

## QA

To replicate, I happened to follow the QA instructions in https://github.com/woocommerce/woocommerce-gateway-paypal-powered-by-braintree/pull/342 while I did not have any credit card tokens saved. 

- [x] Code review

## Before merge

- [ ] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [ ] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code