### PR TITLE
Apple Pay: Set order attribution data

### DIFF
--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -198,12 +198,15 @@ class SV_WC_Payment_Gateway_Apple_Pay extends Payment_Gateway\External_Checkout\
 
 	protected function maybeAddAttributionData(\WC_Order $order) : void
 	{
+		$this->log( 'Maybe adding attribution data to order' );
 		$attributionData = SV_WC_Helper::get_posted_value( 'order_attribution' );
 		if ( empty( $attributionData ) ) {
+			$this->log( '-- No attribution data found' );
 			return;
 		}
 
 		if (! class_exists( \Automattic\WooCommerce\Internal\Orders\OrderAttributionController::class )) {
+			$this->log( '-- Order attribution controller not found' );
 			return;
 		}
 
@@ -213,6 +216,7 @@ class SV_WC_Payment_Gateway_Apple_Pay extends Payment_Gateway\External_Checkout\
 			$featureController = $container->get( \Automattic\WooCommerce\Internal\Features\FeaturesController::class );
 
 			if (! $featureController->is_feature_active( 'order_attribution' )) {
+				$this->log( '-- Order attribution feature not active' );
 				return;
 			}
 
@@ -220,8 +224,11 @@ class SV_WC_Payment_Gateway_Apple_Pay extends Payment_Gateway\External_Checkout\
 
 			// bail if the order already has attribution
 			if ($orderAttributionController->has_attribution($order)) {
+				$this->log( '-- Order already has attribution' );
 				return;
 			}
+
+			$this->log( '-- Adding attribution data to order' );
 
 			/**
 			 * Run an action to save order attribution data.

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-apple-pay.coffee
@@ -313,6 +313,8 @@ jQuery ( $ ) ->
 			# Add order attribution data if available
 			if window?.wc_order_attribution
 				data.order_attribution = wc_order_attribution.getAttributionData()
+			else
+				console.log 'No order attribution data found'
 
 			$.post @ajax_url, data, ( response ) =>
 


### PR DESCRIPTION
# Summary

This attempts to set order attribution data when using Apple Pay.

### Story: [MWC-18191](https://godaddy-corp.atlassian.net/browse/MWC-18191)
### Release: X

## Details

No idea if this works, unfortunately.

If we render the Apple Pay button on pages other than checkout then this likely needs changes.

## QA

1. Place an order using Apple Pay.
    - [ ] Order attribution data is set

## Before merge

- [ ] Debug / logging code is removed (revert commit https://github.com/godaddy-wordpress/wc-plugin-framework/commit/aa3637ec69d042b68d273c11755eaa3b55426d77 )
- [ ] I have confirmed these changes in each supported minor WooCommerce version
