### PR TITLE
Add the is_wc_navigation_enabled method

### DIFF
--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -983,6 +983,19 @@ class SV_WC_Helper {
 
 
 	/**
+	 * Determines whether the new WooCommerce enhanced navigation is supported and enabled.
+	 *
+	 * @since 5.10.6
+	 *
+	 * @return bool
+	 */
+	public static function is_wc_navigation_enabled() {
+
+
+	}
+
+
+	/**
 	 * Determines if the current request is for a WC REST API endpoint.
 	 *
 	 * @see \WooCommerce::is_rest_api_request()

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -24,6 +24,9 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_10_6;
 
+use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
+use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Loader;
 
 defined( 'ABSPATH' ) or exit;

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -973,7 +973,7 @@ class SV_WC_Helper {
 	 */
 	public static function is_enhanced_admin_screen() {
 
-		return is_admin() && SV_WC_Plugin_Compatibility::is_enhanced_admin_available() && ( Automattic\WooCommerce\Admin\Loader::is_admin_page() || Automattic\WooCommerce\Admin\Loader::is_embed_page() );
+		return is_admin() && SV_WC_Plugin_Compatibility::is_enhanced_admin_available() && ( \Automattic\WooCommerce\Admin\Loader::is_admin_page() || \Automattic\WooCommerce\Admin\Loader::is_embed_page() );
 	}
 
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -24,11 +24,6 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_10_6;
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
-use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Admin\Loader;
-
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_10_6\\SV_WC_Helper' ) ) :
@@ -978,7 +973,7 @@ class SV_WC_Helper {
 	 */
 	public static function is_enhanced_admin_screen() {
 
-		return is_admin() && SV_WC_Plugin_Compatibility::is_enhanced_admin_available() && ( Loader::is_admin_page() || Loader::is_embed_page() );
+		return is_admin() && SV_WC_Plugin_Compatibility::is_enhanced_admin_available() && ( Automattic\WooCommerce\Admin\Loader::is_admin_page() || Automattic\WooCommerce\Admin\Loader::is_embed_page() );
 	}
 
 
@@ -992,11 +987,11 @@ class SV_WC_Helper {
 	public static function is_wc_navigation_enabled() {
 
 		return
-			is_callable( [ Screen::class, 'register_post_type' ] ) &&
-			is_callable( [ Menu::class, 'add_plugin_item' ] ) &&
-			is_callable( [ Menu::class, 'add_plugin_category' ] ) &&
-			is_callable( [ Features::class, 'is_enabled' ] ) &&
-			Features::is_enabled( 'navigation' );
+			is_callable( [ Automattic\WooCommerce\Admin\Features\Navigation\Screen::class, 'register_post_type' ] ) &&
+			is_callable( [ Automattic\WooCommerce\Admin\Features\Navigation\Menu::class, 'add_plugin_item' ] ) &&
+			is_callable( [ Automattic\WooCommerce\Admin\Features\Navigation\Menu::class, 'add_plugin_category' ] ) &&
+			is_callable( [ Automattic\WooCommerce\Admin\Features\Features::class, 'is_enabled' ] ) &&
+			Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'navigation' );
 	}
 
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -991,7 +991,7 @@ class SV_WC_Helper {
 	 */
 	public static function is_wc_navigation_enabled() {
 
-		return self::is_enhanced_admin_screen() &&
+		return
 			is_callable( [ Screen::class, 'register_post_type' ] ) &&
 			is_callable( [ Menu::class, 'add_plugin_item' ] ) &&
 			is_callable( [ Menu::class, 'add_plugin_category' ] ) &&

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -991,7 +991,12 @@ class SV_WC_Helper {
 	 */
 	public static function is_wc_navigation_enabled() {
 
-
+		return self::is_enhanced_admin_screen() &&
+			is_callable( [ Screen::class, 'register_post_type' ] ) &&
+			is_callable( [ Menu::class, 'add_plugin_item' ] ) &&
+			is_callable( [ Menu::class, 'add_plugin_category' ] ) &&
+			is_callable( [ Features::class, 'is_enabled' ] ) &&
+			Features::is_enabled( 'navigation' );
 	}
 
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -987,11 +987,11 @@ class SV_WC_Helper {
 	public static function is_wc_navigation_enabled() {
 
 		return
-			is_callable( [ Automattic\WooCommerce\Admin\Features\Navigation\Screen::class, 'register_post_type' ] ) &&
-			is_callable( [ Automattic\WooCommerce\Admin\Features\Navigation\Menu::class, 'add_plugin_item' ] ) &&
-			is_callable( [ Automattic\WooCommerce\Admin\Features\Navigation\Menu::class, 'add_plugin_category' ] ) &&
-			is_callable( [ Automattic\WooCommerce\Admin\Features\Features::class, 'is_enabled' ] ) &&
-			Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'navigation' );
+			is_callable( [ \Automattic\WooCommerce\Admin\Features\Navigation\Screen::class, 'register_post_type' ] ) &&
+			is_callable( [ \Automattic\WooCommerce\Admin\Features\Navigation\Menu::class, 'add_plugin_item' ] ) &&
+			is_callable( [ \Automattic\WooCommerce\Admin\Features\Navigation\Menu::class, 'add_plugin_category' ] ) &&
+			is_callable( [ \Automattic\WooCommerce\Admin\Features\Features::class, 'is_enabled' ] ) &&
+			\Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'navigation' );
 	}
 
 


### PR DESCRIPTION
# Summary

This PR will add a helper method that will be used by a few plugins to add menu items to the new WooCommerce enhanced navigation menu.

### Story: [MWC-350](https://jira.godaddy.com/browse/MWC-350)
### Release: #532 (release PR)

## QA

Setting up an environment that allowed me to enable the new WC navigation wasn't that easy and I had to build up a brand new WP instance to avoid any trash options preventing the features section from loading in the WC settings.

Maybe you'll find that easy, but if not, consider starting this PR to set up a new WP instance that could be used to QA the entire [epic](https://jira.godaddy.com/browse/MWC-124).

### Setup

1. Install WooCommerce 4.9.0
1. Install WooCommerce Admin **2.1.1** (I only got it working in this specific version)
1. Install the **WooCommerce Customer/Order/Coupons Export** plugin
1. Branch `temporary-proof-of-concept-updating-plugins-for-new-woocommerce-navigation` for this plugin - which is already set to use FW 5.10.6
1. Run `composer update skyverge/wc-plugin-framework`
1. Tweak `WC_Customer_Order_CSV_Export_Admin::add_menu_link()` by adding `error_log( '{is_wc_navigation_enabled} ' . wc_bool_to_string( \SkyVerge\WooCommerce\PluginFramework\v5_10_6\SV_WC_Helper::is_wc_navigation_enabled() ) );` in its first line

### Steps

1. Navigate through the admin pages
    - [ ] `{is_wc_navigation_enabled} no` is being logged to the `debug.log` file
1. Go to WooCommerce > Settings > Advanced > Features
1. Check the **Navigation** option and save changes
    - [ ] You're now seeing the new WC navigation
1. Navigate through the admin pages
    - [ ] `{is_wc_navigation_enabled} yes` is being logged to the `debug.log` file

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version