### PR TITLE
update deprecated function nonce_user_logged_out

### DIFF
--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -158,12 +158,12 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		//  for logged-out users to use the customer session ID instead of 0 for user ID. We *want* to check
 		//  against a UID of 0 (since that's how the nonce was created), so we temporarily pause the
 		//  logged-out nonce hijacking before standing aside.
-		remove_filter( 'nonce_user_logged_out', array( WC()->session, 'nonce_user_logged_out' ) );
+		remove_filter( 'nonce_user_logged_out', array( WC()->session, 'maybe_update_nonce_user_logged_out' ) );
 
 		check_ajax_referer( $this->identifier, 'nonce' );
 
 		// sorry, later nonce users! please play again
-		add_filter( 'nonce_user_logged_out', array( WC()->session, 'nonce_user_logged_out' ) );
+		add_filter( 'nonce_user_logged_out', array( WC()->session, 'maybe_update_nonce_user_logged_out' ) );
 
 		$this->handle();
 

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -158,12 +158,20 @@ abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 		//  for logged-out users to use the customer session ID instead of 0 for user ID. We *want* to check
 		//  against a UID of 0 (since that's how the nonce was created), so we temporarily pause the
 		//  logged-out nonce hijacking before standing aside.
-		remove_filter( 'nonce_user_logged_out', array( WC()->session, 'maybe_update_nonce_user_logged_out' ) );
+		if ( version_compare( WC()->version , '5.3' , '>=' ) ) {
+			remove_filter( 'nonce_user_logged_out', array( WC()->session, 'maybe_update_nonce_user_logged_out' ) );
+		} else {
+			remove_filter( 'nonce_user_logged_out', array( WC()->session, 'nonce_user_logged_out' ) );
+		}
 
 		check_ajax_referer( $this->identifier, 'nonce' );
 
 		// sorry, later nonce users! please play again
-		add_filter( 'nonce_user_logged_out', array( WC()->session, 'maybe_update_nonce_user_logged_out' ) );
+		if ( version_compare( WC()->version , '5.3' , '>=' ) ) {
+			add_filter( 'nonce_user_logged_out', array( WC()->session, 'maybe_update_nonce_user_logged_out' ) );
+		} else {
+			add_filter( 'nonce_user_logged_out', array( WC()->session, 'nonce_user_logged_out' ) );
+		}
 
 		$this->handle();
 


### PR DESCRIPTION
Resolves https://github.com/skyverge/wc-plugin-framework/issues/541 and https://github.com/woocommerce/facebook-for-woocommerce/issues/1966 Other Skyverge plugins like Social Login and Address Validation use this code and should benefit from this change