### PR TITLE
Apple Pay - validate country against allow list for orders/shipping

### DIFF
--- a/tests/unit/Helpers/CheckoutHelperTest.php
+++ b/tests/unit/Helpers/CheckoutHelperTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace SkyVerge\WooCommerce\PluginFramework\v6_0_1\Tests\unit\Helpers;
+namespace SkyVerge\WooCommerce\PluginFramework\v6_0_2\Tests\unit\Helpers;
 
 use Generator;
 use Mockery;
-use SkyVerge\WooCommerce\PluginFramework\v6_0_1\Helpers\CheckoutHelper;
-use SkyVerge\WooCommerce\PluginFramework\v6_0_1\Tests\TestCase;
+use SkyVerge\WooCommerce\PluginFramework\v6_0_2\Helpers\CheckoutHelper;
+use SkyVerge\WooCommerce\PluginFramework\v6_0_2\Tests\TestCase;
 use WP_Mock;
 
 /**
- * @coversDefaultClass \SkyVerge\WooCommerce\PluginFramework\v6_0_1\Helpers\CheckoutHelper
+ * @coversDefaultClass \SkyVerge\WooCommerce\PluginFramework\v6_0_2\Helpers\CheckoutHelper
  */
 final class CheckoutHelperTest extends TestCase
 {

--- a/woocommerce/Helpers/CheckoutHelper.php
+++ b/woocommerce/Helpers/CheckoutHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SkyVerge\WooCommerce\PluginFramework\v6_0_1\Helpers;
+namespace SkyVerge\WooCommerce\PluginFramework\v6_0_2\Helpers;
 
 class CheckoutHelper
 {

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2026.nn.nn - version 6.0.2
+ * Fix - Apple Pay: Check store country restrictions for selling/shipping
 
 2025.nn.nn - version 6.0.1
  * New: Introduced a new ScriptHelper class with addInlineScript() method

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -24,7 +24,7 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v6_0_2;
 
-use SkyVerge\WooCommerce\PluginFramework\v6_0_1\Helpers\CheckoutHelper;
+use SkyVerge\WooCommerce\PluginFramework\v6_0_2\Helpers\CheckoutHelper;
 
 defined( 'ABSPATH' ) or exit;
 


### PR DESCRIPTION
# Summary

This adds a new `CheckoutHelper` class with some country validation methods. It then also updates the Apple Pay integration to check the country code against the allow lists for ordering and shipping, to ensure people in other countries cannot place orders when they should not be able to.

### Story: [MWC-10109](https://godaddy-corp.atlassian.net/browse/MWC-10109)
### Release: #802

## Details

_Additional details to expand on the summary, if needed_

## QA

1. Use the Apple Pay gateway
2. Configure WooCommerce settings to allow selling and shipping to all countries
    <img width="997" height="287" alt="image" src="https://github.com/user-attachments/assets/b8636458-7716-4bbe-9067-397f6aaffd31" />
3. Place an order using Apple Pay.
    - [ ] Successful
4. Change settings to be more restrictive so that your country (whatever you use for Apple Pay) is not allowed.
5. Place an order using Apple Pay.
    - [ ] You are not allowed / you get an error

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
