### PR TITLE
Prevent External_Checkout extensions initialization issues on integrations

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -188,10 +188,10 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		add_action( 'init', array( $this, 'maybe_init_my_payment_methods' ) );
 
 		// apple pay feature
-		add_action( 'init', array( $this, 'maybe_init_apple_pay' ) );
+		add_action( 'wp_loaded', array( $this, 'maybe_init_apple_pay' ) );
 
 		// Google Pay feature
-		add_action( 'init', [ $this, 'maybe_init_google_pay' ] );
+		add_action( 'wp_loaded', [ $this, 'maybe_init_google_pay' ] );
 
 		// TODO: move these to Subscriptions integration
 		if ( $this->is_subscriptions_active() ) {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -188,7 +188,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		add_action( 'init', array( $this, 'maybe_init_my_payment_methods' ) );
 
 		// apple pay feature
-		add_action( 'wp_loaded', array( $this, 'maybe_init_apple_pay' ) );
+		add_action( 'wp_loaded', [ $this, 'maybe_init_apple_pay' ] );
 
 		// Google Pay feature
 		add_action( 'wp_loaded', [ $this, 'maybe_init_google_pay' ] );


### PR DESCRIPTION
# Summary

This PR will tweak how the `\SkyVerge\WooCommerce\PluginFramework\v*_*_*\Payment_Gateway\External_Checkout\External_Checkout` extensions are loaded to prevent PHP Warnings.

### Story: [MWC-647](https://jira.godaddy.com/browse/MWC-647)

## Details

`External_Checkout::is_available` gets the available payment gateways which causes WooCommerce to iterate over the payment methods checking for the available ones. When a store has a payment gateway that calls `get_cart` in one of those checks, it's ending up with tons of warnings in the `error_log` file since `get_cart` cannot be called on `init` but on or after `wp_loaded`.

## ⚠️ Note

* This PR must be reviewed by someone that can test with Apple Pay/Google Pay. I can't test those due to device and country eligibility so I couldn't be sure that by changing the stage where they're initialized won't have collateral effects on payments.

### Setup

1. Activate Braintree for WooCommerce Payment Gateway
1. Setup the gateway if not configured yet
1. Make sure `skyverge/wc-plugin-framework` is pointing to `5.10.5` in the `composer.json` file
1. Add the following snippet to your WP instance
```php
add_filter( 'wc_payment_gateway_braintree_activate_apple_pay', static function( $activate ) {

  if ( WC()->cart ) {
    WC()->cart->get_cart();
  }

  return $activate;
});
```
_This will try to call `get_cart` in the same stage as other incompatible gateways, simulating the same scenario._

### Steps

1. Navigate to your `/shop`
    - [x] A big PHP Notice starting with `Notice: get_cart was called incorrectly...` is shown and logged to `debug.log`
1. Update `skyverge/wc-plugin-framework` to `dev-mwc-647/prevent-external-checkout-extensions-initialization-issues-on-integrations`
1. Run `composer update skyverge/wc-plugin-framework`
1. Do a quick Find/Replace All `5_10_5` with `5_10_6` just to match with the current FW version
1. Refresh the shop page
    - [x] The PHP Notice is gone
1. Attempt to shop and paying with Google Pay
    - [x] No errors or warnings were caught
    - [x] The order is processed succesfully
1. Attempt to shop and paying with Apple Pay
    - [x] No errors or warnings were caught
    - [x] The order is processed succesfully

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version