### PR TITLE
Replace is_ajax calls with wp_doing_ajax

### DIFF
--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -83,7 +83,7 @@ class Lifecycle {
 		// handle deactivation
 		add_action( 'deactivate_' . $this->get_plugin()->get_plugin_file(), array( $this, 'handle_deactivation' ) );
 
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 
 			// initialize the plugin lifecycle
 			add_action( 'wp_loaded', array( $this, 'init' ) );

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2022.nn.nn - version 5.10.12
+ * Fix - Remove deprecated usages of `is_ajax()` in favor of `wp_doing_ajax()`
 
 2022.01.11 - version 5.10.11
  * Tweak - Remove automatic notices for unsupported WooCommerce versions

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -1089,7 +1089,7 @@ class SV_WC_Helper {
 	 */
 	public static function trigger_error( $message, $type = E_USER_NOTICE ) {
 
-		if ( is_callable( 'is_ajax' ) && is_ajax() ) {
+		if ( is_callable( 'wp_doing_ajax' ) && wp_doing_ajax() ) {
 
 			switch ( $type ) {
 

--- a/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
+++ b/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
@@ -71,7 +71,7 @@ abstract class External_Checkout {
 	 */
 	protected function init() {
 
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			$this->init_admin();
 		} elseif ( $this->get_processing_gateway() && $this->get_plugin()->get_id() === $this->get_processing_gateway()->get_plugin()->get_id() ) {
 			$this->init_ajax();

--- a/woocommerce/payment-gateway/External_Checkout/Frontend.php
+++ b/woocommerce/payment-gateway/External_Checkout/Frontend.php
@@ -102,7 +102,7 @@ abstract class Frontend extends Script_Handler {
 		}
 
 		$locations    = $this->get_handler()->get_display_locations();
-		$is_cart_ajax = is_ajax() && 'update_shipping_method' === SV_WC_Helper::get_requested_value( 'wc-ajax' );
+		$is_cart_ajax = wp_doing_ajax() && 'update_shipping_method' === SV_WC_Helper::get_requested_value( 'wc-ajax' );
 
 		if ( is_product() && in_array( 'product', $locations, true ) ) {
 			$this->init_product();

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -370,7 +370,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	public function maybe_init_my_payment_methods() {
 
 		// bail if not frontend or an AJAX request
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			return;
 		}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -663,7 +663,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		}
 
 		// only load on the frontend and AJAX
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			return;
 		}
 
@@ -3588,7 +3588,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		}
 
 		// add debug message to woocommerce->errors/messages if checkout or both is enabled, the admin/Ajax check ensures capture charge transactions aren't logged as notices to the front end
-		if ( ( $this->debug_checkout() || ( 'error' === $type && $this->is_test_environment() ) ) && ( ! is_admin() || is_ajax() ) ) {
+		if ( ( $this->debug_checkout() || ( 'error' === $type && $this->is_test_environment() ) ) && ( ! is_admin() || wp_doing_ajax() ) ) {
 
 			if ( 'message' === $type ) {
 


### PR DESCRIPTION
## Summary

Replaces instances of `is_ajax()` function calls with `wp_doing_ajax()` as the former has been deprecated in WooCommerce 6.1, while the latter is the indicated replacement being available in WordPress since v4.7.

The FW is also embedded in some MWC packages for native features so we may need this there as well. 

## QA

- [x] Code review
- [x] No other instances of `is_ajax` are found in the framework codebase

## After merge

- Update and deploy #557 