### PR TITLE
Support cacheable requests in API base class

### DIFF
--- a/tests/integration/API/CacheableAPIBaseTest.php
+++ b/tests/integration/API/CacheableAPIBaseTest.php
@@ -13,6 +13,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
+	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::is_response_loaded_from_cache()}.
+	 * @throws ReflectionException
+	 */
+	public function test_is_response_loaded_from_cache() {
+
+		$api = $this->get_new_api_instance();
+
+		$property = new ReflectionProperty( get_class( $api ), 'response_loaded_from_cache' );
+		$property->setAccessible( true );
+
+		$method = new ReflectionMethod( get_class( $api ), 'is_response_loaded_from_cache' );
+		$method->setAccessible( true );
+		$method->invoke( $api );
+
+		$this->assertFalse( $method->invoke( $api ) );
+
+		$property->setValue( $api, true );
+
+		$this->assertTrue( $method->invoke( $api ) );
+	}
+
+
+	/**
 	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::reset_response()}.
 	 * @throws ReflectionException
 	 */

--- a/tests/integration/API/CacheableAPIBaseTest.php
+++ b/tests/integration/API/CacheableAPIBaseTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use SkyVerge\WooCommerce\PluginFramework\v5_10_10 as Framework;
-use SkyVerge\WooCommerce\PluginFramework\v5_10_10\SV_WC_API_JSON_Request;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Abstract_Cacheable_API_Base;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Traits\Cacheable_Request_Trait;
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\SV_WC_API_JSON_Request;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_10\SV_WC_API_Request;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,18 +22,19 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @param bool|null $force_refresh
 	 * @param bool|null $cache_exists
 	 * @param bool $should_load_from_cache
+	 *
 	 * @throws ReflectionException
 	 */
 	public function test_do_remote_request( bool $is_cacheable, bool $force_refresh = null, bool $cache_exists = null, bool $should_load_from_cache = false ) {
 
-		$api     = $this->get_new_api_instance(['load_response_from_cache']);
+		$api     = $this->get_new_api_instance( [ 'load_response_from_cache' ] );
 		$request = $this->get_new_request_instance( $is_cacheable );
 
 		if ( $is_cacheable ) {
 			$request->set_force_refresh( $force_refresh );
 		}
 
-		$api->method('load_response_from_cache')->willReturn( $cache_exists ? ['foo' => 'bar'] : null );
+		$api->method( 'load_response_from_cache' )->willReturn( $cache_exists ? [ 'foo' => 'bar' ] : null );
 
 		$property = new ReflectionProperty( get_class( $api ), 'request' );
 		$property->setAccessible( true );
@@ -56,13 +57,13 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_do_remote_request() : array {
+	public function provider_do_remote_request(): array {
 		return [
-			'cacheable, no refresh, cache exists'            => [true, false, true, true],
-			'cacheable, no refresh, cache does not exist'    => [true, false, false, false],
-			'cacheable, force refresh, cache exists'         => [true, true, true, false],
-			'cacheable, force refresh, cache does not exist' => [true, true, false, false],
-			'non-cacheable'                                  => [false, null, null, false],
+			'cacheable, no refresh, cache exists'            => [ true, false, true, true ],
+			'cacheable, no refresh, cache does not exist'    => [ true, false, false, false ],
+			'cacheable, force refresh, cache exists'         => [ true, true, true, false ],
+			'cacheable, force refresh, cache does not exist' => [ true, true, false, false ],
+			'non-cacheable'                                  => [ false, null, null, false ],
 		];
 	}
 
@@ -75,15 +76,20 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @param bool $is_cacheable
 	 * @param bool|null $loaded_from_cache
 	 * @param bool $should_save_response_to_cache
+	 *
 	 * @throws ReflectionException
 	 */
 	public function test_handle_response( bool $is_cacheable, bool $loaded_from_cache = false, bool $should_save_response_to_cache = false ) {
 
-		$api     = $this->get_new_api_instance(['is_response_loaded_from_cache', 'get_response_handler', 'save_response_to_cache']);
+		$api     = $this->get_new_api_instance( [
+			'is_response_loaded_from_cache',
+			'get_response_handler',
+			'save_response_to_cache'
+		] );
 		$request = $this->get_new_request_instance( $is_cacheable );
 
-		$api->method('get_response_handler')->willReturn( new stdClass );
-		$api->method('is_response_loaded_from_cache')->willReturn( $loaded_from_cache );
+		$api->method( 'get_response_handler' )->willReturn( new stdClass );
+		$api->method( 'is_response_loaded_from_cache' )->willReturn( $loaded_from_cache );
 
 		$property = new ReflectionProperty( get_class( $api ), 'request' );
 		$property->setAccessible( true );
@@ -103,11 +109,11 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_handle_response() : array {
+	public function provider_handle_response(): array {
 		return [
-			'cacheable, response loaded from cache'          => [true, true, false],
-			'cacheable, response not loaded from cache'      => [true, false, true],
-			'non-cacheable'                                  => [false, false, false],
+			'cacheable, response loaded from cache'     => [ true, true, false ],
+			'cacheable, response not loaded from cache' => [ true, false, true ],
+			'non-cacheable'                             => [ false, false, false ],
 		];
 	}
 
@@ -118,14 +124,14 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_load_response_from_cache() {
 
-		$api     = $this->get_new_api_instance(['get_request_transient_key']);
+		$api     = $this->get_new_api_instance( [ 'get_request_transient_key' ] );
 		$request = $this->get_new_request_instance();
 
 		$property = new ReflectionProperty( get_class( $api ), 'request' );
 		$property->setAccessible( true );
 		$property->setValue( $api, $request );
 
-		$api->method('get_request_transient_key')->willReturn( 'foo' );
+		$api->method( 'get_request_transient_key' )->willReturn( 'foo' );
 
 		set_transient( 'foo', 'bar' );
 
@@ -142,19 +148,19 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_save_response_to_cache() {
 
-		$api     = $this->get_new_api_instance(['get_request_transient_key']);
+		$api     = $this->get_new_api_instance( [ 'get_request_transient_key' ] );
 		$request = $this->get_new_request_instance();
 
 		$property = new ReflectionProperty( get_class( $api ), 'request' );
 		$property->setAccessible( true );
 		$property->setValue( $api, $request );
 
-		$api->method('get_request_transient_key')->willReturn( 'foo' );
+		$api->method( 'get_request_transient_key' )->willReturn( 'foo' );
 
 		$method = new ReflectionMethod( get_class( $api ), 'save_response_to_cache' );
 		$method->setAccessible( true );
 
-		$data = ['bar' => 'baz'];
+		$data = [ 'bar' => 'baz' ];
 
 		$method->invoke( $api, $data );
 
@@ -219,15 +225,16 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @param string $uri request uri
 	 * @param string $body request body
 	 * @param int $lifetime request lifetime
+	 *
 	 * @throws ReflectionException
 	 */
 	public function test_get_request_transient_key( string $uri, string $body, int $lifetime ) {
 
-		$api = $this->get_new_api_instance(['get_request_uri', 'get_request_body']);
+		$api     = $this->get_new_api_instance( [ 'get_request_uri', 'get_request_body' ] );
 		$request = $this->get_new_request_instance()->set_cache_lifetime( $lifetime );
 
-		$api->method('get_request_uri')->willReturn( $uri );
-		$api->method('get_request_body')->willReturn( $body );
+		$api->method( 'get_request_uri' )->willReturn( $uri );
+		$api->method( 'get_request_body' )->willReturn( $body );
 
 		$property = new ReflectionProperty( get_class( $api ), 'request' );
 		$property->setAccessible( true );
@@ -252,13 +259,13 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_get_request_transient_key() : array {
+	public function provider_get_request_transient_key(): array {
 		return [
-			['foo', 'a=1', 100],
-			['foo', 'a=2', 100],
-			['foo', 'a=2', 200],
-			['bar', '', 100],
-			['bar/baz', '', 100],
+			[ 'foo', 'a=1', 100 ],
+			[ 'foo', 'a=2', 100 ],
+			[ 'foo', 'a=2', 200 ],
+			[ 'bar', '', 100 ],
+			[ 'bar/baz', '', 100 ],
 		];
 	}
 
@@ -271,6 +278,7 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @param bool $cacheable whether to test with a cacheable request
 	 * @param null|bool $filter_value when provided, will filter is_cacheable with the given value
 	 * @param bool $expected expected return value
+	 *
 	 * @throws ReflectionException
 	 */
 	public function test_is_request_cacheable( bool $cacheable, $filter_value = null, bool $expected ) {
@@ -285,7 +293,7 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 			add_filter(
 				'wc_plugin_' . sv_wc_test_plugin()->get_id() . '_api_request_is_cacheable',
 				// the typehints in the closure ensure we're passing the correct arguments to the filter from `is_request_cacheable`
-				static function( bool $is_cacheable, SV_WC_API_Request $request ) use ( $filter_value ) {
+				static function ( bool $is_cacheable, SV_WC_API_Request $request ) use ( $filter_value ) {
 					return $filter_value;
 				}, 10, 2 );
 		}
@@ -302,12 +310,12 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_is_request_cacheable() : array {
+	public function provider_is_request_cacheable(): array {
 		return [
-			'cacheable request, no filtering'          => [true, null, true],
-			'non-cacheable request, no filtering'      => [false, null, false],
-			'cacheable request, filtering to false'    => [true, false, false],
-			'non-cacheable request, filtering to true' => [false, true, false],
+			'cacheable request, no filtering'          => [ true, null, true ],
+			'non-cacheable request, no filtering'      => [ false, null, false ],
+			'cacheable request, filtering to false'    => [ true, false, false ],
+			'non-cacheable request, filtering to true' => [ false, true, false ],
 		];
 	}
 
@@ -320,6 +328,7 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @param int $lifetime request cache lifetime
 	 * @param null|int $filter_value when provided, will filter cache_lifetime with the given value
 	 * @param int $expected expected return value
+	 *
 	 * @throws ReflectionException
 	 */
 	public function test_get_request_cache_lifetime( int $lifetime, $filter_value = null, int $expected ) {
@@ -335,7 +344,7 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 			add_filter(
 				'wc_plugin_' . sv_wc_test_plugin()->get_id() . '_api_request_cache_lifetime',
 				// the typehints in the closure ensure we're passing the correct arguments to the filter from `is_request_cacheable`
-				static function( int $lifetime, SV_WC_API_Request $request ) use ( $filter_value ) {
+				static function ( int $lifetime, SV_WC_API_Request $request ) use ( $filter_value ) {
 					return $filter_value;
 				}, 10, 2 );
 		}
@@ -352,10 +361,10 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_get_request_cache_lifetime() : array {
+	public function provider_get_request_cache_lifetime(): array {
 		return [
-			'non-filtered' => [100, null, 100],
-			'filtered'     => [100, 200, 200],
+			'non-filtered' => [ 100, null, 100 ],
+			'filtered'     => [ 100, 200, 200 ],
 		];
 	}
 
@@ -368,9 +377,10 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @param bool $is_cacheable
 	 * @param bool|null $force_refresh
 	 * @param bool|null $should_cache
+	 *
 	 * @throws ReflectionException
 	 */
-	public function test_get_request_data_for_broadcast(bool $is_cacheable, bool $force_refresh = null, bool $should_cache = null ) {
+	public function test_get_request_data_for_broadcast( bool $is_cacheable, bool $force_refresh = null, bool $should_cache = null ) {
 
 		$api     = $this->get_new_api_instance();
 		$request = $this->get_new_request_instance( $is_cacheable );
@@ -411,12 +421,12 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_get_request_data_for_broadcast() : array {
+	public function provider_get_request_data_for_broadcast(): array {
 		return [
-			'cacheable, no refresh, should cache' => [true, false, true],
-			'cacheable, force refresh, should cache' => [true, true, true],
-			'cacheable, force refresh, no cache' => [true, true, false],
-			'non-cacheable' => [false],
+			'cacheable, no refresh, should cache'    => [ true, false, true ],
+			'cacheable, force refresh, should cache' => [ true, true, true ],
+			'cacheable, force refresh, no cache'     => [ true, true, false ],
+			'non-cacheable'                          => [ false ],
 		];
 	}
 
@@ -430,6 +440,7 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @param bool|null $cache_exists
 	 * @param bool|null $force_refresh
 	 * @param bool|null $expected_from_cache
+	 *
 	 * @throws ReflectionException
 	 */
 	public function test_get_response_data_for_broadcast( bool $is_cacheable, bool $response_loaded_from_cache = false ) {
@@ -468,11 +479,11 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function provider_get_response_data_for_broadcast() : array {
+	public function provider_get_response_data_for_broadcast(): array {
 		return [
-			'cacheable, loading response from cache' => [true, true],
-			'cacheable, not loading response from cache'  => [true, false],
-			'non-cacheable' => [false],
+			'cacheable, loading response from cache'     => [ true, true ],
+			'cacheable, not loading response from cache' => [ true, false ],
+			'non-cacheable'                              => [ false ],
 		];
 	}
 
@@ -502,13 +513,13 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 			Abstract_Cacheable_API_Base::class,
 			[],
 			'',
-            true,
-            true,
-            true,
+			true,
+			true,
+			true,
 			$mockMethods
 		);
 
-		$api->method('get_plugin')->willReturn( sv_wc_test_plugin() );
+		$api->method( 'get_plugin' )->willReturn( sv_wc_test_plugin() );
 
 		return $api;
 	}

--- a/tests/integration/API/CacheableAPIBaseTest.php
+++ b/tests/integration/API/CacheableAPIBaseTest.php
@@ -13,6 +13,57 @@ if ( ! defined( 'ABSPATH' ) ) {
 class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
+	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::load_response_from_cache()}.
+	 * @throws ReflectionException
+	 */
+	public function test_load_response_from_cache() {
+
+		$api     = $this->get_new_api_instance(['get_request_transient_key']);
+		$request = $this->get_new_request_instance();
+
+		$property = new ReflectionProperty( get_class( $api ), 'request' );
+		$property->setAccessible( true );
+		$property->setValue( $api, $request );
+
+		$api->method('get_request_transient_key')->willReturn( 'foo' );
+
+		set_transient( 'foo', 'bar' );
+
+		$method = new ReflectionMethod( get_class( $api ), 'load_response_from_cache' );
+		$method->setAccessible( true );
+
+		$this->assertEquals( 'bar', $method->invoke( $api ) );
+	}
+
+
+	/**
+	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::save_response_to_cache()}.
+	 * @throws ReflectionException
+	 */
+	public function test_save_response_to_cache() {
+
+		$api     = $this->get_new_api_instance(['get_request_transient_key']);
+		$request = $this->get_new_request_instance();
+
+		$property = new ReflectionProperty( get_class( $api ), 'request' );
+		$property->setAccessible( true );
+		$property->setValue( $api, $request );
+
+		$api->method('get_request_transient_key')->willReturn( 'foo' );
+
+		$method = new ReflectionMethod( get_class( $api ), 'save_response_to_cache' );
+		$method->setAccessible( true );
+
+		$data = ['bar' => 'baz'];
+
+		$method->invoke( $api, $data );
+
+		$this->assertEquals( get_transient( 'foo' ), $data );
+		$this->assertNotFalse( get_option( '_transient_timeout_foo' ) ); // ensure a timeout was set
+	}
+
+
+	/**
 	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::is_response_loaded_from_cache()}.
 	 * @throws ReflectionException
 	 */

--- a/tests/integration/API/CacheableAPIBaseTest.php
+++ b/tests/integration/API/CacheableAPIBaseTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10 as Framework;
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\SV_WC_API_JSON_Request;
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Abstract_Cacheable_API_Base;
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Traits\Cacheable_Request_Trait;
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\SV_WC_API_Request;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', true );
+}
+
+class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
+
+
+	/**
+	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::format_percentage()}.
+	 *
+	 * @dataProvider provider_is_request_cacheable
+	 *
+	 * @param bool $cacheable whether to test with a cacheable request
+	 * @param null|bool $filter_value when provided, will filter is_cacheable with the given value
+	 * @param bool $expected expected return value
+	 * @throws ReflectionException
+	 */
+	public function test_is_request_cacheable( bool $cacheable, $filter_value = null, bool $expected )
+	{
+		$api = $this->get_new_api_instance();
+
+		$property = new ReflectionProperty( get_class( $api ), 'request' );
+		$property->setAccessible( true );
+		$property->setValue( $api, $this->get_new_request_instance( $cacheable ) );
+
+		if ( is_bool( $filter_value ) ) {
+			add_filter(
+				'wc_plugin_' . sv_wc_test_plugin()->get_id() . '_api_request_is_cacheable',
+				// the typehints in the closure ensure we're passing the correct arguments to the filter from `is_request_cacheable`
+				static function( bool $is_cacheable, SV_WC_API_Request $request ) use ( $filter_value ) {
+					return $filter_value;
+				}, 10, 2 );
+		}
+
+		$this->assertEquals( $expected, $api->is_request_cacheable() );
+	}
+
+	/**
+	 * Data provider for {@see CacheableAPIBaseTest::test_is_request_cacheable()}.
+	 *
+	 * @return array[]
+	 */
+	public function provider_is_request_cacheable() : array
+	{
+		return [
+			'cacheable request, no filtering'          => [true, null, true],
+			'non-cacheable request, no filtering'      => [false, null, false],
+			'cacheable request, filtering to false'    => [true, false, false],
+			'non-cacheable request, filtering to true' => [false, true, false],
+		];
+	}
+
+
+	/**
+	 * Gets a test request instance using the CacheableRequestTrait.
+	 */
+	protected function get_new_request_instance( $cacheable = true ) {
+		return $cacheable
+			? new class extends SV_WC_API_JSON_Request {
+				use Cacheable_Request_Trait;
+			}
+			: $this->getMockForAbstractClass( SV_WC_API_JSON_Request::class );
+	}
+
+	/**
+	 * Gets a test request instance using the CacheableRequestTrait.
+	 */
+	protected function get_new_api_instance() {
+		$api = $this->getMockForAbstractClass( Abstract_Cacheable_API_Base::class );
+
+		$api->method('get_plugin')->willReturn( sv_wc_test_plugin() );
+
+		return $api;
+	}
+}
+

--- a/tests/integration/API/CacheableAPIBaseTest.php
+++ b/tests/integration/API/CacheableAPIBaseTest.php
@@ -14,7 +14,7 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
-	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::format_percentage()}.
+	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::is_request_cacheable()}.
 	 *
 	 * @dataProvider provider_is_request_cacheable
 	 *
@@ -40,7 +40,10 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 				}, 10, 2 );
 		}
 
-		$this->assertEquals( $expected, $api->is_request_cacheable() );
+		$method = new ReflectionMethod( get_class( $api ), 'is_request_cacheable' );
+		$method->setAccessible( true );
+
+		$this->assertEquals( $expected, $method->invoke( $api ) );
 	}
 
 	/**

--- a/tests/integration/API/CacheableAPIBaseTest.php
+++ b/tests/integration/API/CacheableAPIBaseTest.php
@@ -68,6 +68,51 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 
 
 	/**
+	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::handle_response()}.
+	 *
+	 * @dataProvider provider_handle_response
+	 *
+	 * @param bool $is_cacheable
+	 * @param bool|null $loaded_from_cache
+	 * @param bool $should_save_response_to_cache
+	 * @throws ReflectionException
+	 */
+	public function test_handle_response( bool $is_cacheable, bool $loaded_from_cache = false, bool $should_save_response_to_cache = false ) {
+
+		$api     = $this->get_new_api_instance(['is_response_loaded_from_cache', 'get_response_handler', 'save_response_to_cache']);
+		$request = $this->get_new_request_instance( $is_cacheable );
+
+		$api->method('get_response_handler')->willReturn( new stdClass );
+		$api->method('is_response_loaded_from_cache')->willReturn( $loaded_from_cache );
+
+		$property = new ReflectionProperty( get_class( $api ), 'request' );
+		$property->setAccessible( true );
+		$property->setValue( $api, $request );
+
+		$method = new ReflectionMethod( get_class( $api ), 'handle_response' );
+		$method->setAccessible( true );
+
+		$api->expects( $should_save_response_to_cache ? $this->once() : $this->never() )->method( 'save_response_to_cache' );
+
+		$method->invoke( $api, [] );
+	}
+
+
+	/**
+	 * Data provider for {@see CacheableAPIBaseTest::test_handle_response()}.
+	 *
+	 * @return array[]
+	 */
+	public function provider_handle_response() : array {
+		return [
+			'cacheable, response loaded from cache'          => [true, true, false],
+			'cacheable, response not loaded from cache'      => [true, false, true],
+			'non-cacheable'                                  => [false, false, false],
+		];
+	}
+
+
+	/**
 	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::load_response_from_cache()}.
 	 * @throws ReflectionException
 	 */

--- a/tests/integration/API/CacheableAPIBaseTest.php
+++ b/tests/integration/API/CacheableAPIBaseTest.php
@@ -13,6 +13,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
+	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::reset_response()}.
+	 * @throws ReflectionException
+	 */
+	public function test_reset_response() {
+
+		$api = $this->get_new_api_instance();
+
+		$property = new ReflectionProperty( get_class( $api ), 'response_loaded_from_cache' );
+		$property->setAccessible( true );
+
+		$this->assertFalse( $property->getValue( $api ) );
+
+		$property->setValue( $api, true );
+
+		$this->assertTrue( $property->getValue( $api ) );
+
+		$method = new ReflectionMethod( get_class( $api ), 'reset_response' );
+		$method->setAccessible( true );
+		$method->invoke( $api );
+
+		$this->assertFalse( $property->getValue( $api ) );
+	}
+
+
+	/**
 	 * Tests {@see Framework\API\Abstract_Cacheable_API_Base::get_request_transient_key()}.
 	 *
 	 * @dataProvider provider_get_request_transient_key
@@ -23,6 +48,7 @@ class CacheableAPIBaseTest extends \Codeception\TestCase\WPTestCase {
 	 * @throws ReflectionException
 	 */
 	public function test_get_request_transient_key( string $uri, string $body, int $lifetime ) {
+
 		$api = $this->get_new_api_instance(['get_request_uri', 'get_request_body']);
 		$request = $this->get_new_request_instance()->set_cache_lifetime( $lifetime );
 

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -219,7 +219,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	 */
 	protected function save_response_to_cache( array $response ) {
 
-		set_transient( $this->get_request_transient_key(), $response, $this->get_request_cache_lifetime());
+		set_transient( $this->get_request_transient_key(), $response, $this->get_request_cache_lifetime() );
 	}
 
 

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -22,13 +22,14 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_10_10;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_10_10\API;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\SV_WC_API_Base;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Traits\Cacheable_Request_Trait;
 
 defined( 'ABSPATH' ) or exit;
 
-if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_10_10\\Abstract_Cacheable_API_Base' ) ) :
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_10_10\\API\\Abstract_Cacheable_API_Base' ) ) :
 
 
 /**
@@ -134,7 +135,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	 *
 	 * @return bool
 	 */
-	protected function is_request_cacheable() : bool {
+	public function is_request_cacheable() : bool {
 
 		if ( ! in_array( Cacheable_Request_Trait::class, class_uses( $this->get_request() ), true ) ) {
 			return false;

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -192,6 +192,28 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	 *
 	 * @return array
 	 */
+	protected function get_request_data_for_broadcast() : array {
+
+		$request_data = parent::get_request_data_for_broadcast();
+
+		if ( $this->is_request_cacheable() ) {
+			$request_data['force_refresh'] = $this->get_request()->should_refresh();
+			$request_data['should_cache']  = $this->get_request()->should_cache();
+		}
+
+		return $request_data;
+	}
+
+
+	/**
+	 * Gets the response data for broadcasting the request.
+	 *
+	 * Adds a flag to the response data indicating whether the response was loaded from cache.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return array
+	 */
 	protected function get_response_data_for_broadcast() : array {
 
 		$response_data = parent::get_response_data_for_broadcast();

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -135,7 +135,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	 *
 	 * @return bool
 	 */
-	public function is_request_cacheable() : bool {
+	protected function is_request_cacheable() : bool {
 
 		if ( ! in_array( Cacheable_Request_Trait::class, class_uses( $this->get_request() ), true ) ) {
 			return false;

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -1,9 +1,44 @@
 <?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/API
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2021, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_10_10;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Cacheable_Request_Trait;
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Traits\Cacheable_Request_Trait;
 
+defined( 'ABSPATH' ) or exit;
+
+if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_10_10\\Abstract_Cacheable_API_Base' ) ) :
+
+
+/**
+ * Abstract API base class with caching support.
+ *
+ * Plugins which need to use API request caching should use extend this API base class rather than SV_WC_API_Base.
+ * In addition, each request class which needs caching, should use the Cacheable_Request_Trait.
+ *
+ * @since 5.10.10
+ */
 abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 {
 
@@ -39,7 +74,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	/**
 	 * Handle and parse the response
 	 *
-	 * @since 2.2.0
+	 * @since 5.10.10
 	 *
 	 * @param array|\WP_Error $response response data
 	 * @throws SV_WC_API_Exception network issues, timeouts, API errors, etc
@@ -62,7 +97,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	/**
 	 * Resets the API response members to their default values.
 	 *
-	 * @since 1.0.0
+	 * @since 5.10.10
 	 */
 	protected function reset_response() {
 
@@ -230,3 +265,6 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	}
 
 }
+
+
+endif;

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -183,4 +183,24 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	}
 
 
+	/**
+	 * Gets the response data for broadcasting the request.
+	 *
+	 * Adds a flag to the response data indicating whether the response was loaded from cache.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return array
+	 */
+	protected function get_response_data_for_broadcast() : array {
+
+		$response_data = parent::get_response_data_for_broadcast();
+
+		if ( $this->is_request_cacheable() ) {
+			$response_data['from_cache'] = $this->is_response_loaded_from_cache();
+		}
+
+		return $response_data;
+	}
+
 }

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_10_10;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\CacheableRequestTrait;
+
+abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
+{
+
+
+	/** @var bool whether the response was loaded from cache */
+	protected $response_loaded_from_cache = false;
+
+
+	/**
+	 * Simple wrapper for wp_remote_request() so child classes can override this
+	 * and provide their own transport mechanism if needed, e.g. a custom
+	 * cURL implementation
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string $request_uri
+	 * @param string $request_args
+	 * @return array|\WP_Error
+	 */
+	protected function do_remote_request( $request_uri, $request_args ) {
+
+		if ( $this->is_request_cacheable() && ! $this->get_request()->should_refresh() && $response = $this->load_response_from_cache() ) {
+
+			$this->response_loaded_from_cache = true;
+
+			return $response;
+		}
+
+		return parent::do_remote_request( $request_uri, $request_args );
+	}
+
+
+	/**
+	 * Handle and parse the response
+	 *
+	 * @since 2.2.0
+	 * @param array|\WP_Error $response response data
+	 * @throws SV_WC_API_Exception network issues, timeouts, API errors, etc
+	 * @return SV_WC_API_Request|object request class instance that implements SV_WC_API_Request
+	 */
+	protected function handle_response( $response ) {
+
+		parent::handle_response( $response );
+
+		// cache the response
+		if ( ! $this->is_response_loaded_from_cache() && $this->is_request_cacheable() ) {
+
+			$this->save_response_to_cache( $response );
+		}
+
+		return $this->response; // this param is set by the parent method
+	}
+
+
+	/**
+	 * Reset the API response members to their
+	 *
+	 * @since 1.0.0
+	 */
+	protected function reset_response() {
+
+		$this->response_loaded_from_cache = false;
+
+		parent::reset_response();
+	}
+
+
+	/**
+	 * Gets the request transient key for the current plugin and request data.
+	 *
+	 * Request transients can be disabled by using the filter below.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return string transient key
+	 */
+	protected function get_request_transient_key() : string {
+
+		// ex: wc_<plugin_id>_<md5 hash of request uri, request data and cache lifetime>
+		return sprintf( 'wc_%s_api_response_%s', $this->get_plugin()->get_id(), md5( implode( '_', [
+			$this->get_request_uri(),
+			$this->get_request_body(),
+			$this->get_request_cache_lifetime(),
+		] ) ) );
+	}
+
+
+	/**
+	 * Checks whether the current request is cacheable.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return bool
+	 */
+	protected function is_request_cacheable() : bool {
+
+		if ( ! in_array( CacheableRequestTrait::class, class_uses( $this->get_request() ), true ) ) {
+			return false;
+		}
+
+		/**
+		 * Filters whether the API request is cacheable.
+		 *
+		 * Allows actors to disable API request caching when a request is normally cacheable. This may be useful
+		 * primarily for debugging situations.
+		 *
+		 * Note: this filter is only applied if the request is originally cacheable, in order to prevent issues when
+		 * a non-cacheable request is accidentally flagged as cacheable.
+		 *
+		 * @since 5.10.10
+		 * @param bool $is_cacheable whether the request is cacheable
+		 * @param SV_WC_API_Request $request the request instance
+		 */
+		return (bool) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_is_cacheable', true, $this->get_request() );
+	}
+
+
+	/**
+	 * Gets the cache lifetime for the current request.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return int
+	 */
+	protected function get_request_cache_lifetime() : int {
+
+		/**
+		 * Filters API request cache lifetime.
+		 *
+		 * Allows actors to override cache lifetime for cacheable API requests. This may be useful for debugging
+		 * API requests by temporarily setting short cache timeouts.
+		 *
+		 * @since 5.10.10
+		 * @param int $lifetime cache lifetime in seconds, 0 = unlimited
+		 * @param SV_WC_API_Request $request the request instance
+		 */
+		return (int) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_cache_lifetime' , $this->get_request()->get_cache_lifetime(), $this->get_request() );
+	}
+
+
+
+	/**
+	 * Determine whether the response was loaded from cache or not.
+	 *
+	 * @since 5.10.10
+	 * @return bool
+	 */
+	protected function is_response_loaded_from_cache() : bool {
+
+		return $this->response_loaded_from_cache;
+	}
+
+
+	/**
+	 * Loads the response for the current request from the cache, if available.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return array|null
+	 */
+	protected function load_response_from_cache() {
+
+		return get_transient( $this->get_request_transient_key() );
+	}
+
+
+	/**
+	 * Saves the response to cache.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @param array $response
+	 */
+	protected function save_response_to_cache( array $response ) {
+
+		set_transient( $this->get_request_transient_key(), $response, $this->get_request_cache_lifetime());
+	}
+
+
+}

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -236,8 +236,10 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 		$request_data = parent::get_request_data_for_broadcast();
 
 		if ( $this->is_request_cacheable() ) {
-			$request_data['force_refresh'] = $this->get_request()->should_refresh();
-			$request_data['should_cache']  = $this->get_request()->should_cache();
+			$request_data = [
+				'force_refresh' => $this->get_request()->should_refresh(),
+				'should_cache'  => $this->get_request()->should_cache(),
+			] + $request_data;
 		}
 
 		return $request_data;
@@ -258,7 +260,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 		$response_data = parent::get_response_data_for_broadcast();
 
 		if ( $this->is_request_cacheable() ) {
-			$response_data['from_cache'] = $this->is_response_loaded_from_cache();
+			$response_data = [ 'from_cache' => $this->is_response_loaded_from_cache() ] + $response_data;
 		}
 
 		return $response_data;

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -2,7 +2,7 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_10_10;
 
-use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\CacheableRequestTrait;
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\Cacheable_Request_Trait;
 
 abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 {
@@ -100,7 +100,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 	 */
 	protected function is_request_cacheable() : bool {
 
-		if ( ! in_array( CacheableRequestTrait::class, class_uses( $this->get_request() ), true ) ) {
+		if ( ! in_array( Cacheable_Request_Trait::class, class_uses( $this->get_request() ), true ) ) {
 			return false;
 		}
 

--- a/woocommerce/api/CacheableRequestTrait.php
+++ b/woocommerce/api/CacheableRequestTrait.php
@@ -39,7 +39,7 @@ trait CacheableRequestTrait {
 	 * @since 5.10.10
 	 *
 	 * @param int $lifetime cache lifetime, in seconds
-	 * @return $this
+	 * @return CacheableRequestTrait $this
 	 */
 	public function set_cache_lifetime( int $lifetime ) {
 
@@ -68,7 +68,7 @@ trait CacheableRequestTrait {
 	 * @since 5.10.10
 	 *
 	 * @param bool $force whether to force a fresh request, or not
-	 * @return $this
+	 * @return CacheableRequestTrait $this
 	 */
 	public function set_force_refresh( bool $force ) {
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -582,10 +582,11 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function get_request_transient_key() : string {
 
-		// ex: wc_<plugin_id>_<md5 hash of request uri and request data>
+		// ex: wc_<plugin_id>_<md5 hash of request uri, request data and cache lifetime>
 		return sprintf( 'wc_%s_api_response_%s', $this->get_plugin()->get_id(), md5( implode( '_', [
 			$this->get_request_uri(),
-			$this->get_request_body()
+			$this->get_request_body(),
+			$this->get_request_cache_lifetime(),
 		] ) ) );
 	}
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -583,26 +583,10 @@ abstract class SV_WC_API_Base {
 	protected function get_request_transient_key() : string {
 
 		// ex: wc_sv_requests_<md5 hash of plugin_id and request data>
-		$key = sprintf( 'wc_sv_requests_%s', md5( implode( '_', [
+		return sprintf( 'wc_sv_requests_%s', md5( implode( '_', [
 			$this->get_plugin()->get_id(),
 			$this->request->to_string(),
 		] ) ) );
-
-		/**
-		 * Filters API request transient key.
-		 *
-		 * Warning: this filter should generally only be used to disable API request
-		 * transients by returning false or an empty string. Setting an incorrect or invalid
-		 * transient key (e.g. not keyed to the current plugin or request) can
-		 * result in unexpected and difficult to debug situations.
-		 *
-		 * Filter responsibly!
-		 *
-		 * @since 5.10.10
-		 * @param string $key transient key (must be 45 chars or less)
-		 * @param SV_WC_API_Request $request the request instance
-		 */
-		return apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_transient_key', $key, $this->request );
 	}
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -103,7 +103,7 @@ abstract class SV_WC_API_Base {
 
 		$start_time = microtime( true );
 
-		if ( $this->is_request_cacheable() && ! $this->request->should_refresh() && $response = $this->load_response_from_cache() ) {
+		if ( $this->is_request_cacheable() && ! $this->get_request()->should_refresh() && $response = $this->load_response_from_cache() ) {
 
 			$this->response_loaded_from_cache = true;
 
@@ -585,7 +585,7 @@ abstract class SV_WC_API_Base {
 		// ex: wc_sv_requests_<md5 hash of plugin_id and request data>
 		return sprintf( 'wc_sv_requests_%s', md5( implode( '_', [
 			$this->get_plugin()->get_id(),
-			$this->request->to_string(),
+			$this->get_request()->to_string(),
 		] ) ) );
 	}
 
@@ -599,7 +599,7 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function is_request_cacheable() : bool {
 
-		if ( ! in_array( CacheableRequestTrait::class, class_uses( $this->request ), true ) ) {
+		if ( ! in_array( CacheableRequestTrait::class, class_uses( $this->get_request() ), true ) ) {
 			return false;
 		}
 
@@ -616,7 +616,7 @@ abstract class SV_WC_API_Base {
 		 * @param bool $is_cacheable whether the request is cacheable
 		 * @param SV_WC_API_Request $request the request instance
 		 */
-		return (bool) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_is_cacheable', true, $this->request );
+		return (bool) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_is_cacheable', true, $this->get_request() );
 	}
 
 
@@ -639,7 +639,7 @@ abstract class SV_WC_API_Base {
 		 * @param int $lifetime cache lifetime in seconds, 0 = unlimited
 		 * @param SV_WC_API_Request $request the request instance
 		 */
-		return (int) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_cache_lifetime' , $this->request->get_cache_lifetime(), $this->request );
+		return (int) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_cache_lifetime' , $this->get_request()->get_cache_lifetime(), $this->get_request() );
 	}
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -880,6 +880,32 @@ abstract class SV_WC_API_Base {
 	}
 
 
+	/**
+	 * Loads the response for the current request from the cache, if available.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return array|null
+	 */
+	protected function load_response_from_cache() {
+
+		return get_transient( $this->get_request_transient_key() );
+	}
+
+
+	/**
+	 * Saves the response to cache.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @param array $response
+	 */
+	protected function save_response_to_cache( array $response ) {
+
+		set_transient( $this->get_request_transient_key(), $response, $this->request->get_cache_lifetime() );
+	}
+
+
 }
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -252,31 +252,16 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function broadcast_request() {
 
-		$request_data = array(
-			'method'     => $this->get_request_method(),
-			'uri'        => $this->get_request_uri(),
-			'user-agent' => $this->get_request_user_agent(),
-			'headers'    => $this->get_sanitized_request_headers(),
-			'body'       => $this->get_sanitized_request_body(),
-			'duration'   => $this->get_request_duration() . 's', // seconds
-		);
-
-		$response_data = array(
-			'code'    => $this->get_response_code(),
-			'message' => $this->get_response_message(),
-			'headers' => $this->get_response_headers(),
-			'body'    => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
-		);
-
-		if ( $this->is_request_cacheable() ) {
-			$response_data['from_cache'] = $this->is_response_loaded_from_cache();
-		}
+		$request_data  = $this->get_request_data_for_broadcast();
+		$response_data = $this->get_response_data_for_broadcast();
 
 		/**
 		 * API Base Request Performed Action.
 		 *
 		 * Fired when an API request is performed via this base class. Plugins can
 		 * hook into this to log request/response data.
+		 *
+		 * Note: request and response data arrays may contain additional, undocumented keys provided by the implementing plugin.
 		 *
 		 * @since 2.2.0
 		 * @param array $request_data {
@@ -292,7 +277,6 @@ abstract class SV_WC_API_Base {
 		 *     @type string $message response message
 		 *     @type string $headers response HTTP headers
 		 *     @type string $body response body
-		 *     @type bool $from_cache whether the response was loaded from cache or not - only provided if the request supports caching
 		 * }
 		 * @param SV_WC_API_Base $this instance
 		 */
@@ -552,6 +536,28 @@ abstract class SV_WC_API_Base {
 	}
 
 
+	/**
+	 * Gets the request data for broadcasting the request.
+	 *
+	 * Overriding this method allows child classes to customize the request data when broadcasting the request.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return array
+	 */
+	protected function get_request_data_for_broadcast() : array {
+
+		return [
+			'method'     => $this->get_request_method(),
+			'uri'        => $this->get_request_uri(),
+			'user-agent' => $this->get_request_user_agent(),
+			'headers'    => $this->get_sanitized_request_headers(),
+			'body'       => $this->get_sanitized_request_body(),
+			'duration'   => $this->get_request_duration() . 's', // seconds
+		];
+	}
+
+
 	/** Response Getters ******************************************************/
 
 
@@ -619,6 +625,27 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function get_sanitized_response_body() {
 		return is_callable( array( $this->get_response(), 'to_string_safe' ) ) ? $this->get_response()->to_string_safe() : null;
+	}
+
+
+	/**
+	 * Gets the response data for broadcasting the request.
+	 *
+	 * Overriding this method allows child classes to customize the response data when broadcasting the request.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return array
+	 * @return array
+	 */
+	protected function get_response_data_for_broadcast() : array
+	{
+		return [
+			'code'    => $this->get_response_code(),
+			'message' => $this->get_response_message(),
+			'headers' => $this->get_response_headers(),
+			'body'    => $this->get_sanitized_response_body() ?: $this->get_raw_response_body(),
+		];
 	}
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -582,11 +582,10 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function get_request_transient_key() : string {
 
-		// ex: wc_sv_requests_<md5 hash of plugin_id, request uri and request data>
-		return sprintf( 'wc_sv_requests_%s', md5( implode( '_', [
-			$this->get_plugin()->get_id(),
+		// ex: wc_<plugin_id>_<md5 hash of request uri and request data>
+		return sprintf( 'wc_%s_api_response_%s', $this->get_plugin()->get_id(), md5( implode( '_', [
 			$this->get_request_uri(),
-			$this->get_request_body(),
+			$this->get_request_body()
 		] ) ) );
 	}
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -583,6 +583,19 @@ abstract class SV_WC_API_Base {
 	}
 
 
+	/**
+	 * Checks whether the current request is cacheable.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return bool
+	 */
+	protected function is_request_cacheable() : bool {
+
+		return in_array( CacheableRequestTrait::class, class_uses( $this->request ), true) ;
+	}
+
+
 	/** Response Getters ******************************************************/
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -81,6 +81,8 @@ abstract class SV_WC_API_Base {
 	/** @var SV_WC_API_Response|object response */
 	protected $response;
 
+	/** @var bool whether the response was loaded from cache */
+	protected $response_loaded_from_cache = false;
 
 	/**
 	 * Perform the request and return the parsed response
@@ -265,10 +267,11 @@ abstract class SV_WC_API_Base {
 		);
 
 		$response_data = array(
-			'code'    => $this->get_response_code(),
-			'message' => $this->get_response_message(),
-			'headers' => $this->get_response_headers(),
-			'body'    => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
+			'code'       => $this->get_response_code(),
+			'message'    => $this->get_response_message(),
+			'headers'    => $this->get_response_headers(),
+			'body'       => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
+			'from_cache' => $this->is_response_loaded_from_cache(),
 		);
 
 		/**
@@ -291,6 +294,7 @@ abstract class SV_WC_API_Base {
 		 *     @type string $message response message
 		 *     @type string $headers response HTTP headers
 		 *     @type string $body response body
+		 *     @type bool $from_cache whether the response was loaded from cache or not
 		 * }
 		 * @param SV_WC_API_Base $this instance
 		 */
@@ -305,12 +309,13 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function reset_response() {
 
-		$this->response_code     = null;
-		$this->response_message  = null;
-		$this->response_headers  = null;
-		$this->raw_response_body = null;
-		$this->response          = null;
-		$this->request_duration  = null;
+		$this->response_code              = null;
+		$this->response_message           = null;
+		$this->response_headers           = null;
+		$this->raw_response_body          = null;
+		$this->response                   = null;
+		$this->request_duration           = null;
+		$this->response_loaded_from_cache = false;
 	}
 
 
@@ -665,6 +670,17 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function get_sanitized_response_body() {
 		return is_callable( array( $this->get_response(), 'to_string_safe' ) ) ? $this->get_response()->to_string_safe() : null;
+	}
+
+
+	/**
+	 * Determine whether the response was loaded from cache or not.
+	 *
+	 * @since 5.10.10
+	 * @return bool
+	 */
+	protected function is_response_loaded_from_cache() : bool {
+		return $this->response_loaded_from_cache;
 	}
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -548,6 +548,41 @@ abstract class SV_WC_API_Base {
 	}
 
 
+	/**
+	 * Gets the request transient key for the current plugin and request data.
+	 *
+	 * Request transients can be disabled by using the filter below.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return string transient key
+	 */
+	protected function get_request_transient_key() : string {
+
+		// ex: wc_sv_requests_<md5 hash of plugin_id and request data>
+		$key = sprintf( 'wc_sv_requests_%s', md5( implode( '_', [
+			$this->get_plugin()->get_id(),
+			$this->request->to_string(),
+		] ) ) );
+
+		/**
+		 * Filters API request transient key.
+		 *
+		 * Warning: this filter should generally only be used to disable API request
+		 * transients by returning false or an empty string. Setting an incorrect or invalid
+		 * transient key (e.g. not keyed to the current plugin or request) can
+		 * result in unexpected and difficult to debug situations.
+		 *
+		 * Filter responsibly!
+		 *
+		 * @since 5.10.10
+		 * @param string $key transient key (must be 45 chars or less)
+		 * @param SV_WC_API_Request $request the request instance
+		 */
+		return apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_transient_key', $key, $this->request );
+	}
+
+
 	/** Response Getters ******************************************************/
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -280,10 +280,10 @@ abstract class SV_WC_API_Base {
 		);
 
 		$response_data = array(
-			'code'       => $this->get_response_code(),
-			'message'    => $this->get_response_message(),
-			'headers'    => $this->get_response_headers(),
-			'body'       => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
+			'code'    => $this->get_response_code(),
+			'message' => $this->get_response_message(),
+			'headers' => $this->get_response_headers(),
+			'body'    => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
 		);
 
 		if ( $this->is_request_cacheable() ) {

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -582,10 +582,11 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function get_request_transient_key() : string {
 
-		// ex: wc_sv_requests_<md5 hash of plugin_id and request data>
+		// ex: wc_sv_requests_<md5 hash of plugin_id, request uri and request data>
 		return sprintf( 'wc_sv_requests_%s', md5( implode( '_', [
 			$this->get_plugin()->get_id(),
-			$this->get_request()->to_string(),
+			$this->get_request_uri(),
+			$this->get_request_body(),
 		] ) ) );
 	}
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -615,7 +615,24 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function is_request_cacheable() : bool {
 
-		return in_array( CacheableRequestTrait::class, class_uses( $this->request ), true) ;
+		if ( ! in_array( CacheableRequestTrait::class, class_uses( $this->request ), true ) ) {
+			return false;
+		}
+
+		/**
+		 * Filters whether the API request is cacheable.
+		 *
+		 * Allows actors to disable API request caching when a request is normally cacheable. This may be useful
+		 * primarily for debugging situations.
+		 *
+		 * Note: this filter is only applied if the request is originally cacheable, in order to prevent issues when
+		 * a non-cacheable request is accidentally flagged as cacheable.
+		 *
+		 * @since 5.10.10
+		 * @param bool $is_cacheable whether the request is cacheable
+		 * @param SV_WC_API_Request $request the request instance
+		 */
+		return (bool) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_is_cacheable', true, $this->request );
 	}
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -291,12 +291,12 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function reset_response() {
 
-		$this->response_code              = null;
-		$this->response_message           = null;
-		$this->response_headers           = null;
-		$this->raw_response_body          = null;
-		$this->response                   = null;
-		$this->request_duration           = null;
+		$this->response_code     = null;
+		$this->response_message  = null;
+		$this->response_headers  = null;
+		$this->raw_response_body = null;
+		$this->response          = null;
+		$this->request_duration  = null;
 	}
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -24,6 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_10_10;
 
+use SkyVerge\WooCommerce\PluginFramework\v5_10_10\API\CacheableRequestTrait;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_10_10\\SV_WC_API_Base' ) ) :

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -619,6 +619,29 @@ abstract class SV_WC_API_Base {
 	}
 
 
+	/**
+	 * Gets the cache lifetime for the current request.
+	 *
+	 * @since 5.10.10
+	 *
+	 * @return int
+	 */
+	protected function get_request_cache_lifetime() : int {
+
+		/**
+		 * Filters API request cache lifetime.
+		 *
+		 * Allows actors to override cache lifetime for cacheable API requests. This may be useful for debugging
+		 * API requests by temporarily setting short cache timeouts.
+		 *
+		 * @since 5.10.10
+		 * @param int $lifetime cache lifetime in seconds, 0 = unlimited
+		 * @param SV_WC_API_Request $request the request instance
+		 */
+		return (int) apply_filters( 'wc_plugin_' . $this->get_plugin()->get_id() . '_api_request_cache_lifetime' , $this->request->get_cache_lifetime(), $this->request );
+	}
+
+
 	/** Response Getters ******************************************************/
 
 
@@ -934,7 +957,7 @@ abstract class SV_WC_API_Base {
 	 */
 	protected function save_response_to_cache( array $response ) {
 
-		set_transient( $this->get_request_transient_key(), $response, $this->request->get_cache_lifetime() );
+		set_transient( $this->get_request_transient_key(), $response, $this->get_request_cache_lifetime());
 	}
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -284,8 +284,11 @@ abstract class SV_WC_API_Base {
 			'message'    => $this->get_response_message(),
 			'headers'    => $this->get_response_headers(),
 			'body'       => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
-			'from_cache' => $this->is_response_loaded_from_cache(),
 		);
+
+		if ( $this->is_request_cacheable() ) {
+			$response_data['from_cache'] = $this->is_response_loaded_from_cache();
+		}
 
 		/**
 		 * API Base Request Performed Action.
@@ -307,7 +310,7 @@ abstract class SV_WC_API_Base {
 		 *     @type string $message response message
 		 *     @type string $headers response HTTP headers
 		 *     @type string $body response body
-		 *     @type bool $from_cache whether the response was loaded from cache or not
+		 *     @type bool $from_cache whether the response was loaded from cache or not - only provided if the request supports caching
 		 * }
 		 * @param SV_WC_API_Base $this instance
 		 */

--- a/woocommerce/api/traits/Cacheable_Request_Trait.php
+++ b/woocommerce/api/traits/Cacheable_Request_Trait.php
@@ -32,10 +32,10 @@ if ( ! trait_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_10_10\\API\\T
  * This trait can be used to add response caching support to API requests.
  *
  * It is intended to be used by a class implementing the SV_WC_API_Request interface. Caching itself is handled
- * by the SV_WC_API_Base class in the perform_request method.
+ * by the Abstract_Cacheable_API_Base class, which the API handler should abstract in order to support caching.
  *
- * Simply adding `use Cacheable_Request_Trait;` to a request class will enable caching, but it's also possible to
- * customize the cache lifetime by setting it in the request constructor.
+ * Adding `use Cacheable_Request_Trait;` to a request class will declare caching support for that request class.
+ * It's also possible to customize the cache lifetime by setting it in the request constructor.
  */
 trait Cacheable_Request_Trait {
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -725,7 +725,14 @@ abstract class SV_WC_Plugin {
 		$messages[] = isset( $data['uri'] ) && $data['uri'] ? 'Request' : 'Response';
 
 		foreach ( (array) $data as $key => $value ) {
-			$messages[] = trim( sprintf( '%s: %s', $key, is_array( $value ) || ( is_object( $value ) && 'stdClass' == get_class( $value ) ) ? print_r( (array) $value, true ) : $value ) );
+
+			if ( is_array( $value ) || ( is_object( $value ) && 'stdClass' == get_class( $value ) ) ) {
+				$value = print_r( (array) $value, true );
+			} else if ( is_bool( $value ) ) {
+				$value = wc_bool_to_string( $value );
+			}
+
+			$messages[] = trim( sprintf( '%s: %s', $key, $value ) );
 		}
 
 		return implode( "\n", $messages ) . "\n";

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -451,8 +451,9 @@ abstract class SV_WC_Plugin {
 		require_once( $framework_path . '/api/abstract-sv-wc-api-json-request.php' );
 		require_once( $framework_path . '/api/abstract-sv-wc-api-json-response.php' );
 
-		// Cacheable API Requests
+		// Cacheable API
 		require_once( $framework_path . '/api/Cacheable_Request_Trait.php' );
+		require_once( $framework_path . '/api/Abstract_Cacheable_API_Base.php' );
 
 		// REST API Controllers
 		require_once( $framework_path . '/rest-api/Controllers/Settings.php' );

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -726,9 +726,9 @@ abstract class SV_WC_Plugin {
 
 		foreach ( (array) $data as $key => $value ) {
 
-			if ( is_array( $value ) || ( is_object( $value ) && 'stdClass' == get_class( $value ) ) ) {
+			if ( is_array( $value ) || ( is_object( $value ) && 'stdClass' === get_class( $value ) ) ) {
 				$value = print_r( (array) $value, true );
-			} else if ( is_bool( $value ) ) {
+			} elseif ( is_bool( $value ) ) {
 				$value = wc_bool_to_string( $value );
 			}
 


### PR DESCRIPTION
## Summary

This PR adds request/response caching support to the API base class in a transparent manner. This allows caching requests on a per-request basis. Meaning, if a request class declares support for caching, it's also possible to disable request caching for a concrete request by setting using the `$request->set_force_refresh( true )` setter, before performing the request.

### Story: [MWC-2478](https://jira.godaddy.com/browse/MWC-2478)

## Details

Originally, I had anticipated that the `CacheableRequestTrait` would be responsible for generating the transient (cache) key for the request. However, as the request instance does not have access to the plugin instance, I decided that the transient key should be generated in the `SV_WC_API_Base` class instead.

On a related note - I also did not add a way to filter or override the params which are used to generate the transient key at the moment. I could not think of an immediate use-case for this. Also, it allowed to keep the implementation much simpler for now, since we're just building the key base don the request URI and body. However, I'm open to suggestions.

The overall caching implementation is such that it should not affect any existing plugins in any way. Caching is completely opt-in. 

The raw response is stored in the cache, as this allows normal response handling and broadcasting. However, the raw response will only be stored after it's been successfully parsed. This will prevent storing the response if the request failed or if there was a parsing error. Consequently, it will also protect from corrupted transients, as the response handler will fail with an error, if the cached response data is broken.

Note that a `response_loaded_from_cache` flag is stored on the API instance, which should help debugging.

## Example Usage

```php

class ExchangeRatesRequest extends SV_WC_API_JSON_Request {

    use CacheableRequestTrait;

    public function __construct() {
        $this->cache_lifetime = 600; // override the deafult cache lifetime
    }

    // ...

}

class ExchangeRateAPI extends SV_WC_API_Base {

    public function get_currencies( $refresh = false )
    {
        $request = new ExchangeRatesRequest();

        if ( $refresh ) {
            $request->set_force_refresh( true );
        }

        $this->perform_request( $request );
    }

    // ..
}

$api = new ExchangeRateAPI();

$api->get_currencies(); // this should be a fresh request, the response will be cached
$api->get_currencies(); // this should use the cached response
$api->get_currencies( true ); // this should be a fresh request again, the response will be cached

// override cache timeout on runtime:
$request->set_cache_lifetime( 60 ); // note - this won't invalidate a previous cache with a longer lifetime - should it?

```

### Code style considerations

See my comments in #552

## Open questions

- [x] Should changing the cache lifetime invalidate any previously cached responses? Ie, should the lifetime be part of the cache key MD5 hash?

## QA

- [x] Review and merge #552 first
- [x] Change the base branch to `release/5.10.10`
- [x] Code review
- [x] Unit & integration tests pass `vendor/bin/codecept run unit && vendor/bin/codecept run integration`

Note: it probably makes sense to review this in tandem with https://github.com/gdcorp-partners/woocommerce-avatax/pull/74 as it helps to validate the functionality and ensure code is working as expected (we don't have tests for the API base class 😬 )