### PR TITLE
Bail if script helper class does not exist

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2026.nn.nn - version 6.2.1
+* Fix - Protect against `ScriptHelper` fatal errors on plugin upgrades
 
 2026.04.16 - version 6.2.0
 * New - Added REST API support to Abilities for automatic route registration

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -252,6 +252,11 @@ class SV_WC_Admin_Notice_Handler {
 			return;
 		}
 
+		// Bail if the script helper class does not exist. This can occur in the middle of plugin upgrades.
+		if (! class_exists(ScriptHelper::class)) {
+			return;
+		}
+
 		$plugin_slug = $this->get_plugin()->get_id_dasherized();
 
 		self::$admin_notice_js_rendered = true;


### PR DESCRIPTION
# Summary

This protects against fatal errors in the middle of plugin upgrades, when an admin notice is visible. This is a similar issue to https://github.com/godaddy-wordpress/wc-plugin-framework/pull/826

### Story: [MWC-19746](https://godaddy-corp.atlassian.net/browse/MWC-19746)
### Release: #836 (release PR)

## Details

<img width="1217" height="1767" alt="Screenshot 2026-05-18 131357" src="https://github.com/user-attachments/assets/47e23c3c-17bd-4f15-a534-4c63f5b248a0" />


## QA

_If applicable, add specific steps for the reviewer to perform as part of their QA process prior to approving this pull request. Steps should be in a step -> success? format, like below_

### Setup

1. Activate a plugin that has an admin notice visible.
2. Manually apply the patch to the _current_ version of the plugin. This is necessary because it's the old version (before the update) that needs the fix.
3. Upload a new version of the plugin, containing this branch of the plugin framework.
    - [x] No fatal error on upgrade screen

<img width="1257" height="1109" alt="image" src="https://github.com/user-attachments/assets/b81473c9-06a3-4322-b895-cced6c9ce2f9" />


## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
