### PR TITLE
Remove package.json from export-ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,6 @@
 .gitattributes  export-ignore
 .gitignore      export-ignore
 Gruntfile.js    export-ignore
-package.json    export-ignore
 package-lock.json export-ignore
 phpcs.xml       export-ignore
 phpunit.xml     export-ignore

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
-2026.nn.nn - version 6.1.4
+2026.04.01 - version 6.1.4
+* Fix - Remove package.json from export-ignore
 
 2026.04.01 - version 6.1.3
 * Fix - Move WeakMap initialization to PHP 8.2+ only, as there are some bugs with it in certain versions of PHP 8.0.x and 8.1.x.


### PR DESCRIPTION
# Summary

This removes `package.json` from gitattributes `export-ignore` because it would seem Sake uses this to determine the "current framework version" during deployments.

## Before merge

- [x] Checks pass
- [ ] I have confirmed these changes in each supported minor WooCommerce version
