### PR TITLE
Move render_js() call to enqueue scripts callback

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2026.nn.nn - version 6.2.3
+* Fix - Address "wp_script_is was called incorrectly" errors when instantiating the `SV_WP_Job_Batch_Handler` class
 
 2026.06.15 - version 6.2.2
 * Fix - Failed transaction attempt causes future attempts to fail when using Block checkout

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -71,8 +71,6 @@ class SV_WP_Job_Batch_Handler {
 		$this->plugin      = $plugin;
 
 		$this->add_hooks();
-
-		$this->render_js();
 	}
 
 
@@ -110,6 +108,8 @@ class SV_WP_Job_Batch_Handler {
 	public function enqueue_scripts() {
 
 		wp_enqueue_script( $this->getScriptHandle(),  $this->get_plugin()->get_framework_assets_url() . '/js/admin/sv-wp-admin-job-batch-handler.min.js', [ 'jquery' ], $this->get_plugin()->get_assets_version() );
+
+		$this->render_js();
 	}
 
 

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -136,7 +136,7 @@ class SV_WP_Job_Batch_Handler {
 			json_encode( $args )
 		);
 
-		ScriptHelper::addInlineScript($this->getScriptHandle(), $script);
+		ScriptHelper::addInlinejQuery($this->getScriptHandle(), $script);
 	}
 
 


### PR DESCRIPTION
# Summary

`SV_WP_Job_Batch_Handler::__construct()` was calling `$this->render_js()` directly. Consumers typically instantiate the handler during `plugins_loaded` (e.g. CSV Export's `includes()`), so `render_js()` — which calls `ScriptHelper::addInlineScript()` → `wp_register_script()` — ran before `admin_enqueue_scripts`. As of WP 6.7, that trips a `_doing_it_wrong` notice on every admin page load.

This PR moves the `render_js()` call into `enqueue_scripts()`, which is already hooked to `admin_enqueue_scripts` in `add_hooks()` and is also where the script handle the inline JS attaches to is registered.

### Story: [MWC-20065](https://godaddy-corp.atlassian.net/browse/MWC-20065)
### Release: https://github.com/godaddy-wordpress/wc-plugin-framework/pull/847

## Details

- `__construct()` no longer calls `render_js()`.
- `enqueue_scripts()` calls `render_js()` after enqueuing the handler script, so the inline `new SV_WP_Job_Batch_Handler(...)` snippet is still attached to the right handle and emitted on the same admin pages as before.
- No public API changes; subclasses that override `enqueue_scripts()` and call `parent::enqueue_scripts()` (the documented pattern) pick up the new behavior automatically.

## QA

### Setup

- WordPress 6.7 or newer (so the `_doing_it_wrong` notice is emitted).
- `WP_DEBUG` and `WP_DEBUG_LOG` enabled, or `define( 'WP_DEBUG_DISPLAY', true )` so notices surface.
- WooCommerce Customer/Order/Coupon Export plugin installed and active. Point its `composer.json` at this branch (`mwc-20065`) and `composer update skyverge/wc-plugin-framework` so it loads the patched framework copy.
- At least one order exists in the store so an export has something to process.

### Steps

1. With the **unpatched** framework still in place, load **any** WP admin page (e.g. WP dashboard).
    - [x] `debug.log` / on-screen notice contains: _"Function wp_register_script was called incorrectly... triggered by the `wc_customer_order_export_background_export_batch_handler` handle."_ (baseline — confirm the bug reproduces before fixing)
2. Switch the CSV Export plugin to the patched framework branch and reload the same admin page.
    - [x] The `_doing_it_wrong` notice is **gone** from `debug.log` and the page.
3. Go to **WooCommerce → Exports → Export**, tick **Enable batch processing**, and run a manual orders export.
    - [x] The progress modal appears and the progress bar advances from 0% to 100%.
    - [x] The export completes and the file downloads (or is delivered per the chosen method).
4. On the same export screen, open browser DevTools → Console and evaluate `window.wc_customer_order_export_background_export_batch_handler`.
    - [x] It is an instance of `SV_WP_Job_Batch_Handler` (not `undefined`). This proves the inline `render_js()` snippet executed on the page.
5. View page source / Network tab on the export screen and search for `new SV_WP_Job_Batch_Handler(`.
    - [x] The inline script tag is present in the rendered HTML.
6. Cancel a batch export mid-run via the modal's Cancel button.
    - [x] The job stops and the modal closes cleanly (exercises the `cancel_job` AJAX path wired up via the same inline JS).

<img width="1976" height="515" alt="image" src="https://github.com/user-attachments/assets/6b22287b-c632-4f9f-a731-6a62a10777d0" />

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version