### PR TITLE
Creates function for retrieving placeholder lists

### DIFF
--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -1,0 +1,51 @@
+<?php
+
+define( 'ABSPATH', true );
+
+class HelperTest extends \Codeception\Test\Unit {
+
+	/**
+	 * @var \UnitTester
+	 */
+	protected $tester;
+
+	protected function _before() {
+
+		require_once( 'woocommerce/class-sv-wc-helper.php' );
+	}
+
+	protected function _after() {
+
+	}
+
+	/**
+	 * Tests \SkyVerge\WooCommerce\PluginFramework\v5_10_8\SV_WC_Helper::get_placeholder_list()
+	 *
+	 * @param array $array input country code
+	 * @param string $expected expected return value
+	 *
+	 * @dataProvider provider_can_get_placeholder_list
+	 */
+	public function test_can_get_placeholder_list( array $array, $expected, $placeholder ) {
+
+		$result = \SkyVerge\WooCommerce\PluginFramework\v5_10_8\SV_WC_Helper::get_placeholder_list( $array, $placeholder );
+		$this->assertEquals( $expected, $result );
+	}
+
+
+	/**
+	 * Provider for test_can_get_placeholder_list()
+	 *
+	 * @return array
+	 */
+	public function provider_can_get_placeholder_list() {
+
+		return [
+			'Floating point values' => [ [1.1, 2.1], '%f, %f', '%f' ],
+			'Integer values' => [ [1, 2], '%d, %d', '%d' ],
+			'String values' => [ ['yes', 'no'], '%s, %s', '%s' ],
+		];
+	}
+
+
+}

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -1095,7 +1095,18 @@ class SV_WC_Helper {
 		}
 	}
 
-
+	/**
+	 * Returns a string of placeholders correlating to the quantity of the passed in array.
+	 *
+	 * This function prepares a string list of placeholders to be utilized with $wpdb::prepare().
+	 *
+	 * @since x.y.z
+	 * @param array $array An array of SQL query args.
+	 * @param string $placeholder Optional. The placeholder type.
+	 */
+	public static function get_placeholder_list( array $array, string $placeholder = '%s' ) : string {
+		return implode( ', ', array_fill( 0, count( $array ), $placeholder ) );
+	}
 }
 
 


### PR DESCRIPTION
# Summary <!-- Required -->
Creates helper function for retrieving placeholder lists to be used with wpdb::prepare()

⚠️ This [PR](https://github.com/gdcorp-partners/woocommerce-shipping-local-pickup-plus/pull/54) relies on this PR being merged ⚠️ 

### Issue: [MWC-2097](https://jira.godaddy.com/browse/MWC-2097)

## QA <!-- Optional -->

- [ ] Code Review
- [x] Unit Test Passes

## Before merge <!-- Required -->

- [x] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [ ] This PR makes the appropriate modifications to documentation or explains why none are needed
- [ ] This change does not impact usage or expected outputs of covered code
