### PR TITLE
Pin GitHub actions to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
           php-version: ${{ env.PHP_VERSION }}
 
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/golf-integration-send-translations.yml
+++ b/.github/workflows/golf-integration-send-translations.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Checkout action-golf-integration repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: gdcorp-partners/action-golf-integration
           ref: 'main'

--- a/.github/workflows/golf-integration-translations-received.yml
+++ b/.github/workflows/golf-integration-translations-received.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Checkout action-golf-integration repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: gdcorp-partners/action-golf-integration
           ref: 'main'

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -20,7 +20,7 @@ jobs:
       NEW_VERSION: ${{ inputs.new-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate release branch
         run: |
@@ -41,7 +41,7 @@ jobs:
         run: ./.github/scripts/update-namespace.sh
 
       - name: Install Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1.307.0
         with:
           ruby-version: '3.3'
 
@@ -53,7 +53,7 @@ jobs:
         run: sudo phpdismod xdebug
 
       - name: Setup WP-CLI
-        uses: godaddy-wordpress/setup-wp-cli@1
+        uses: godaddy-wordpress/setup-wp-cli@80c9a89bd347082429795c0f12acf567e2c390d4 # v1
 
       - name: Install packages
         run: npm install

--- a/.github/workflows/update-translations-files.yml
+++ b/.github/workflows/update-translations-files.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Checkout localization-actions repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: gdcorp-partners/localization-actions
           ref: 'main'


### PR DESCRIPTION
# Summary

This pins all GitHub actions used in our workflows to a SHA. Also updates all `actions/checkout` to be v6 across the board.

### Story: [MWC-19728](https://godaddy-corp.atlassian.net/browse/MWC-19728)

## QA

- [ ] Code review
- [x] Checks pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
