### PR TITLE
Protect against Notes_Helper fatal errors during plugin updates

### DIFF
--- a/woocommerce/Plugin/Lifecycle.php
+++ b/woocommerce/Plugin/Lifecycle.php
@@ -194,7 +194,10 @@ class Lifecycle {
 	public function handle_deactivation() {
 
 		// if the enhanced admin is available, delete all of this plugin's notes on deactivation
-		if ( SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
+		// note: the class_exists() check needs to remain due to how the namespace changes with each framework version
+		// not checking can cause fatal errors in the middle of plugin upgrades
+		// @link https://github.com/godaddy-wordpress/wc-plugin-framework/issues/824
+		if ( SV_WC_Plugin_Compatibility::is_enhanced_admin_available() && class_exists( Notes_Helper::class ) ) {
 
 			Notes_Helper::delete_notes_with_source( $this->get_plugin()->get_id_dasherized() );
 

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2026.nn.nn - version 6.1.5
+* Fix - Protect against `Notes_Helper` fatal errors on plugin upgrades
 
 2026.04.01 - version 6.1.4
 * Fix - Remove package.json from export-ignore

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -810,7 +810,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 						$note->save();
 
-					} catch ( \Exception $exception ) {}
+					} catch ( \Throwable $exception ) {}
 				}
 
 				// if not an enhanced admin screen, output the legacy style notice
@@ -822,7 +822,10 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 				}
 
 			// if all's well with this gateway, make sure and delete any previously added notes
-			} elseif ( $is_enhanced_admin_available && Admin\Notes_Helper::note_with_name_exists( $note_name ) ) {
+			// note: the class_exists() check needs to remain due to how the namespace changes with each framework version
+			// not checking can cause fatal errors in the middle of plugin upgrades
+			// @link https://github.com/godaddy-wordpress/wc-plugin-framework/issues/824
+			} elseif ( $is_enhanced_admin_available && class_exists( Admin\Notes_Helper::class ) && Admin\Notes_Helper::note_with_name_exists( $note_name ) ) {
 
 				WC_Admin_Notes::delete_notes_with_name( $note_name );
 			}


### PR DESCRIPTION
# Summary

This adds some various protection measures to avoid `Notes_Helper` fatal errors during plugin updates, which is when the framework namespace changes.

Fixes #824

### Story: [MWC-19419](https://godaddy-corp.atlassian.net/browse/MWC-19419)
### Release: #825 (release PR)

## QA

- [ ] Code review
- [x] Checks pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
