### PR TITLE
Don't add notices during REST requests

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2026.nn.nn - version 6.2.2
+* Fix - Failed transaction attempt causes future attempts to fail when using Block checkout
 
 2026.05.18 - version 6.2.1
 * Fix - Protect against `ScriptHelper` fatal errors on plugin upgrades

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -3070,17 +3070,22 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		$this->add_debug_message( $error_message, 'error' );
 
-		$user_message = '';
+		// In Store API / REST context the message is returned in the process_payment()
+		// result and surfaced via RouteException; adding a session notice here leaks
+		// into the next request's cart validation (woocommerce_rest_cart_item_error 409).
+		if ( ! SV_WC_Helper::is_rest_api_request() ) {
+			$user_message = '';
 
-		if ( $response && $this->is_detailed_customer_decline_messages_enabled() ) {
-			$user_message = $response->get_user_message();
+			if ( $response && $this->is_detailed_customer_decline_messages_enabled() ) {
+				$user_message = $response->get_user_message();
+			}
+
+			if ( ! $user_message ) {
+				$user_message = esc_html__( 'An error occurred, please try again or try an alternate form of payment.', 'woocommerce-plugin-framework' );
+			}
+
+			SV_WC_Helper::wc_add_notice( $user_message, 'error' );
 		}
-
-		if ( ! $user_message ) {
-			$user_message = esc_html__( 'An error occurred, please try again or try an alternate form of payment.', 'woocommerce-plugin-framework' );
-		}
-
-		SV_WC_Helper::wc_add_notice( $user_message, 'error' );
 	}
 
 
@@ -3747,6 +3752,13 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		// avoid adding notices when performing refunds, these occur in the admin as an Ajax call, so checking the current filter
 		// is the only reliably way to do so
 		if ( in_array( 'wp_ajax_woocommerce_refund_line_items', $GLOBALS['wp_current_filter'] ) ) {
+			return;
+		}
+
+		// avoid adding notices on Store API / REST requests; the message is already returned in the
+		// response body and a session notice would leak into the next cart-validation request and
+		// surface as a 409 woocommerce_rest_cart_item_error.
+		if ( SV_WC_Helper::is_rest_api_request() ) {
 			return;
 		}
 


### PR DESCRIPTION
[MWC-19933](https://godaddy-corp.atlassian.net/browse/MWC-19933)

## Summary

On Block Checkout, when an SV-framework gateway transaction fails, `mark_order_as_failed()` and `add_debug_message()` push the error into the WC session via `wc_add_notice()`. The Store API never renders or clears those notices, so `CartController::validate_cart()` sweeps them on the next request and throws a 409 `woocommerce_rest_cart_item_error` — blocking any retry, even with a valid card. This PR gates both `wc_add_notice()` calls on `! SV_WC_Helper::is_rest_api_request()`; the message is already returned in the `process_payment()` result and surfaced via `RouteException`, so the session notice is redundant in REST.

## QA steps

1. Update Bambora to use this version of the framework via composer.
2. Save this card number to your account: `4123456789010343`
3. Attempt to purchase an item using that saved card. It will fail.
4. After getting the error message, try again, this time entering in a new card that's valid.
    - [x] Order completes successfully without errors