### PR TITLE
Fix resolved package urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -324,7 +324,7 @@
     },
     "node_modules/@parcel/codeframe": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/codeframe/-/codeframe-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.4.tgz",
       "integrity": "sha512-s64aMfOJoPrXhKH+Y98ahX0O8aXWvTR+uNlOaX4yFkpr4FFDnviLcGngDe/Yo4Qq2FJZ0P6dNswbJTUH9EGxkQ==",
       "dev": true,
       "license": "MIT",
@@ -341,7 +341,7 @@
     },
     "node_modules/@parcel/codeframe/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -357,7 +357,7 @@
     },
     "node_modules/@parcel/codeframe/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -374,7 +374,7 @@
     },
     "node_modules/@parcel/codeframe/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -387,14 +387,14 @@
     },
     "node_modules/@parcel/codeframe/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@parcel/codeframe/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -404,7 +404,7 @@
     },
     "node_modules/@parcel/codeframe/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -537,7 +537,7 @@
     },
     "node_modules/@parcel/diagnostic": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/diagnostic/-/diagnostic-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.4.tgz",
       "integrity": "sha512-YN5CfX7lFd6yRLxyZT4Sj3sR6t7nnve4TdXSIqapXzQwL7Bw+sj79D95wTq2rCm3mzk5SofGxFAXul2/nG6gcQ==",
       "dev": true,
       "license": "MIT",
@@ -569,7 +569,7 @@
     },
     "node_modules/@parcel/events": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/events/-/events-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.4.tgz",
       "integrity": "sha512-slWQkBRAA7o0cN0BLEd+yCckPmlVRVhBZn5Pn6ktm4EzEtrqoMzMeJOxxH8TXaRzrQDYnTcnYIHFgXWd4kkUfg==",
       "dev": true,
       "license": "MIT",
@@ -583,7 +583,7 @@
     },
     "node_modules/@parcel/feature-flags": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/feature-flags/-/feature-flags-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.4.tgz",
       "integrity": "sha512-nYdx53siKPLYikHHxfzgjzzgxdrjquK6DMnuSgOTyIdRG4VHdEN0+NqKijRLuVgiUFo/dtxc2h+amwqFENMw8w==",
       "dev": true,
       "license": "MIT",
@@ -640,7 +640,7 @@
     },
     "node_modules/@parcel/logger": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/logger/-/logger-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.4.tgz",
       "integrity": "sha512-QR8QLlKo7xAy9JBpPDAh0RvluaixqPCeyY7Fvo2K7hrU3r85vBNNi06pHiPbWoDmB4x1+QoFwMaGnJOHR+/fMA==",
       "dev": true,
       "license": "MIT",
@@ -658,7 +658,7 @@
     },
     "node_modules/@parcel/markdown-ansi": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/markdown-ansi/-/markdown-ansi-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.4.tgz",
       "integrity": "sha512-0+oQApAVF3wMcQ6d1ZfZ0JsRzaMUYj9e4U+naj6YEsFsFGOPp+pQYKXBf1bobQeeB7cPKPT3SUHxFqced722Hw==",
       "dev": true,
       "license": "MIT",
@@ -675,7 +675,7 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -691,7 +691,7 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -708,7 +708,7 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -721,14 +721,14 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@parcel/markdown-ansi/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -738,7 +738,7 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -1086,7 +1086,7 @@
     },
     "node_modules/@parcel/plugin": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/plugin/-/plugin-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.4.tgz",
       "integrity": "sha512-aN2VQoRGC1eB41ZCDbPR/Sp0yKOxe31oemzPx1nJzOuebK2Q6FxSrJ9Bjj9j/YCaLzDtPwelsuLOazzVpXJ6qg==",
       "dev": true,
       "license": "MIT",
@@ -1103,7 +1103,7 @@
     },
     "node_modules/@parcel/profiler": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/profiler/-/profiler-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.4.tgz",
       "integrity": "sha512-R3JhfcnoReTv2sVFHPR2xKZvs3d3IRrBl9sWmAftbIJFwT4rU70/W7IdwfaJVkD/6PzHq9mcgOh1WKL4KAxPdA==",
       "dev": true,
       "license": "MIT",
@@ -1363,7 +1363,7 @@
     },
     "node_modules/@parcel/rust": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/rust/-/rust-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.4.tgz",
       "integrity": "sha512-RBMKt9rCdv6jr4vXG6LmHtxzO5TuhQvXo1kSoSIF7fURRZ81D1jzBtLxwLmfxCPsofJNqWwdhy5vIvisX+TLlQ==",
       "dev": true,
       "license": "MIT",
@@ -1614,7 +1614,7 @@
     },
     "node_modules/@parcel/transformer-coffeescript": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/transformer-coffeescript/-/transformer-coffeescript-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-coffeescript/-/transformer-coffeescript-2.16.4.tgz",
       "integrity": "sha512-OOPGH78XrcHZGJMj0HCHD2iwjQDiVhF5QwzB6hxP2EqJw31jWasn4QL1///N9HufR0b3xa0WZZykyQqCWHWK5Q==",
       "dev": true,
       "license": "MIT",
@@ -1911,7 +1911,7 @@
     },
     "node_modules/@parcel/types": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/types/-/types-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.4.tgz",
       "integrity": "sha512-ctx4mBskZHXeDVHg4OjMwx18jfYH9BzI/7yqbDQVGvd5lyA+/oVVzYdpele2J2i2sSaJ87cA8nb57GDQ8kHAqA==",
       "dev": true,
       "license": "MIT",
@@ -1922,7 +1922,7 @@
     },
     "node_modules/@parcel/types-internal": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/types-internal/-/types-internal-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.4.tgz",
       "integrity": "sha512-PE6Qmt5cjzBxX+6MPLiF7r+twoC+V9Skt3zyuBQ+H1c0i9o07Bbz2NKX10nvlPukfmW6Fu/1RvTLkzBZR1bU6A==",
       "dev": true,
       "license": "MIT",
@@ -1935,7 +1935,7 @@
     },
     "node_modules/@parcel/utils": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/utils/-/utils-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.4.tgz",
       "integrity": "sha512-lkmxQHcHyOWZLbV8t+h2CGZIkPiBurLm/TS5wNT7+tq0qt9KbVwL7FP2K93TbXhLMGTmpI79Bf3qKniPM167Mw==",
       "dev": true,
       "license": "MIT",
@@ -1959,7 +1959,7 @@
     },
     "node_modules/@parcel/utils/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -1975,7 +1975,7 @@
     },
     "node_modules/@parcel/utils/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -1992,7 +1992,7 @@
     },
     "node_modules/@parcel/utils/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -2005,14 +2005,14 @@
     },
     "node_modules/@parcel/utils/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@parcel/utils/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -2022,7 +2022,7 @@
     },
     "node_modules/@parcel/utils/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -2367,7 +2367,7 @@
     },
     "node_modules/@parcel/workers": {
       "version": "2.16.4",
-      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@parcel/workers/-/workers-2.16.4.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.4.tgz",
       "integrity": "sha512-dkBEWqnHXDZnRbTZouNt4uEGIslJT+V0c8OH1MPOfjISp1ucD6/u9ET8k9d/PxS9h1hL53og0SpBuuSEPLDl6A==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
# Summary

This addresses this failed workflow:

<img width="2540" height="717" alt="Screenshot 2026-05-18 132322" src="https://github.com/user-attachments/assets/8d51a390-b24d-43ef-833b-5358a1ccff79" />

Problem:

Commit eb46b274 changed some `resolved` URLs from `registry.npmjs.org` to `gdartifactory1.jfrog.io`, the latter of which requires auth.

<img width="1296" height="271" alt="image" src="https://github.com/user-attachments/assets/f4e4b2d2-53e6-4d50-bb93-a579c591fe4c" />

This switches them back to the public npm registry.

## QA

- [x] New "Prepare Release" workflow executes successfully - https://github.com/godaddy-wordpress/wc-plugin-framework/actions/runs/26033344458

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
